### PR TITLE
improve context-driven-development skill structure and eval score

### DIFF
--- a/plugins/conductor/skills/context-driven-development/SKILL.md
+++ b/plugins/conductor/skills/context-driven-development/SKILL.md
@@ -1,248 +1,50 @@
 ---
 name: context-driven-development
-description: Use this skill when working with Conductor's context-driven development methodology, managing project context artifacts, or understanding the relationship between product.md, tech-stack.md, and workflow.md files.
-version: 1.0.0
+description: >-
+  Creates and maintains project context artifacts (product.md, tech-stack.md, workflow.md, tracks.md)
+  in a `conductor/` directory. Scaffolds new projects from scratch, extracts context from existing
+  codebases, validates artifact consistency before implementation, and synchronizes documents as the
+  project evolves. Use when setting up a project, creating or updating product docs, managing a tech
+  stack file, defining development workflows, tracking work units, onboarding to an existing codebase,
+  or running project scaffolding.
 ---
 
 # Context-Driven Development
 
-Guide for implementing and maintaining context as a managed artifact alongside code, enabling consistent AI interactions and team alignment through structured project documentation.
+## Workflow
 
-## When to Use This Skill
+Follow **Context → Spec & Plan → Implement**:
 
-- Setting up new projects with Conductor
-- Understanding the relationship between context artifacts
-- Maintaining consistency across AI-assisted development sessions
-- Onboarding team members to an existing Conductor project
-- Deciding when to update context documents
-- Managing greenfield vs brownfield project contexts
+1. **Context** — verify project artifacts exist and are current
+2. **Spec** — define requirements and acceptance criteria for a work unit
+3. **Plan** — break the spec into phased, actionable tasks
+4. **Implement** — execute tasks following established workflow patterns
 
-## Core Philosophy
+## Artifacts
 
-Context-Driven Development treats project context as a first-class artifact managed alongside code. Instead of relying on ad-hoc prompts or scattered documentation, establish a persistent, structured foundation that informs all AI interactions.
+| Artifact | Role | Update trigger |
+|---|---|---|
+| `product.md` | WHAT + WHY — vision, goals, users, features | Vision/goals change, features ship, audience shifts |
+| `product-guidelines.md` | Voice, terminology, copy standards | Brand guidelines change, new terminology introduced |
+| `tech-stack.md` | Languages, deps, infra, tools with versions | Deps added/upgraded, infra changes, new tools adopted |
+| `workflow.md` | Methodology, git conventions, testing, quality gates | Practices evolve, standards change |
+| `tracks.md` | Work-unit registry with status and assignees | Tracks created, status changes, tracks completed |
 
