### PR TITLE
fix: add missing name field to all 3 meigen-ai-design agents

### DIFF
--- a/plugins/meigen-ai-design/agents/gallery-researcher.md
+++ b/plugins/meigen-ai-design/agents/gallery-researcher.md
@@ -1,4 +1,5 @@
 ---
+name: gallery-researcher
 description: >-
   Gallery search and inspiration agent. Delegates here when user wants
   to find references, explore styles, build a mood board, or needs

--- a/plugins/meigen-ai-design/agents/image-generator.md
+++ b/plugins/meigen-ai-design/agents/image-generator.md
@@ -1,4 +1,5 @@
 ---
+name: image-generator
 description: >-
   Image generation executor agent. Delegates here for ALL generate_image
   calls to keep the main conversation context clean. Spawn one per image;

--- a/plugins/meigen-ai-design/agents/prompt-crafter.md
+++ b/plugins/meigen-ai-design/agents/prompt-crafter.md
@@ -1,4 +1,5 @@
 ---
+name: prompt-crafter
 description: >-
   Batch prompt writing agent. Delegates here when you need to write
   multiple distinct prompts at once — for parallel image generation


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

All three agents in `plugins/meigen-ai-design/agents/` have YAML frontmatter blocks but are missing the required `name` field:

- `prompt-crafter.md`
- `gallery-researcher.md`
- `image-generator.md`

The `name` field is how Claude Code identifies and registers an agent. Without it, these agents cannot be invoked — the entire `meigen-ai-design` plugin is non-functional despite having otherwise complete and well-structured definitions.

## Fix

Added `name:` to each agent's frontmatter, derived from the filename (the conventional source of truth):

```yaml
# prompt-crafter.md
name: prompt-crafter

# gallery-researcher.md
name: gallery-researcher

# image-generator.md
name: image-generator
```

No other content was changed. This is a one-line-per-file mechanical fix.