### PR TITLE
fix: add missing YAML frontmatter to codebase-cleanup commands

### DIFF
--- a/plugins/codebase-cleanup/commands/deps-audit.md
+++ b/plugins/codebase-cleanup/commands/deps-audit.md
@@ -1,3 +1,7 @@
+---
+description: Audit project dependencies for vulnerabilities, outdated packages, license conflicts, and supply chain risks — then provide actionable remediation strategies.
+---
+
 # Dependency Audit and Security Analysis
 
 You are a dependency security expert specializing in vulnerability scanning, license compliance, and supply chain security. Analyze project dependencies for known vulnerabilities, licensing issues, outdated packages, and provide actionable remediation strategies.

--- a/plugins/codebase-cleanup/commands/refactor-clean.md
+++ b/plugins/codebase-cleanup/commands/refactor-clean.md
@@ -1,3 +1,7 @@
+---
+description: Refactor provided code for cleanliness, maintainability, and alignment with SOLID principles and modern best practices — no over-engineering.
+---
+
 # Refactor and Clean Code
 
 You are a code refactoring expert specializing in clean code principles, SOLID design patterns, and modern software engineering best practices. Analyze and refactor the provided code to improve its quality, maintainability, and performance.

--- a/plugins/codebase-cleanup/commands/tech-debt.md
+++ b/plugins/codebase-cleanup/commands/tech-debt.md
@@ -1,3 +1,7 @@
+---
+description: Analyze and remediate technical debt — inventory debt items, score by impact, and produce a prioritized remediation plan with estimated effort.
+---
+
 # Technical Debt Analysis and Remediation
 
 You are a technical debt expert specializing in identifying, quantifying, and prioritizing technical debt in software projects. Analyze the codebase to uncover debt, assess its impact, and create actionable remediation plans.


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

All three commands in `plugins/codebase-cleanup/commands/` have no YAML frontmatter block:

- `tech-debt.md` — starts with `# Technical Debt Analysis and Remediation`
- `deps-audit.md` — starts with `# Dependency Audit and Security Analysis`
- `refactor-clean.md` — starts with `# Refactor and Clean Code`

Claude Code requires a `---` delimited frontmatter block with at minimum a `description` field to register a slash command. Without it, the command is silently absent when users install the `codebase-cleanup` plugin — all three slash commands are completely unavailable.

## Fix

Added minimal frontmatter to each command with a `description` derived from the file's title and opening paragraph:

```yaml
---
description: "..."
---
```

No content was changed — only the required registration header was prepended. The descriptions are concise, single-sentence summaries of what each command does.