-Key principles:
-
-1. **Context precedes code**: Define what you're building and how before implementation
-2. **Living documentation**: Context artifacts evolve with the project
-3. **Single source of truth**: One canonical location for each type of information
-4. **AI alignment**: Consistent context produces consistent AI behavior
-
-## The Workflow
-
-Follow the **Context → Spec & Plan → Implement** workflow:
-
-1. **Context Phase**: Establish or verify project context artifacts exist and are current
-2. **Specification Phase**: Define requirements and acceptance criteria for work units
-3. **Planning Phase**: Break specifications into phased, actionable tasks
-4. **Implementation Phase**: Execute tasks following established workflow patterns
-
-## Artifact Relationships
-
-### product.md - Defines WHAT and WHY
-
-Purpose: Captures product vision, goals, target users, and business context.
-
-Contents:
-
-- Product name and one-line description
-- Problem statement and solution approach
-- Target user personas
-- Core features and capabilities
-- Success metrics and KPIs
-- Product roadmap (high-level)
-
-Update when:
-
-- Product vision or goals change
-- New major features are planned
-- Target audience shifts
-- Business priorities evolve
-
-### product-guidelines.md - Defines HOW to Communicate
-
-Purpose: Establishes brand voice, messaging standards, and communication patterns.
-
-Contents:
-
-- Brand voice and tone guidelines
-- Terminology and glossary
-- Error message conventions
-- User-facing copy standards
-- Documentation style
-
-Update when:
-
-- Brand guidelines change
-- New terminology is introduced
-- Communication patterns need refinement
-
-### tech-stack.md - Defines WITH WHAT
-
-Purpose: Documents technology choices, dependencies, and architectural decisions.
-
-Contents:
-
-- Primary languages and frameworks
-- Key dependencies with versions
-- Infrastructure and deployment targets
-- Development tools and environment
-- Testing frameworks
-- Code quality tools
-
-Update when:
-
-- Adding new dependencies
-- Upgrading major versions
-- Changing infrastructure
-- Adopting new tools or patterns
-
-### workflow.md - Defines HOW to Work
-
-Purpose: Establishes development practices, quality gates, and team workflows.
-
-Contents:
-
-- Development methodology (TDD, etc.)
-- Git workflow and commit conventions
-- Code review requirements
-- Testing requirements and coverage targets
-- Quality assurance gates
-- Deployment procedures
-
-Update when:
-
-- Team practices evolve
-- Quality standards change
-- New workflow patterns are adopted
-
-### tracks.md - Tracks WHAT'S HAPPENING
-
-Purpose: Registry of all work units with status and metadata.
-
-Contents:
-
-- Active tracks with current status
-- Completed tracks with completion dates
-- Track metadata (type, priority, assignee)
-- Links to individual track directories
-
-Update when:
-
-- New tracks are created
-- Track status changes
-- Tracks are completed or archived
-
-## Context Maintenance Principles
-
-### Keep Artifacts Synchronized
-
-Ensure changes in one artifact reflect in related documents:
-
-- New feature in product.md → Update tech-stack.md if new dependencies needed
-- Completed track → Update product.md to reflect new capabilities
-- Workflow change → Update all affected track plans
-
-### Update tech-stack.md When Adding Dependencies
-
-Before adding any new dependency:
-
-1. Check if existing dependencies solve the need
-2. Document the rationale for new dependencies
-3. Add version constraints
-4. Note any configuration requirements
-
-### Update product.md When Features Complete
-
-After completing a feature track:
-
-1. Move feature from "planned" to "implemented" in product.md
-2. Update any affected success metrics
-3. Document any scope changes from original plan
-
-### Verify Context Before Implementation
-
-Before starting any track:
-
-1. Read all context artifacts
-2. Flag any outdated information
-3. Propose updates before proceeding
-4. Confirm context accuracy with stakeholders
-
-## Greenfield vs Brownfield Handling
-
-### Greenfield Projects (New)
-
-For new projects:
-
-1. Run `/conductor:setup` to create all artifacts interactively
-2. Answer questions about product vision, tech preferences, and workflow
-3. Generate initial style guides for chosen languages
-4. Create empty tracks registry
-
-Characteristics:
-
-- Full control over context structure
-- Define standards before code exists
-- Establish patterns early
-
-### Brownfield Projects (Existing)
-
-For existing codebases:
-
-1. Run `/conductor:setup` with existing codebase detection
-2. System analyzes existing code, configs, and documentation
-3. Pre-populate artifacts based on discovered patterns
-4. Review and refine generated context
-
-Characteristics:
-
-- Extract implicit context from existing code
-- Reconcile existing patterns with desired patterns
-- Document technical debt and modernization plans
-- Preserve working patterns while establishing standards
-
-## Benefits
-
-### Team Alignment
-
-- New team members onboard faster with explicit context
-- Consistent terminology and conventions across the team
-- Shared understanding of product goals and technical decisions
-
-### AI Consistency
-
-- AI assistants produce aligned outputs across sessions
-- Reduced need to re-explain context in each interaction
-- Predictable behavior based on documented standards
-
-### Institutional Memory
-
-- Decisions and rationale are preserved
-- Context survives team changes
-- Historical context informs future decisions
-
-### Quality Assurance
-
-- Standards are explicit and verifiable
-- Deviations from context are detectable
-- Quality gates are documented and enforceable
+See [references/artifact-templates.md](references/artifact-templates.md) for copy-paste starter templates.
 
 ## Directory Structure
 
 ```
 conductor/
-├── index.md              # Navigation hub linking all artifacts
-├── product.md            # Product vision and goals
-├── product-guidelines.md # Communication standards
-├── tech-stack.md         # Technology preferences
-├── workflow.md           # Development practices
-├── tracks.md             # Work unit registry
+├── index.md              # Navigation hub
+├── product.md
+├── product-guidelines.md
+├── tech-stack.md
+├── workflow.md
+├── tracks.md
 ├── setup_state.json      # Resumable setup state
 ├── code_styleguides/     # Language-specific conventions
-│   ├── python.md
-│   ├── typescript.md
-│   └── ...
+│   └── <language>.md
 └── tracks/
     └── <track-id>/
         ├── spec.md
@@ -251,135 +53,56 @@ conductor/
         └── index.md
 ```
 
