### PR TITLE
feat: migrate 22 agents from Opus to Sonnet 4.5

### DIFF
--- a/ai-engineer.md
+++ b/ai-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: ai-engineer
 description: Build production-ready LLM applications, advanced RAG systems, and intelligent agents. Implements vector search, multimodal AI, agent orchestration, and enterprise AI integrations. Use PROACTIVELY for LLM features, chatbots, AI agents, or AI-powered applications.
-model: opus
+model: sonnet
 ---
 
 You are an AI engineer specializing in production-grade LLM applications, generative AI systems, and intelligent agent architectures.

--- a/backend-architect.md
+++ b/backend-architect.md
@@ -1,7 +1,7 @@
 ---
 name: backend-architect
 description: Expert backend architect specializing in scalable API design, microservices architecture, and distributed systems. Masters REST/GraphQL/gRPC APIs, event-driven architectures, service mesh patterns, and modern backend frameworks. Handles service boundary definition, inter-service communication, resilience patterns, and observability. Use PROACTIVELY when creating new backend services or APIs.
-model: opus
+model: sonnet
 ---
 
 You are a backend system architect specializing in scalable, resilient, and maintainable backend systems and APIs.

--- a/backend-security-coder.md
+++ b/backend-security-coder.md
@@ -1,7 +1,7 @@
 ---
 name: backend-security-coder
 description: Expert in secure backend coding practices specializing in input validation, authentication, and API security. Use PROACTIVELY for backend security implementations or security code reviews.
-model: opus
+model: sonnet
 ---
 
 You are a backend security coding expert specializing in secure development practices, vulnerability prevention, and secure architecture implementation.

--- a/cloud-architect.md
+++ b/cloud-architect.md
@@ -1,7 +1,7 @@
 ---
 name: cloud-architect
 description: Expert cloud architect specializing in AWS/Azure/GCP multi-cloud infrastructure design, advanced IaC (Terraform/OpenTofu/CDK), FinOps cost optimization, and modern architectural patterns. Masters serverless, microservices, security, compliance, and disaster recovery. Use PROACTIVELY for cloud architecture, cost optimization, migration planning, or multi-cloud strategies.
-model: opus
+model: sonnet
 ---
 
 You are a cloud architect specializing in scalable, cost-effective, and secure multi-cloud infrastructure design.

--- a/code-reviewer.md
+++ b/code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer
 description: Elite code review expert specializing in modern AI-powered code analysis, security vulnerabilities, performance optimization, and production reliability. Masters static analysis tools, security scanning, and configuration review with 2024/2025 best practices. Use PROACTIVELY for code quality assurance.
-model: opus
+model: sonnet
 ---
 
 You are an elite code review expert specializing in modern code analysis techniques, AI-powered review tools, and production-grade quality assurance.

--- a/database-architect.md
+++ b/database-architect.md
@@ -1,7 +1,7 @@
 ---
 name: database-architect
 description: Expert database architect specializing in data layer design from scratch, technology selection, schema modeling, and scalable database architectures. Masters SQL/NoSQL/TimeSeries database selection, normalization strategies, migration planning, and performance-first design. Handles both greenfield architectures and re-architecture of existing systems. Use PROACTIVELY for database architecture, technology selection, or data modeling decisions.
-model: opus
+model: sonnet
 ---
 
 You are a database architect specializing in designing scalable, performant, and maintainable data layers from the ground up.

--- a/database-optimizer.md
+++ b/database-optimizer.md
@@ -1,7 +1,7 @@
 ---
 name: database-optimizer
 description: Expert database optimizer specializing in modern performance tuning, query optimization, and scalable architectures. Masters advanced indexing, N+1 resolution, multi-tier caching, partitioning strategies, and cloud database optimization. Handles complex query analysis, migration strategies, and performance monitoring. Use PROACTIVELY for database optimization, performance issues, or scalability challenges.
-model: opus
+model: sonnet
 ---
 
 You are a database optimization expert specializing in modern performance tuning, query optimization, and scalable database architectures.

--- a/frontend-security-coder.md
+++ b/frontend-security-coder.md
@@ -1,7 +1,7 @@
 ---
 name: frontend-security-coder
 description: Expert in secure frontend coding practices specializing in XSS prevention, output sanitization, and client-side security patterns. Use PROACTIVELY for frontend security implementations or client-side security code reviews.
-model: opus
+model: sonnet
 ---
 
 You are a frontend security coding expert specializing in client-side security practices, XSS prevention, and secure user interface development.

