### PR TITLE
meigen-ai-design: bump to 1.0.1 (pin meigen@1.2.8)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -963,7 +963,7 @@
       "name": "meigen-ai-design",
       "source": "./plugins/meigen-ai-design",
       "description": "AI image generation with creative workflow orchestration, prompt engineering, and curated inspiration library via MCP server",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "MeiGen",
         "url": "https://github.com/jau123"

--- a/plugins/meigen-ai-design/.claude-plugin/plugin.json
+++ b/plugins/meigen-ai-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "meigen-ai-design",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "AI image generation with creative workflow orchestration, parallel multi-direction output, prompt engineering, and a 1,300+ curated inspiration library. Requires MeiGen MCP server (supports MeiGen Cloud, local ComfyUI, and OpenAI-compatible APIs).",
   "author": {
     "name": "MeiGen",

--- a/plugins/meigen-ai-design/README.md
+++ b/plugins/meigen-ai-design/README.md
@@ -11,7 +11,7 @@ This plugin requires the **meigen** MCP server. Install it by adding to your pro
   "mcpServers": {
     "meigen": {
       "command": "npx",
-      "args": ["-y", "meigen@1.2.5"]
+      "args": ["-y", "meigen@1.2.8"]
     }
   }
 }

--- a/plugins/meigen-ai-design/agents/image-generator.md
+++ b/plugins/meigen-ai-design/agents/image-generator.md
@@ -44,7 +44,8 @@ Multiple derivative images — spawn parallel agents, each with referenceImages 
 1. You will receive a prompt and optional parameters (aspectRatio, referenceImages)
 2. Call `generate_image` with EXACTLY the provided parameters
 3. Do NOT specify `model` or `provider` — let the server auto-detect
-4. Return the COMPLETE tool response text as-is
+4. If `aspectRatio` was NOT provided, OMIT it from the call — the server defaults to `"auto"` and will infer the best ratio from the prompt. Only pass an explicit value (e.g. `"16:9"`, `"1:1"`) when the caller specified one.
+5. Return the COMPLETE tool response text as-is
 
 ## Rules
 


### PR DESCRIPTION
Patch bump to keep `meigen-ai-design` in sync with the upstream MCP server.

## Changes
- Pin MCP server to `meigen@1.2.8` (was `meigen@1.2.5`)
- `image-generator` agent: omit `aspectRatio` by default; the server (>=1.2.8) now auto-infers the best ratio from the prompt
- Bump plugin version `1.0.0` → `1.0.1` (both `plugin.json` and `marketplace.json` entry)

## Upstream reference
- MCP server changelog: https://github.com/jau123/MeiGen-AI-Design-MCP
- npm: https://www.npmjs.com/package/meigen

New in 1.2.8 (propagated via MCP, no plugin content change required):
- Midjourney V7 guidance + V7/Niji comparison in server instructions
- Aspect ratio `auto` default
- Clarified `--sref` usage (Midjourney style codes only)