-## Context Lifecycle
+## Project Setup
 
-1. **Creation**: Initial setup via `/conductor:setup`
-2. **Validation**: Verify before each track
-3. **Evolution**: Update as project grows
-4. **Synchronization**: Keep artifacts aligned
-5. **Archival**: Document historical decisions
+| Scenario | Command | Behavior |
+|---|---|---|
+| **Greenfield** (new repo) | `/conductor:setup` | Interactively creates all artifacts, generates style guides, initializes empty tracks registry |
+| **Brownfield** (existing repo) | `/conductor:setup` | Analyzes existing code, configs, and docs — pre-populates artifacts for review |
 
-## Context Validation Checklist
+### Starting a New Track
 
-Before starting implementation on any track, validate context:
+```bash
+# 1. validate context is current
+cat conductor/tracks.md
+cat conductor/tech-stack.md
 
-### Product Context
+# 2. create track directory and spec
+mkdir -p conductor/tracks/TRACK-042
+cat > conductor/tracks/TRACK-042/spec.md << 'EOF'
+# Add Redis Caching
+## Requirements
+- Cache auth sessions in Redis
+- TTL: 24 hours
+## Acceptance Criteria
+- [ ] Redis added to tech-stack.md with version and rationale
+- [ ] Session lookup < 5ms p99
+EOF
 
-- [ ] product.md reflects current product vision
-- [ ] Target users are accurately described
-- [ ] Feature list is up to date
-- [ ] Success metrics are defined
+# 3. register the track
+echo "| TRACK-042 | Add Redis caching | in-progress | high | @dev |" >> conductor/tracks.md
 
-### Technical Context
+# 4. commit context before implementation
+git add conductor/ && git commit -m "feat(conductor): add TRACK-042 redis caching spec"
+```
 
-- [ ] tech-stack.md lists all current dependencies
-- [ ] Version numbers are accurate
-- [ ] Infrastructure targets are correct
-- [ ] Development tools are documented
+## Pre-Implementation Validation
 
-### Workflow Context
+Before starting work on any track, confirm artifacts are current:
 
-- [ ] workflow.md describes current practices
-- [ ] Quality gates are defined
-- [ ] Coverage targets are specified
-- [ ] Commit conventions are documented
+| Area | Check |
+|---|---|
+| Product | `product.md` reflects current vision, users, and feature list |
+| Tech | `tech-stack.md` lists all deps with accurate versions |
+| Workflow | `workflow.md` describes current practices and quality gates |
+| Tracks | `tracks.md` shows all active work, no stale entries |
 
-### Track Context
+**On failure**: flag outdated items → propose specific updates → get confirmation before proceeding.
 
-- [ ] tracks.md shows all active work
-- [ ] No stale or abandoned tracks
-- [ ] Dependencies between tracks are noted
+See [references/maintenance-principles.md](references/maintenance-principles.md) for artifact synchronization rules and dependency update procedures.
 
-## Common Anti-Patterns
+See [references/anti-patterns.md](references/anti-patterns.md) for common context management mistakes.
 
-Avoid these context management mistakes:
+See [references/integration-patterns.md](references/integration-patterns.md) for IDE, git hook, and CI/CD integration guidance.
 
