### PR TITLE
fix: monte carlo layer uses nonexistent sdk.stream() instead of sdk.query()

### DIFF
--- a/plugins/plugin-eval/src/plugin_eval/layers/monte_carlo.py
+++ b/plugins/plugin-eval/src/plugin_eval/layers/monte_carlo.py
@@ -53,25 +53,38 @@ class MonteCarloConfig:
 async def run_simulation(skill_content: str, prompt: str, auth: str) -> SimResult:
     """Run a single simulation via Agent SDK. Returns SimResult. On error, errored=True."""
     try:
-        import claude_agent_sdk as sdk  # type: ignore[import-untyped]
+        from claude_agent_sdk import (  # type: ignore[import-untyped]
+            ClaudeAgentOptions,
+            ResultMessage,
+            query,
+        )
+        import time
+
+        full_prompt = (
+            f"You are evaluating a skill. Apply the skill if appropriate.\n\n"
+            f"{skill_content}\n\n{prompt}"
+        )
 
         result_text = ""
         activated = False
         tokens = 0
 
-        import time
-
         start = time.monotonic()
 
-        async for event in sdk.stream(
-            prompt,
-            system=f"You are evaluating a skill. Apply the skill if appropriate.\n\n{skill_content}",
+        async for message in query(
+            prompt=full_prompt,
+            options=ClaudeAgentOptions(
+                allowed_tools=[],
+            ),
         ):
-            if hasattr(event, "text"):
-                result_text += event.text
-                activated = True
-            if hasattr(event, "usage"):
-                tokens = getattr(event.usage, "total_tokens", 0)
+            if isinstance(message, ResultMessage):
+                for block in getattr(message, "content", []):
+                    if hasattr(block, "text"):
+                        result_text += block.text
+                        activated = True
+                usage = getattr(message, "usage", None)
+                if usage:
+                    tokens = getattr(usage, "total_tokens", 0)
 
         duration_ms = int((time.monotonic() - start) * 1000)
 


### PR DESCRIPTION
Fixes #477. Monte Carlo layer was calling `sdk.stream()` which doesn't exist in `claude-agent-sdk` — replaced with the `query()` + `ClaudeAgentOptions` + `ResultMessage` pattern that the judge layer already uses correctly.

## What changed

`run_simulation()` in `layers/monte_carlo.py` now imports and uses the same SDK API as `query_llm()` in `layers/judge.py`:
- `from claude_agent_sdk import query, ClaudeAgentOptions, ResultMessage`
- Iterates `async for message in query(...)` and extracts text from `ResultMessage.content` blocks

The old code used `sdk.stream()` which doesn't exist, causing every simulation to silently fail (`errored=True`) due to the bare `except` handler. This reported 100% failure rate and tanked composite scores on triggering accuracy, robustness, and token efficiency.

## Test plan

- [x] All 3 monte carlo tests pass
- [x] Pattern matches the working judge layer implementation

I maintain [PRISM](https://github.com/jakeefr/prism), a post-session diagnostics tool for Claude Code. Fixed this while exploring agent orchestration patterns.