### PR TITLE
fix: add missing YAML frontmatter to framework-migration and c4-architecture commands

### DIFF
--- a/plugins/c4-architecture/commands/c4-architecture.md
+++ b/plugins/c4-architecture/commands/c4-architecture.md
@@ -1,3 +1,7 @@
+---
+description: Generate comprehensive C4 architecture documentation (Context, Container, Component, Code) for a codebase using bottom-up analysis and four coordinated C4 agents.
+---
+
 # C4 Architecture Documentation Workflow
 
 Generate comprehensive C4 architecture documentation for an existing repository/codebase using a bottom-up analysis approach.

--- a/plugins/framework-migration/commands/code-migrate.md
+++ b/plugins/framework-migration/commands/code-migrate.md
@@ -1,3 +1,7 @@
+---
+description: Generate comprehensive migration plans and scripts for transitioning codebases between frameworks, languages, versions, or platforms with minimal disruption.
+---
+
 # Code Migration Assistant
 
 You are a code migration expert specializing in transitioning codebases between frameworks, languages, versions, and platforms. Generate comprehensive migration plans, automated migration scripts, and ensure smooth transitions with minimal disruption.

--- a/plugins/framework-migration/commands/deps-upgrade.md
+++ b/plugins/framework-migration/commands/deps-upgrade.md
@@ -1,3 +1,7 @@
+---
+description: Plan and execute safe, incremental dependency upgrades with minimal risk — including breaking-change migration paths and proper test verification.
+---
+
 # Dependency Upgrade Strategy
 
 You are a dependency management expert specializing in safe, incremental upgrades of project dependencies. Plan and execute dependency updates with minimal risk, proper testing, and clear migration paths for breaking changes.


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

Three commands have no YAML frontmatter and silently fail to register in Claude Code:

- `plugins/framework-migration/commands/code-migrate.md` — starts with `# Code Migration Assistant`
- `plugins/framework-migration/commands/deps-upgrade.md` — starts with `# Dependency Upgrade Strategy`
- `plugins/c4-architecture/commands/c4-architecture.md` — starts with `# C4 Architecture Documentation Workflow`

Without frontmatter, these slash commands are completely unavailable to users who install these plugins — Claude Code skips registration with no error message.

## Fix

Added minimal frontmatter to each command with a `description` field derived from each file's title and opening paragraph. No content was changed.

```yaml
---
description: "..."
---
```