-### Stale Context
-
-Problem: Context documents become outdated and misleading.
-Solution: Update context as part of each track's completion process.
-
-### Context Sprawl
-
-Problem: Information scattered across multiple locations.
-Solution: Use the defined artifact structure; resist creating new document types.
-
-### Implicit Context
-
-Problem: Relying on knowledge not captured in artifacts.
-Solution: If you reference something repeatedly, add it to the appropriate artifact.
-
-### Context Hoarding
-
-Problem: One person maintains context without team input.
-Solution: Review context artifacts in pull requests; make updates collaborative.
-
-### Over-Specification
-
-Problem: Context becomes so detailed it's impossible to maintain.
-Solution: Keep artifacts focused on decisions that affect AI behavior and team alignment.
-
-## Integration with Development Tools
-
-### IDE Integration
-
-Configure your IDE to display context files prominently:
-
-- Pin conductor/product.md for quick reference
-- Add tech-stack.md to project notes
-- Create snippets for common patterns from style guides
-
-### Git Hooks
-
-Consider pre-commit hooks that:
-
-- Warn when dependencies change without tech-stack.md update
-- Remind to update product.md when feature branches merge
-- Validate context artifact syntax
-
-### CI/CD Integration
-
-Include context validation in pipelines:
-
-- Check tech-stack.md matches actual dependencies
-- Verify links in context documents resolve
-- Ensure tracks.md status matches git branch state
-
-## Session Continuity
-
-Conductor supports multi-session development through context persistence:
-
-### Starting a New Session
-
-1. Read index.md to orient yourself
-2. Check tracks.md for active work
-3. Review relevant track's plan.md for current task
-4. Verify context artifacts are current
-
-### Ending a Session
-
-1. Update plan.md with current progress
-2. Note any blockers or decisions made
-3. Commit in-progress work with clear status
-4. Update tracks.md if status changed
-
-### Handling Interruptions
-
-If interrupted mid-task:
-
-1. Mark task as `[~]` with note about stopping point
-2. Commit work-in-progress to feature branch
-3. Document any uncommitted decisions in plan.md
-
-## Best Practices
-
-1. **Read context first**: Always read relevant artifacts before starting work
-2. **Small updates**: Make incremental context changes, not massive rewrites
-3. **Link decisions**: Reference context when making implementation choices
-4. **Version context**: Commit context changes alongside code changes
-5. **Review context**: Include context artifact reviews in code reviews
-6. **Validate regularly**: Run context validation checklist before major work
-7. **Communicate changes**: Notify team when context artifacts change significantly
-8. **Preserve history**: Use git to track context evolution over time
-9. **Question staleness**: If context feels wrong, investigate and update
-10. **Keep it actionable**: Every context item should inform a decision or behavior
+See [references/best-practices.md](references/best-practices.md) for session continuity and context management tips.

--- a/plugins/conductor/skills/context-driven-development/references/anti-patterns.md
+++ b/plugins/conductor/skills/context-driven-development/references/anti-patterns.md
@@ -1,0 +1,28 @@
+# Common Anti-Patterns
+
+Avoid these context management mistakes:
+
+### Stale Context
+
+Problem: Context documents become outdated and misleading.
+Solution: Update context as part of each track's completion process.
+
+### Context Sprawl
+
+Problem: Information scattered across multiple locations.
+Solution: Use the defined artifact structure; resist creating new document types.
+
+### Implicit Context
+
+Problem: Relying on knowledge not captured in artifacts.
+Solution: If you reference something repeatedly, add it to the appropriate artifact.
+
+### Context Hoarding
+
+Problem: One person maintains context without team input.
+Solution: Review context artifacts in pull requests; make updates collaborative.
+
+### Over-Specification
+
+Problem: Context becomes so detailed it's impossible to maintain.
+Solution: Keep artifacts focused on decisions that affect AI behavior and team alignment.

