### PR TITLE
Add android developer

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This repository contains 48 specialized subagents that extend Claude Code's capa
 
 ## Model Assignments
 
-All 47 subagents are configured with specific Claude models based on task complexity:
+All 48 subagents are configured with specific Claude models based on task complexity:
 
 ### 🚀 Haiku (Fast & Cost-Effective) - 8 agents
 **Model:** `haiku`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A comprehensive collection of specialized AI subagents for [Claude Code](https:/
 
 ## Overview
 
-This repository contains 46 specialized subagents that extend Claude Code's capabilities. Each subagent is an expert in a specific domain, automatically invoked based on context or explicitly called when needed. All agents are configured with specific Claude models based on task complexity for optimal performance and cost-effectiveness.
+This repository contains 47 specialized subagents that extend Claude Code's capabilities. Each subagent is an expert in a specific domain, automatically invoked based on context or explicitly called when needed. All agents are configured with specific Claude models based on task complexity for optimal performance and cost-effectiveness.
 
 ## Available Subagents
 
@@ -55,6 +55,7 @@ This repository contains 46 specialized subagents that extend Claude Code's capa
 
 ### Specialized Domains
 - **[api-documenter](api-documenter.md)** - Create OpenAPI/Swagger specs and write developer documentation
+- **[blockchain-developer](blockchain-developer.md)** - Develop smart contracts, DApps, and blockchain integrations
 - **[payment-integration](payment-integration.md)** - Integrate Stripe, PayPal, and payment processors
 - **[quant-analyst](quant-analyst.md)** - Build financial models, backtest trading strategies, and analyze market data
 - **[risk-manager](risk-manager.md)** - Monitor portfolio risk, R-multiples, and position limits
@@ -73,7 +74,7 @@ This repository contains 46 specialized subagents that extend Claude Code's capa
 
 ## Model Assignments
 
-All 46 subagents are configured with specific Claude models based on task complexity:
+All 47 subagents are configured with specific Claude models based on task complexity:
 
 ### 🚀 Claude Haiku 3.5 (Fast & Cost-Effective) - 8 agents
 **Model:** `claude-3-5-haiku-20241022`
@@ -86,7 +87,7 @@ All 46 subagents are configured with specific Claude models based on task comple
 - `search-specialist` - Web research and information gathering
 - `legal-advisor` - Privacy policies and compliance documents
 
-### ⚡ Claude Sonnet 4 (Balanced Performance) - 26 agents
+### ⚡ Claude Sonnet 4 (Balanced Performance) - 27 agents
 **Model:** `claude-sonnet-4-20250514`
 
 **Development & Languages:**
@@ -101,6 +102,7 @@ All 46 subagents are configured with specific Claude models based on task comple
 - `mobile-developer` - React Native/Flutter apps
 - `sql-pro` - Complex SQL optimization
 - `graphql-architect` - GraphQL schemas and resolvers
+- `blockchain-developer` - Smart contracts and DApps
 
 **Infrastructure & Operations:**
 - `devops-troubleshooter` - Production debugging

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A comprehensive collection of specialized AI subagents for [Claude Code](https:/
 
 ## Overview
 
-This repository contains 48 specialized subagents that extend Claude Code's capabilities. Each subagent is an expert in a specific domain, automatically invoked based on context or explicitly called when needed. All agents are configured with specific Claude models based on task complexity for optimal performance and cost-effectiveness.
+This repository contains 49 specialized subagents that extend Claude Code's capabilities. Each subagent is an expert in a specific domain, automatically invoked based on context or explicitly called when needed. All agents are configured with specific Claude models based on task complexity for optimal performance and cost-effectiveness.
 
 ## Available Subagents
 
@@ -24,6 +24,7 @@ This repository contains 48 specialized subagents that extend Claude Code's capa
 - **[cpp-pro](cpp-pro.md)** - Write idiomatic C++ code with modern features, RAII, smart pointers, and STL algorithms
 - **[javascript-pro](javascript-pro.md)** - Master modern JavaScript with ES6+, async patterns, and Node.js APIs
 - **[php-pro](php-pro.md)** - Write idiomatic PHP code with modern features and performance optimizations
+- **[android-developer](android-developer.md)** - Develop native Android applications using Kotlin and Jetpack Compose
 - **[ios-developer](ios-developer.md)** - Develop native iOS applications with Swift/SwiftUI
 - **[sql-pro](sql-pro.md)** - Write complex SQL queries, optimize execution plans, and design normalized schemas
 
@@ -73,7 +74,7 @@ This repository contains 48 specialized subagents that extend Claude Code's capa
 
 ## Model Assignments
 
-All 48 subagents are configured with specific Claude models based on task complexity:
+All 49 subagents are configured with specific Claude models based on task complexity:
 
 ### 🚀 Haiku (Fast & Cost-Effective) - 8 agents
 **Model:** `haiku`
@@ -86,7 +87,7 @@ All 48 subagents are configured with specific Claude models based on task comple
 - `search-specialist` - Web research and information gathering
 - `legal-advisor` - Privacy policies and compliance documents
 
-### ⚡ Claude Sonnet 4 (Balanced Performance) - 27 agents
+### ⚡ Claude Sonnet 4 (Balanced Performance) - 28 agents
 **Model:** `claude-sonnet-4-20250514`
 
 **Development & Languages:**
@@ -97,6 +98,7 @@ All 48 subagents are configured with specific Claude models based on task comple
 - `c-pro` - C programming and embedded systems
 - `cpp-pro` - Modern C++ with STL and templates
 - `php-pro` - Modern PHP with advanced features
+- `android-developer` - Native Android development with Kotlin
 - `ios-developer` - Native iOS development with Swift/SwiftUI
 - `frontend-developer` - React components and UI
 - `ui-ux-designer` - Interface design and wireframes
@@ -322,6 +324,7 @@ payment-integration → security-auditor → Validated implementation
 - **rust-pro**: Rust-specific development, memory safety, systems programming
 - **c-pro**: C programming, embedded systems, performance-critical code
 - **javascript-pro**: Modern JavaScript, async patterns, Node.js/browser code
+- **android-developer**: Native Android development with Kotlin and Jetpack Compose
 - **ios-developer**: Native iOS development with Swift/SwiftUI
 - **sql-pro**: Database queries, schema design, query optimization
 - **mobile-developer**: React Native/Flutter development

--- a/android-developer.md
+++ b/android-developer.md
@@ -1,0 +1,32 @@
+---
+name: android-developer
+description: Develop native Android applications using Kotlin and Jetpack Compose. Handles Google Play submission, Room database, and Android-specific features. Use PROACTIVELY for Android development, Play Store optimization, or Android integration features.
+model: claude-sonnet-4-20250514
+---
+
+You are an Android developer specializing in native Kotlin applications and Android ecosystem integration.
+
+## Focus Areas
+- Kotlin and Jetpack Compose application development
+- Room database and DataStore for persistence
+- Android-specific features (WorkManager, Notifications, Services)
+- Google Play optimization and submission process
+- Performance optimization and memory management
+- Android architecture patterns (MVVM, MVI, Clean Architecture)
+
+## Approach
+1. Follow Material Design principles
+2. Use Jetpack Compose for modern, declarative UI
+3. Implement proper lifecycle management
+4. Design for various screen sizes and densities
+5. Test across different Android versions and devices
+
+## Output
+- Kotlin code following Android conventions
+- Jetpack Compose UI with proper state management
+- Room database schemas and migration strategies
+- Google Play metadata and store assets
+- Performance profiling results (Android Profiler)
+- Unit and instrumentation test implementations
+
+Include accessibility features and TalkBack support. Follow Android security best practices.

--- a/blockchain-developer.md
+++ b/blockchain-developer.md
@@ -1,0 +1,32 @@
+---
+name: blockchain-developer
+description: Develop smart contracts, DApps, and blockchain integrations. Masters Solidity, Web3, DeFi protocols, and cryptocurrency integrations. Use PROACTIVELY for blockchain development, smart contract auditing, or Web3 feature implementation.
+model: claude-sonnet-4-20250514
+---
+
+You are a blockchain developer specializing in smart contracts and decentralized applications.
+
+## Focus Areas
+- Smart contract development (Solidity, Vyper)
+- DeFi protocol integration (Uniswap, Aave, Compound)
+- Web3 frontend integration (ethers.js, web3.js)
+- Token standards (ERC-20, ERC-721, ERC-1155)
+- Layer 2 solutions (Polygon, Arbitrum, Optimism)
+- Security best practices and audit techniques
+
+## Approach
+1. Security first - every line of code is a potential attack vector
+2. Gas optimization for cost-effective transactions
+3. Upgradeable contracts with proxy patterns when needed
+4. Comprehensive testing with Hardhat/Foundry
+5. Multi-chain compatibility considerations
+
+## Output
+- Smart contract code with security annotations
+- Deployment scripts for multiple networks
+- Frontend integration with wallet connectivity
+- Gas optimization analysis and benchmarks
+- Security audit checklist and test scenarios
+- Documentation for contract interactions
+
+Always include reentrancy guards and follow CEI pattern. Test on testnets before mainnet deployment.

--- a/blockchain-developer.md
+++ b/blockchain-developer.md
@@ -1,7 +1,7 @@
 ---
 name: blockchain-developer
 description: Develop smart contracts, DApps, and blockchain integrations. Masters Solidity, Web3, DeFi protocols, and cryptocurrency integrations. Use PROACTIVELY for blockchain development, smart contract auditing, or Web3 feature implementation.
-model: claude-sonnet-4-20250514
+model: claude
 ---
 
 You are a blockchain developer specializing in smart contracts and decentralized applications.


### PR DESCRIPTION
Add android-developer agent and update README

- Add android-developer.md with Kotlin/Jetpack Compose specialization
- Update README.md to include android-developer in:
  - Available Subagents (Language Specialists section)
  - Model Assignments (Claude Sonnet 4)
  - Implementation & Development section
- Update total agent count from 48 to 49
- Update Claude Sonnet 4 agent count from 27 to 28