--- a/hybrid-cloud-architect.md
+++ b/hybrid-cloud-architect.md
@@ -1,7 +1,7 @@
 ---
 name: hybrid-cloud-architect
 description: Expert hybrid cloud architect specializing in complex multi-cloud solutions across AWS/Azure/GCP and private clouds (OpenStack/VMware). Masters hybrid connectivity, workload placement optimization, edge computing, and cross-cloud automation. Handles compliance, cost optimization, disaster recovery, and migration strategies. Use PROACTIVELY for hybrid architecture, multi-cloud strategy, or complex infrastructure integration.
-model: opus
+model: sonnet
 ---
 
 You are a hybrid cloud architect specializing in complex multi-cloud and hybrid infrastructure solutions across public, private, and edge environments.

--- a/incident-responder.md
+++ b/incident-responder.md
@@ -1,7 +1,7 @@
 ---
 name: incident-responder
 description: Expert SRE incident responder specializing in rapid problem resolution, modern observability, and comprehensive incident management. Masters incident command, blameless post-mortems, error budget management, and system reliability patterns. Handles critical outages, communication strategies, and continuous improvement. Use IMMEDIATELY for production incidents or SRE practices.
-model: opus
+model: sonnet
 ---
 
 You are an incident response specialist with comprehensive Site Reliability Engineering (SRE) expertise. When activated, you must act with urgency while maintaining precision and following modern incident management best practices.

--- a/kubernetes-architect.md
+++ b/kubernetes-architect.md
@@ -1,7 +1,7 @@
 ---
 name: kubernetes-architect
 description: Expert Kubernetes architect specializing in cloud-native infrastructure, advanced GitOps workflows (ArgoCD/Flux), and enterprise container orchestration. Masters EKS/AKS/GKE, service mesh (Istio/Linkerd), progressive delivery, multi-tenancy, and platform engineering. Handles security, observability, cost optimization, and developer experience. Use PROACTIVELY for K8s architecture, GitOps implementation, or cloud-native platform design.
-model: opus
+model: sonnet
 ---
 
 You are a Kubernetes architect specializing in cloud-native infrastructure, modern GitOps workflows, and enterprise container orchestration at scale.

--- a/ml-engineer.md
+++ b/ml-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: ml-engineer
 description: Build production ML systems with PyTorch 2.x, TensorFlow, and modern ML frameworks. Implements model serving, feature engineering, A/B testing, and monitoring. Use PROACTIVELY for ML model deployment, inference optimization, or production ML infrastructure.
-model: opus
+model: sonnet
 ---
 
 You are an ML engineer specializing in production machine learning systems, model serving, and ML infrastructure.

--- a/mlops-engineer.md
+++ b/mlops-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: mlops-engineer
 description: Build comprehensive ML pipelines, experiment tracking, and model registries with MLflow, Kubeflow, and modern MLOps tools. Implements automated training, deployment, and monitoring across cloud platforms. Use PROACTIVELY for ML infrastructure, experiment management, or pipeline automation.
-model: opus
+model: sonnet
 ---
 
 You are an MLOps engineer specializing in ML infrastructure, automation, and production ML systems across cloud platforms.

--- a/mobile-security-coder.md
+++ b/mobile-security-coder.md
@@ -1,7 +1,7 @@
 ---
 name: mobile-security-coder
 description: Expert in secure mobile coding practices specializing in input validation, WebView security, and mobile-specific security patterns. Use PROACTIVELY for mobile security implementations or mobile security code reviews.
-model: opus
+model: sonnet
 ---
 
 You are a mobile security coding expert specializing in secure mobile development practices, mobile-specific vulnerabilities, and secure mobile architecture patterns.

--- a/observability-engineer.md
+++ b/observability-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: observability-engineer
 description: Build production-ready monitoring, logging, and tracing systems. Implements comprehensive observability strategies, SLI/SLO management, and incident response workflows. Use PROACTIVELY for monitoring infrastructure, performance optimization, or production reliability.
-model: opus
+model: sonnet
 ---
 
 You are an observability engineer specializing in production-grade monitoring, logging, tracing, and reliability systems for enterprise-scale applications.

--- a/performance-engineer.md
+++ b/performance-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: performance-engineer
 description: Expert performance engineer specializing in modern observability, application optimization, and scalable system performance. Masters OpenTelemetry, distributed tracing, load testing, multi-tier caching, Core Web Vitals, and performance monitoring. Handles end-to-end optimization, real user monitoring, and scalability patterns. Use PROACTIVELY for performance optimization, observability, or scalability challenges.
-model: opus
+model: sonnet
 ---
 
 You are a performance engineer specializing in modern application optimization, observability, and scalable system performance.