--- a/plugins/conductor/skills/context-driven-development/references/artifact-templates.md
+++ b/plugins/conductor/skills/context-driven-development/references/artifact-templates.md
@@ -1,0 +1,152 @@
+# Artifact Templates
+
+Starter templates for each Conductor context artifact. Copy and fill in for new projects.
+
+## product.md
+
+```markdown
+# [Product Name]
+
+> One-line description of what this product does.
+
+## Problem
+
+What problem does this solve and for whom?
+
+## Solution
+
+High-level approach to solving the problem.
+
+## Target Users
+
+| Persona | Needs | Pain Points |
+|---|---|---|
+| Persona 1 | What they need | What frustrates them |
+
+## Core Features
+
+| Feature | Status | Description |
+|---|---|---|
+| Feature A | planned | What it does |
+| Feature B | implemented | What it does |
+
+## Success Metrics
+
+| Metric | Target | Current |
+|---|---|---|
+| Metric 1 | target value | - |
+
+## Roadmap
+
+- **Phase 1**: scope
+- **Phase 2**: scope
+```
+
+## tech-stack.md
+
+```markdown
+# Tech Stack
+
+## Languages & Frameworks
+
+| Technology | Version | Purpose |
+|---|---|---|
+| Python | 3.12 | Backend API |
+| React | 18.x | Frontend UI |
+
+## Key Dependencies
+
+| Package | Version | Rationale |
+|---|---|---|
+| FastAPI | 0.100+ | REST API framework |
+| SQLAlchemy | 2.x | ORM and database access |
+
+## Infrastructure
+
+| Component | Choice | Notes |
+|---|---|---|
+| Hosting | AWS ECS | Production containers |
+| Database | PostgreSQL 16 | Primary data store |
+| CI/CD | GitHub Actions | Build and deploy |
+
+## Dev Tools
+
+| Tool | Purpose | Config |
+|---|---|---|
+| pytest | Testing (target: 80% coverage) | pyproject.toml |
+| ruff | Linting + formatting | ruff.toml |
+```
+
+## workflow.md
+
+```markdown
+# Workflow
+
+## Methodology
+
+TDD with trunk-based development.
+
+## Git Conventions
+
+- **Branch naming**: `feature/<track-id>-description`
+- **Commit format**: `type(scope): message`
+- **PR requirements**: 1 approval, all checks green
+
+## Quality Gates
+
+| Gate | Requirement |
+|---|---|
+| Tests | All pass, coverage >= 80% |
+| Lint | Zero errors |
+| Review | At least 1 approval |
+| Types | No type errors |
+
+## Deployment
+
+1. PR merged to main
+2. CI runs tests + build
+3. Auto-deploy to staging
+4. Manual promotion to production
+```
+
+## tracks.md
+
+```markdown
+# Tracks
+
+## Active
+
+| ID | Title | Status | Priority | Assignee |
+|---|---|---|---|---|
+| TRACK-001 | Feature name | in-progress | high | @person |
+
+## Completed
+
+| ID | Title | Completed |
+|---|---|---|
+| TRACK-000 | Initial setup | 2024-01-15 |
+```
+
+## product-guidelines.md
+
+```markdown
+# Product Guidelines
+
+## Voice & Tone
+
+- Professional but approachable
+- Direct and concise
+- Technical where needed, plain language by default
+
+## Terminology
+
+| Term | Use | Don't Use |
+|---|---|---|
+| workspace | preferred | project, repo |
+| track | preferred | ticket, issue |
+
+## Error Messages
+
+Format: `[Component] What happened. What to do next.`
+Example: `[Auth] Session expired. Please sign in again.`
+```

