### PR TITLE
fix: add missing YAML frontmatter to error-diagnostics commands

### DIFF
--- a/plugins/error-diagnostics/commands/error-analysis.md
+++ b/plugins/error-diagnostics/commands/error-analysis.md
@@ -1,3 +1,7 @@
+---
+description: Analyze and resolve errors across the full application lifecycle — from stack traces to distributed tracing — using systematic root-cause analysis and observability tools.
+---
+
 # Error Analysis and Resolution
 
 You are an expert error analysis specialist with deep expertise in debugging distributed systems, analyzing production incidents, and implementing comprehensive observability solutions.

--- a/plugins/error-diagnostics/commands/error-trace.md
+++ b/plugins/error-diagnostics/commands/error-trace.md
@@ -1,3 +1,7 @@
+---
+description: Set up error tracking and monitoring — implement structured logging, configure alerts, and integrate with error tracking services for real-time error detection.
+---
+
 # Error Tracking and Monitoring
 
 You are an error tracking and observability expert specializing in implementing comprehensive error monitoring solutions. Set up error tracking systems, configure alerts, implement structured logging, and ensure teams can quickly identify and resolve production issues.

--- a/plugins/error-diagnostics/commands/smart-debug.md
+++ b/plugins/error-diagnostics/commands/smart-debug.md
@@ -1,3 +1,7 @@
+---
+description: AI-assisted smart debugging — parse error messages, stack traces, and failure patterns to identify root causes and produce a fix with automated observability steps.
+---
+
 You are an expert AI-assisted debugging specialist with deep knowledge of modern debugging tools, observability platforms, and automated root cause analysis.
 
 ## Context


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

All three commands in `plugins/error-diagnostics/commands/` have no YAML frontmatter:

- `error-trace.md` — starts with `# Error Tracking and Monitoring`
- `error-analysis.md` — starts with `# Error Analysis and Resolution`
- `smart-debug.md` — starts directly with prose (no heading)

Claude Code requires a `---` delimited frontmatter block with at minimum a `description` field to register a slash command. Without it, all three slash commands silently fail to register — users installing `error-diagnostics` get no working commands.

## Fix

Added a minimal frontmatter block to each command with a `description` derived from each file's title and opening paragraph. No content was changed.

```yaml
---
description: "..."
---
```