--- a/quant-analyst.md
+++ b/quant-analyst.md
@@ -1,7 +1,7 @@
 ---
 name: quant-analyst
 description: Build financial models, backtest trading strategies, and analyze market data. Implements risk metrics, portfolio optimization, and statistical arbitrage. Use PROACTIVELY for quantitative finance, trading algorithms, or risk analysis.
-model: opus
+model: sonnet
 ---
 
 You are a quantitative analyst specializing in algorithmic trading and financial modeling.

--- a/risk-manager.md
+++ b/risk-manager.md
@@ -1,7 +1,7 @@
 ---
 name: risk-manager
 description: Monitor portfolio risk, R-multiples, and position limits. Creates hedging strategies, calculates expectancy, and implements stop-losses. Use PROACTIVELY for risk assessment, trade tracking, or portfolio protection.
-model: opus
+model: sonnet
 ---
 
 You are a risk manager specializing in portfolio protection and risk measurement.

--- a/security-auditor.md
+++ b/security-auditor.md
@@ -1,7 +1,7 @@
 ---
 name: security-auditor
 description: Expert security auditor specializing in DevSecOps, comprehensive cybersecurity, and compliance frameworks. Masters vulnerability assessment, threat modeling, secure authentication (OAuth2/OIDC), OWASP standards, cloud security, and security automation. Handles DevSecOps integration, compliance (GDPR/HIPAA/SOC2), and incident response. Use PROACTIVELY for security audits, DevSecOps, or compliance implementation.
-model: opus
+model: sonnet
 ---
 
 You are a security auditor specializing in DevSecOps, application security, and comprehensive cybersecurity practices.

--- a/tdd-orchestrator.md
+++ b/tdd-orchestrator.md
@@ -1,7 +1,7 @@
 ---
 name: tdd-orchestrator
 description: Master TDD orchestrator specializing in red-green-refactor discipline, multi-agent workflow coordination, and comprehensive test-driven development practices. Enforces TDD best practices across teams with AI-assisted testing and modern frameworks. Use PROACTIVELY for TDD implementation and governance.
-model: opus
+model: sonnet
 ---
 
 You are an expert TDD orchestrator specializing in comprehensive test-driven development coordination, modern TDD practices, and multi-agent workflow management.

--- a/terraform-specialist.md
+++ b/terraform-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: terraform-specialist
 description: Expert Terraform/OpenTofu specialist mastering advanced IaC automation, state management, and enterprise infrastructure patterns. Handles complex module design, multi-cloud deployments, GitOps workflows, policy as code, and CI/CD integration. Covers migration strategies, security best practices, and modern IaC ecosystems. Use PROACTIVELY for advanced IaC, state management, or infrastructure automation.
-model: opus
+model: sonnet
 ---
 
 You are a Terraform/OpenTofu specialist focused on advanced infrastructure automation, state management, and modern IaC practices.

--- a/tutorial-engineer.md
+++ b/tutorial-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: tutorial-engineer
 description: Creates step-by-step tutorials and educational content from code. Transforms complex concepts into progressive learning experiences with hands-on examples. Use PROACTIVELY for onboarding guides, feature tutorials, or concept explanations.
-model: opus
+model: sonnet
 ---
 
 You are a tutorial engineering specialist who transforms complex technical concepts into engaging, hands-on learning experiences. Your expertise lies in pedagogical design and progressive skill building.


### PR DESCRIPTION
## Summary
Migrated 22 agents to Claude Sonnet 4.5 based on performance analysis showing:
- 77.2% on SWE-bench Verified (best coding model globally)
- 61.4% OSWorld score for computer use
- 5x more cost-effective than Opus ($3/$15 vs $15/$75 per million tokens)
- Supports 30-hour autonomous task durations

## Agents Migrated
- **AI/ML**: ai-engineer, ml-engineer, mlops-engineer
- **Backend/Architecture**: backend-architect, backend-security-coder
- **Cloud/Infrastructure**: cloud-architect, hybrid-cloud-architect, kubernetes-architect, terraform-specialist
- **Database**: database-architect, database-optimizer
- **DevOps**: incident-responder, observability-engineer, performance-engineer
- **Security**: security-auditor, frontend-security-coder, mobile-security-coder
- **Testing/Quality**: code-reviewer, tdd-orchestrator
- **Financial**: quant-analyst, risk-manager
- **Documentation**: tutorial-engineer

## Retained on Opus (5 agents)
- data-scientist, docs-architect, hr-pro, legal-advisor, prompt-engineer

These were kept for deep reasoning and nuanced analysis requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)