--- a/plugins/conductor/skills/context-driven-development/references/best-practices.md
+++ b/plugins/conductor/skills/context-driven-development/references/best-practices.md
@@ -1,0 +1,38 @@
+# Best Practices
+
+## Context Management
+
+1. **Read context first** — always read relevant artifacts before starting work
+2. **Small updates** — make incremental context changes, not massive rewrites
+3. **Link decisions** — reference context when making implementation choices
+4. **Version context** — commit context changes alongside code changes
+5. **Review context** — include context artifact reviews in code reviews
+6. **Validate regularly** — run the pre-implementation validation before major work
+7. **Question staleness** — if context feels wrong, investigate and update
+8. **Keep it actionable** — every context item should inform a decision or behavior
+
+## Session Continuity
+
+Conductor supports multi-session development through context persistence.
+
+### Starting a New Session
+
+1. Read `index.md` to orient yourself
+2. Check `tracks.md` for active work
+3. Review the relevant track's `plan.md` for current task
+4. Verify context artifacts are current
+
+### Ending a Session
+
+1. Update `plan.md` with current progress
+2. Note any blockers or decisions made
+3. Commit in-progress work with clear status
+4. Update `tracks.md` if status changed
+
+### Handling Interruptions
+
+If interrupted mid-task:
+
+1. Mark task as `[~]` with note about stopping point
+2. Commit work-in-progress to feature branch
+3. Document any uncommitted decisions in `plan.md`

--- a/plugins/conductor/skills/context-driven-development/references/integration-patterns.md
+++ b/plugins/conductor/skills/context-driven-development/references/integration-patterns.md
@@ -1,0 +1,25 @@
+# Integration with Development Tools
+
+### IDE Integration
+
+Configure your IDE to display context files prominently:
+
+- Pin conductor/product.md for quick reference
+- Add tech-stack.md to project notes
+- Create snippets for common patterns from style guides
+
+### Git Hooks
+
+Consider pre-commit hooks that:
+
+- Warn when dependencies change without tech-stack.md update
+- Remind to update product.md when feature branches merge
+- Validate context artifact syntax
+
+### CI/CD Integration
+
+Include context validation in pipelines:
+
+- Check tech-stack.md matches actual dependencies
+- Verify links in context documents resolve
+- Ensure tracks.md status matches git branch state

--- a/plugins/conductor/skills/context-driven-development/references/maintenance-principles.md
+++ b/plugins/conductor/skills/context-driven-development/references/maintenance-principles.md
@@ -1,0 +1,35 @@
+# Context Maintenance Principles
+
+### Keep Artifacts Synchronized
+
+Ensure changes in one artifact reflect in related documents:
+
+- New feature in product.md → Update tech-stack.md if new dependencies needed
+- Completed track → Update product.md to reflect new capabilities
+- Workflow change → Update all affected track plans
+
+### Update tech-stack.md When Adding Dependencies
+
+Before adding any new dependency:
+
+1. Check if existing dependencies solve the need
+2. Document the rationale for new dependencies
+3. Add version constraints
+4. Note any configuration requirements
+
+### Update product.md When Features Complete
+
+After completing a feature track:
+
+1. Move feature from "planned" to "implemented" in product.md
+2. Update any affected success metrics
+3. Document any scope changes from original plan
+
+### Verify Context Before Implementation
+
+Before starting any track:
+
+1. Read all context artifacts
+2. Flag any outdated information
+3. Propose updates before proceeding
+4. Confirm context accuracy with stakeholders


### PR DESCRIPTION
hey @wshobson, thanks for building and sharing your orchestration framework. Kudos on soon hitting `29k` stars! I just starred it.

was running your skills through some evals and noticed a few things on context-driven-development that were pretty quick to improve (moving from `~60` to `~100` agent performance):

- rewrote frontmatter description with concrete actions + trigger terms like _setting up a project_, _tech stack file_, _onboarding to an existing codebase_ so agents can reliably match user requests

- condensed skill.md by using tables over prose - removed philosophy sections and explanations Claude already knows

- extracted `5` reference files (_anti-patterns_, _artifact-templates_, _best-practices_, _integration-patterns_, _maintenance-principles_) for progressive disclosure

these were easy changes to bring the skill in line with what performs well against **Anthropic's best practices**. honest disclosure, I work at a company where we build tooling around this. not a pitch, just fixes that were straightforward to make.

you've got `16` skills here, if you want to do it yourself, evals are free and open to run: [link](https://tessl.io/registry/skills/github/wshobson/agents) otherwise happy to make the improvements for you.