### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Claude Code Plugins: Orchestration and Automation
 
+[![Run in Smithery](https://smithery.ai/badge/skills/wshobson)](https://smithery.ai/skills?ns=wshobson&utm_source=github&utm_medium=badge)
+
+
 > **⚡ Updated for Sonnet 4.5 & Haiku 4.5** — All agents optimized for latest models with hybrid orchestration
 >
 > **🎯 Agent Skills Enabled** — 47 specialized skills extend Claude's capabilities across plugins with progressive disclosure


### PR DESCRIPTION
## Add "Run in Smithery" Badge

Hi! We'd like to add a badge to your README that lets users instantly discover and try your Claude Skills in [Smithery](https://smithery.ai).

[![Run in Smithery](https://smithery.ai/badge/skills/wshobson)](https://smithery.ai/skills?ns=wshobson&utm_source=github&utm_medium=badge)

### What's Smithery?
Smithery is a platform for discovering and installing Claude Skills and MCP servers. Your 61 skills have been installed **60 times** by **50 users** in the last 30 days.

### Top Skills
- **prompt-engineering-patterns** (37 activations, 29 users)
- **api-design-principles** (4 activations, 3 users)
- **stripe-integration** (3 activations, 2 users)
- **async-python-patterns** (2 activations, 2 users)
- **ml-pipeline-workflow** (2 activations, 2 users)

### What This PR Does
- Adds a badge to your README linking to your skills collection on Smithery
- Lets users browse and install your skills with one click
- Shows aggregate usage metrics across all your skills

### Suggested Placement
We recommend placing the badge at the top of your README, below the title or alongside other badges.

---

Feel free to adjust the placement or close this PR if you're not interested. Thanks for building awesome skills!