### PR TITLE
Add a specialized Java agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A comprehensive collection of specialized AI subagents for [Claude Code](https:/
 
 ## Overview
 
-This repository contains 49 specialized subagents that extend Claude Code's capabilities. Each subagent is an expert in a specific domain, automatically invoked based on context or explicitly called when needed. All agents are configured with specific Claude models based on task complexity for optimal performance and cost-effectiveness.
+This repository contains 50 specialized subagents that extend Claude Code's capabilities. Each subagent is an expert in a specific domain, automatically invoked based on context or explicitly called when needed. All agents are configured with specific Claude models based on task complexity for optimal performance and cost-effectiveness.
 
 ## Available Subagents
 
@@ -25,6 +25,7 @@ This repository contains 49 specialized subagents that extend Claude Code's capa
 - **[javascript-pro](javascript-pro.md)** - Master modern JavaScript with ES6+, async patterns, and Node.js APIs
 - **[typescript-pro](typescript-pro.md)** - Master TypeScript with advanced types, generics, and strict type safety
 - **[php-pro](php-pro.md)** - Write idiomatic PHP code with modern features and performance optimizations
+- **[java-pro](java-pro.md)** - Master modern Java with streams, concurrency, and JVM optimization
 - **[ios-developer](ios-developer.md)** - Develop native iOS applications with Swift/SwiftUI
 - **[sql-pro](sql-pro.md)** - Write complex SQL queries, optimize execution plans, and design normalized schemas
 
@@ -73,7 +74,7 @@ This repository contains 49 specialized subagents that extend Claude Code's capa
 
 ## Model Assignments
 
-All 49 subagents are configured with specific Claude models based on task complexity:
+All 50 subagents are configured with specific Claude models based on task complexity:
 
 ### 🚀 Haiku (Fast & Cost-Effective) - 8 agents
 **Model:** `haiku`
@@ -86,7 +87,7 @@ All 49 subagents are configured with specific Claude models based on task comple
 - `search-specialist` - Web research and information gathering
 - `legal-advisor` - Privacy policies and compliance documents
 
-### ⚡ Sonnet (Balanced Performance) - 30 agents
+### ⚡ Sonnet (Balanced Performance) - 31 agents
 **Model:** `sonnet`
 
 **Development & Languages:**
@@ -98,6 +99,7 @@ All 49 subagents are configured with specific Claude models based on task comple
 - `c-pro` - C programming and embedded systems
 - `cpp-pro` - Modern C++ with STL and templates
 - `php-pro` - Modern PHP with advanced features
+- `java-pro` - Modern Java with streams and concurrency
 - `ios-developer` - Native iOS development with Swift/SwiftUI
 - `frontend-developer` - React components and UI
 - `ui-ux-designer` - Interface design and wireframes
@@ -324,6 +326,7 @@ payment-integration → security-auditor → Validated implementation
 - **c-pro**: C programming, embedded systems, performance-critical code
 - **javascript-pro**: Modern JavaScript, async patterns, Node.js/browser code
 - **typescript-pro**: Advanced TypeScript, generics, type inference, enterprise patterns
+- **java-pro**: Modern Java development, streams, concurrency, Spring Boot
 - **ios-developer**: Native iOS development with Swift/SwiftUI
 - **sql-pro**: Database queries, schema design, query optimization
 - **mobile-developer**: React Native/Flutter development

--- a/java-pro.md
+++ b/java-pro.md
@@ -1,0 +1,35 @@
+---
+name: java-pro
+description: Master modern Java with streams, concurrency, and JVM optimization. Handles Spring Boot, reactive programming, and enterprise patterns. Use PROACTIVELY for Java performance tuning, concurrent programming, or complex enterprise solutions.
+model: sonnet
+---
+
+You are a Java expert specializing in modern Java development and enterprise patterns.
+
+## Focus Areas
+
+- Modern Java features (streams, lambda expressions, records)
+- Concurrency and parallel programming (CompletableFuture, virtual threads)
+- Spring Framework and Spring Boot ecosystem
+- JVM performance tuning and memory management
+- Reactive programming with Project Reactor
+- Enterprise patterns and microservices architecture
+
+## Approach
+
+1. Leverage modern Java features for clean, readable code
+2. Use streams and functional programming patterns appropriately
+3. Handle exceptions with proper error boundaries
+4. Optimize for JVM performance and garbage collection
+5. Follow enterprise security best practices
+
+## Output
+
+- Modern Java with proper exception handling
+- Stream-based data processing with collectors
+- Concurrent code with thread safety guarantees
+- JUnit 5 tests with parameterized and integration tests
+- Performance benchmarks with JMH
+- Maven/Gradle configuration with dependency management
+
+Follow Java coding standards and include comprehensive Javadoc comments.


### PR DESCRIPTION
- Add java-pro.md agent with expertise in modern Java features, concurrency, Spring Boot, and JVM optimization
- Update README.md to include the new Java agent (total count: 49 → 50 agents)
- Categorize Java Pro agent under Sonnet model tier for balanced performance