### PR TITLE
fix(marketplace): bump versions for 15 plugins after skill/agent additions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Production-ready workflow orchestration with 67 focused plugins, 99 specialized agents, and 107 skills - optimized for granular installation and minimal token usage",
-    "version": "1.3.0"
+    "version": "1.3.1"
   },
   "plugins": [
     {
@@ -102,7 +102,7 @@
       "name": "backend-development",
       "source": "./plugins/backend-development",
       "description": "Backend API design, GraphQL architecture, workflow orchestration with Temporal, and test-driven backend development",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "author": {
         "name": "Seth Hobson",
         "url": "https://github.com/wshobson"
@@ -148,7 +148,7 @@
       "name": "frontend-mobile-development",
       "source": "./plugins/frontend-mobile-development",
       "description": "Frontend UI development and mobile application implementation across platforms",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "author": {
         "name": "Seth Hobson",
         "url": "https://github.com/wshobson"
@@ -417,7 +417,7 @@
       "name": "llm-application-dev",
       "source": "./plugins/llm-application-dev",
       "description": "LLM application development, prompt engineering, and AI assistant optimization",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "author": {
         "name": "Seth Hobson",
         "url": "https://github.com/wshobson"
@@ -550,7 +550,7 @@
       "name": "data-engineering",
       "source": "./plugins/data-engineering",
       "description": "ETL pipeline construction, data warehouse design, batch processing workflows, and data-driven feature development",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "author": {
         "name": "Seth Hobson",
         "url": "https://github.com/wshobson"
@@ -586,7 +586,7 @@
       "name": "incident-response",
       "source": "./plugins/incident-response",
       "description": "Production incident management, triage workflows, and automated incident resolution",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "author": {
         "name": "Seth Hobson",
         "url": "https://github.com/wshobson"
@@ -806,7 +806,7 @@
       "name": "cloud-infrastructure",
       "source": "./plugins/cloud-infrastructure",
       "description": "Cloud architecture design for AWS/Azure/GCP, Kubernetes cluster configuration, Terraform infrastructure-as-code, hybrid cloud networking, and multi-cloud cost optimization",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "author": {
         "name": "Seth Hobson",
         "url": "https://github.com/wshobson"
@@ -1132,7 +1132,7 @@
       "name": "security-scanning",
       "source": "./plugins/security-scanning",
       "description": "SAST analysis, dependency vulnerability scanning, OWASP Top 10 compliance, container security scanning, and automated security hardening",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "author": {
         "name": "Seth Hobson",
         "url": "https://github.com/wshobson"
@@ -1427,7 +1427,7 @@
       "name": "documentation-generation",
       "source": "./plugins/documentation-generation",
       "description": "OpenAPI specification generation, Mermaid diagram creation, tutorial writing, API reference documentation",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "author": {
         "name": "Seth Hobson",
         "url": "https://github.com/wshobson"
@@ -1533,7 +1533,7 @@
       "name": "business-analytics",
       "source": "./plugins/business-analytics",
       "description": "Business metrics analysis, KPI tracking, financial reporting, and data-driven decision making",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "author": {
         "name": "Seth Hobson",
         "url": "https://github.com/wshobson"
@@ -1564,7 +1564,7 @@
       "name": "hr-legal-compliance",
       "source": "./plugins/hr-legal-compliance",
       "description": "HR policy documentation, legal compliance templates (GDPR/SOC2/HIPAA), employment contracts, and regulatory documentation",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "author": {
         "name": "Seth Hobson",
         "url": "https://github.com/wshobson"
@@ -1684,7 +1684,7 @@
       "name": "quantitative-trading",
       "source": "./plugins/quantitative-trading",
       "description": "Quantitative analysis, algorithmic trading strategies, financial modeling, portfolio risk management, and backtesting",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "author": {
         "name": "Seth Hobson",
         "url": "https://github.com/wshobson"
@@ -1749,7 +1749,7 @@
       "name": "game-development",
       "source": "./plugins/game-development",
       "description": "Unity game development with C# scripting, Minecraft server plugin development with Bukkit/Spigot APIs",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "author": {
         "name": "Seth Hobson",
         "url": "https://github.com/wshobson"
@@ -1781,7 +1781,7 @@
       "name": "accessibility-compliance",
       "source": "./plugins/accessibility-compliance",
       "description": "WCAG accessibility auditing, compliance validation, UI testing for screen readers, keyboard navigation, and inclusive design",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "author": {
         "name": "Seth Hobson",
         "url": "https://github.com/wshobson"
@@ -1885,7 +1885,7 @@
       "name": "systems-programming",
       "source": "./plugins/systems-programming",
       "description": "Systems programming with Rust, Go, C, and C++ for performance-critical and low-level development",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "author": {
         "name": "Seth Hobson",
         "url": "https://github.com/wshobson"
@@ -2094,7 +2094,7 @@
       "name": "developer-essentials",
       "source": "./plugins/developer-essentials",
       "description": "Essential developer skills including Git workflows, SQL optimization, error handling, code review, E2E testing, authentication, debugging, and monorepo management",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "Seth Hobson",
         "url": "https://github.com/wshobson"


### PR DESCRIPTION
## Summary

Fixes #143 by bumping version numbers for all 15 plugins that had skills/agents added in commit `01d93fc` without corresponding version updates.

**Impact**: 1 file changed (16 version strings updated)  
**Risk Level**: 🟢 Low  
**Review Time**: ~5 minutes

---

## Problem

Commit `01d93fc` added 5 new agents and 45+ skills across 15 plugins without incrementing version numbers in `marketplace.json`. This broke Claude Code's plugin cache invalidation mechanism.

```
User installs plugins (cache: v1.2.0)
     ↓
Commit 01d93fc adds skills (still v1.2.0)
     ↓
User pulls updates
     ↓
Cache thinks v1.2.0 is current → doesn't refresh
     ↓
"Path not found" errors for new skills ❌
```

---

## Solution

Bump patch versions for all 15 affected plugins + marketplace metadata:

| Plugin | Before | After | Additions |
|--------|--------|-------|-----------|
| accessibility-compliance | 1.2.0 | 1.2.1 | +2 skills |
| backend-development | 1.2.3 | 1.2.4 | +1 agent, +4 skills |
| business-analytics | 1.2.0 | 1.2.1 | +2 skills |
| cloud-infrastructure | 1.2.1 | 1.2.2 | +1 agent, +4 skills |
| data-engineering | 1.2.1 | 1.2.2 | +4 skills |
| developer-essentials | 1.0.0 | 1.0.1 | +1 agent, +3 skills |
| documentation-generation | 1.2.0 | 1.2.1 | +3 skills |
| frontend-mobile-development | 1.2.0 | 1.2.1 | +4 skills |
| game-development | 1.2.0 | 1.2.1 | +2 skills |
| hr-legal-compliance | 1.2.0 | 1.2.1 | +2 skills |
| incident-response | 1.2.1 | 1.2.2 | +3 skills |
| llm-application-dev | 1.2.1 | 1.2.2 | +1 agent, +4 skills |
| quantitative-trading | 1.2.0 | 1.2.1 | +2 skills |
| security-scanning | 1.2.2 | 1.2.3 | +1 agent, +4 skills |
| systems-programming | 1.2.0 | 1.2.1 | +3 skills |
| **metadata** | 1.3.0 | 1.3.1 | — |

---

## Risk Assessment

| Factor | Score | Rationale |
|--------|-------|-----------|
| Size | 🟢 1/10 | Single file, 16 line changes |
| Complexity | 🟢 1/10 | Pure version string updates |
| Breaking Changes | 🟢 0/10 | Higher versions are backward compatible |
| Test Coverage | 🟢 N/A | No testable logic changed |
| Rollback | 🟢 1/10 | Single commit revert |

**Overall**: 🟢 **Low Risk** — Surgical metadata fix with no behavioral changes.

---

## User Impact

### Before This Fix
```
$ claude
> /plugin marketplace add wshobson/agents
✓ Installed claude-code-workflows v1.3.0

# Later, after git pull on marketplace...
> Use the vector-database-engineer agent
❌ Error: Path not found: plugins/llm-application-dev/agents/vector-database-engineer.md
```

### After This Fix
```
$ claude  
> /plugin marketplace add wshobson/agents
✓ Installed claude-code-workflows v1.3.1  ← Version bump triggers cache refresh

> Use the vector-database-engineer agent
✓ Agent loaded successfully
```

### Immediate Workaround (for existing users)
Delete the cache directory at `~/.claude/plugins/cache/claude-code-workflows/` and restart Claude Code.

---

## Verification

- ✅ All 5 new agents registered in marketplace.json arrays
- ✅ All 45 new skills registered in marketplace.json arrays
- ✅ JSON syntax validated
- ✅ No other commits between 01d93fc and HEAD with missing bumps
- ✅ Scope expanded from 4 reported → 15 actual affected plugins

---

## Test Plan

1. **Cache Invalidation Test**: Clear plugin cache, reload plugins, verify new version (1.3.1) is fetched
2. **Skill Loading Test**: Load a skill added in 01d93fc (e.g., `embedding-strategies`) — should succeed
3. **Agent Loading Test**: Use `vector-database-engineer` agent — should load successfully

---

## Review Checklist

### Configuration
- [x] No hardcoded values
- [x] Backwards compatibility maintained (patch versions only)
- [x] JSON syntax validated

### Process
- [x] Issue scope documented (see [comment](https://github.com/wshobson/agents/issues/143#issuecomment-3674384968))
- [x] All affected plugins identified via git archaeology
- [x] Specialist agents verified registrations

---

## Related Work

- **Root Cause**: Commit `01d93fc` added content without version bumps
---

## Notes

Investigation found **15 affected plugins** (not 4 as originally reported in issue). Full audit available in [issue comment](https://github.com/wshobson/agents/issues/143#issuecomment-3674384968).