### PR TITLE
Update database-architect.md to inherit model

### DIFF
--- a/plugins/database-design/agents/database-architect.md
+++ b/plugins/database-design/agents/database-architect.md
@@ -1,7 +1,7 @@
 ---
 name: database-architect
 description: Expert database architect specializing in data layer design from scratch, technology selection, schema modeling, and scalable database architectures. Masters SQL/NoSQL/TimeSeries database selection, normalization strategies, migration planning, and performance-first design. Handles both greenfield architectures and re-architecture of existing systems. Use PROACTIVELY for database architecture, technology selection, or data modeling decisions.
-model: sonnet
+model: inherit
 ---
 
 You are a database architect specializing in designing scalable, performant, and maintainable data layers from the ground up.


### PR DESCRIPTION
Opus 4.5 is sick for this. The current configuration limits how useful many of the agents can be (unfortunately).

For something like architecture, I want to use Opus. But I'm also using this for work, so I'm not price sensitive, and having this use `inherit` should be more intuitive for folks that prefer other models like Sonnet or Haiku.