### PR TITLE
fix: add missing YAML frontmatter to threat-modeling-expert agent

### DIFF
--- a/plugins/security-scanning/agents/threat-modeling-expert.md
+++ b/plugins/security-scanning/agents/threat-modeling-expert.md
@@ -1,3 +1,9 @@
+---
+name: threat-modeling-expert
+description: Expert in threat modeling methodologies, security architecture review, and risk assessment. Masters STRIDE, PASTA, attack trees, and security requirement extraction. Use PROACTIVELY for security architecture reviews, threat identification, or building secure-by-design systems.
+model: opus
+---
+
 # Threat Modeling Expert
 
 Expert in threat modeling methodologies, security architecture review, and risk assessment. Masters STRIDE, PASTA, attack trees, and security requirement extraction. Use PROACTIVELY for security architecture reviews, threat identification, or building secure-by-design systems.


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`plugins/security-scanning/agents/threat-modeling-expert.md` has no YAML frontmatter block. The file starts directly with `# Threat Modeling Expert` prose content, skipping the `---` delimited block that Claude Code requires to register an agent.

Without frontmatter, Claude Code cannot identify the agent's `name`, `description`, or `model`, so the agent silently fails to register and is completely unavailable to users who install the `security-scanning` plugin.

## Fix

Added the required frontmatter block at the top of the file:

```yaml
---
name: threat-modeling-expert
description: Expert in threat modeling methodologies, security architecture review, and risk assessment. Masters STRIDE, PASTA, attack trees, and security requirement extraction. Use PROACTIVELY for security architecture reviews, threat identification, or building secure-by-design systems.
model: opus
---
```

- `name`: derived from the filename and H1 heading
- `description`: taken verbatim from the first paragraph of the file
- `model: opus`: consistent with the `security-auditor` agent in the same plugin (threat modeling is complex, multi-step security work appropriate for Opus)

No content was changed — this is a pure structural fix.