### PR TITLE
test(protect-mcp): add test/ fixtures and round-trip verification

### DIFF
--- a/plugins/protect-mcp/test/README.md
+++ b/plugins/protect-mcp/test/README.md
@@ -1,0 +1,94 @@
+# protect-mcp test fixtures
+
+Round-trip tests for the `protect-mcp` plugin's `PreToolUse` and `PostToolUse`
+hooks. Exercises the full evaluate → sign → verify loop against deterministic
+fixtures, including the tamper-detection path.
+
+## Layout
+
+```
+test/
+├── fixtures/
+│   ├── test-policy.cedar                  # Cedar policy used by all tests
+│   ├── pretool-allow-read.json            # Read should be permitted
+│   ├── pretool-allow-bash-safe.json       # Bash "git status" should be permitted
+│   ├── pretool-deny-bash-destructive.json # Bash "rm -rf /" should be denied
+│   ├── pretool-deny-write.json            # Write should be denied
+│   └── posttool-signing-input.json        # Input for receipt signing
+├── expected/
+│   └── receipt-schema.json                # Expected receipt shape (JSON Schema)
+├── run-tests.sh                           # Full round-trip (requires node / npx)
+└── verify-fixtures.sh                     # Static validation (python3 only)
+```
+
+## Running
+
+### Full round-trip (local development)
+
+```bash
+./run-tests.sh
+```
+
+Requires `node` (>= 18), `npx`, and `python3`. Fetches `protect-mcp` and
+`@veritasacta/verify` from npm on first run. Runs eight tests:
+
+| # | Scenario | Expected exit |
+|---|----------|----------------|
+| 1 | `PreToolUse` on `Read`                         | 0 (permit)  |
+| 2 | `PreToolUse` on `Bash git status`              | 0 (permit)  |
+| 3 | `PreToolUse` on `Bash rm -rf /`                | 2 (forbid)  |
+| 4 | `PreToolUse` on `Write`                        | 2 (forbid)  |
+| 5 | `PostToolUse` signing produces a receipt file  | 0 (success) |
+| 6 | Produced receipt conforms to the schema        | 0 (valid)   |
+| 7 | `@veritasacta/verify` accepts the receipt      | 0 (valid)   |
+| 8 | Tampered receipt is rejected                   | 1 (tampered)|
+
+Test 8 is the critical regression guard: flipping the `decision` field in a
+signed receipt must invalidate the Ed25519 signature, so `@veritasacta/verify`
+must exit 1 rather than 0.
+
+### Static validation (CI-safe)
+
+```bash
+./verify-fixtures.sh
+```
+
+Only requires `python3`. Validates that every fixture is well-formed JSON and
+has the expected structure. No network calls, no npm fetches. Safe to run in
+sandboxed or offline CI.
+
+## What the tests prove
+
+- **Policy evaluation:** Cedar `permit` and `forbid` rules produce the
+  expected exit codes (0 / 2).
+- **Receipt schema:** signed receipts include every required field from
+  [`draft-farley-acta-signed-receipts`](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/).
+- **Signature integrity:** `@veritasacta/verify` validates authentic
+  receipts and rejects tampered ones, with the documented exit codes.
+- **End-to-end integration:** the plugin's two hooks compose into a
+  working allow/deny + sign + verify pipeline.
+
+## Extending
+
+To add a new test case:
+
+1. Drop a `pretool-*.json` or `posttool-*.json` fixture into `fixtures/`
+2. Add a matching rule to `fixtures/test-policy.cedar` if the test needs one
+3. Add an assertion block to `run-tests.sh` mirroring the existing ones
+
+Follow the naming convention `pretool-<allow|deny>-<scenario>.json` so the
+intent is obvious from `ls fixtures/`.
+
+## Exit codes
+
+| Script             | Exit | Meaning |
+|--------------------|------|---------|
+| `run-tests.sh`     | 0    | All tests passed |
+| `run-tests.sh`     | 1    | One or more tests failed |
+| `run-tests.sh`     | 77   | Required tool missing (skipped in CI) |
+| `verify-fixtures.sh` | 0  | All fixtures valid |
+| `verify-fixtures.sh` | 1  | Fixture malformed |
+| `verify-fixtures.sh` | 77 | `python3` missing (skipped) |
+
+77 is the autotools convention for "skip this test" and is interpreted as a
+skip by most CI frameworks.

--- a/plugins/protect-mcp/test/expected/receipt-schema.json
+++ b/plugins/protect-mcp/test/expected/receipt-schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://veritasacta.com/schemas/receipt-v1.json",
+  "title": "Veritas Acta Decision Receipt v1",
+  "description": "Expected shape of a protect-mcp-produced receipt. Mirrors draft-farley-acta-signed-receipts.",
+  "type": "object",
+  "required": [
+    "receipt_id",
+    "receipt_version",
+    "issuer_id",
+    "event_time",
+    "tool_name",
+    "decision",
+    "public_key",
+    "signature"
+  ],
+  "properties": {
+    "receipt_id":      { "type": "string", "pattern": "^rec_" },
+    "receipt_version": { "type": "string", "const": "1.0" },
+    "issuer_id":       { "type": "string" },
+    "event_time":      { "type": "string", "format": "date-time" },
+    "tool_name":       { "type": "string" },
+    "input_hash":      { "type": "string", "pattern": "^sha256:" },
+    "decision":        { "type": "string", "enum": ["allow", "deny"] },
+    "policy_id":       { "type": "string" },
+    "policy_digest":   { "type": "string", "pattern": "^sha256:" },
+    "parent_receipt_id": { "type": ["string", "null"] },
+    "public_key":      { "type": "string", "minLength": 32 },
+    "signature":       { "type": "string", "minLength": 32 }
+  },
+  "additionalProperties": true
+}

--- a/plugins/protect-mcp/test/fixtures/posttool-signing-input.json
+++ b/plugins/protect-mcp/test/fixtures/posttool-signing-input.json
@@ -1,0 +1,12 @@
+{
+  "tool_name": "Read",
+  "tool_input": {
+    "file_path": "./README.md"
+  },
+  "tool_output": {
+    "content": "# Example project\n\nTest fixture output."
+  },
+  "session_id": "test-session-sign",
+  "decision": "allow",
+  "policy_id": "protect-mcp-test-policy"
+}

--- a/plugins/protect-mcp/test/fixtures/pretool-allow-bash-safe.json
+++ b/plugins/protect-mcp/test/fixtures/pretool-allow-bash-safe.json
@@ -1,0 +1,10 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "git status"
+  },
+  "session_id": "test-session-allow-bash",
+  "context": {
+    "command_pattern": "git"
+  }
+}

--- a/plugins/protect-mcp/test/fixtures/pretool-allow-read.json
+++ b/plugins/protect-mcp/test/fixtures/pretool-allow-read.json
@@ -1,0 +1,10 @@
+{
+  "tool_name": "Read",
+  "tool_input": {
+    "file_path": "./README.md"
+  },
+  "session_id": "test-session-allow-read",
+  "context": {
+    "path_starts_with": "./"
+  }
+}

--- a/plugins/protect-mcp/test/fixtures/pretool-deny-bash-destructive.json
+++ b/plugins/protect-mcp/test/fixtures/pretool-deny-bash-destructive.json
@@ -1,0 +1,10 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "rm -rf /"
+  },
+  "session_id": "test-session-deny-destructive",
+  "context": {
+    "command_pattern": "rm -rf"
+  }
+}

--- a/plugins/protect-mcp/test/fixtures/pretool-deny-write.json
+++ b/plugins/protect-mcp/test/fixtures/pretool-deny-write.json
@@ -1,0 +1,11 @@
+{
+  "tool_name": "Write",
+  "tool_input": {
+    "file_path": "./secrets.env",
+    "content": "dummy"
+  },
+  "session_id": "test-session-deny-write",
+  "context": {
+    "path_starts_with": "./"
+  }
+}

--- a/plugins/protect-mcp/test/fixtures/test-policy.cedar
+++ b/plugins/protect-mcp/test/fixtures/test-policy.cedar
@@ -1,0 +1,37 @@
+// Test Cedar policy for protect-mcp hook round-trip tests.
+// Not a production example. See ../../agents/policy-enforcer.md for real-world policies.
+
+// Allow all read-oriented tools.
+permit (
+    principal,
+    action in [Action::"Read", Action::"Glob", Action::"Grep", Action::"WebSearch"],
+    resource
+);
+
+// Allow safe Bash commands only.
+permit (
+    principal,
+    action == Action::"Bash",
+    resource
+) when {
+    context.command_pattern in ["git", "npm", "ls", "cat", "echo", "pwd", "test", "node"]
+};
+
+// Explicit deny on destructive commands, even if permit would match elsewhere.
+// Cedar deny is authoritative.
+forbid (
+    principal,
+    action == Action::"Bash",
+    resource
+) when {
+    context.command_pattern in ["rm -rf", "dd", "mkfs", "shred", ":(){ :|:& };:"]
+};
+
+// Writes are denied unscoped. A real policy would permit writes when
+// context.path_starts_with is safe. The tests exercise the unscoped
+// form so we can verify deny is enforced.
+forbid (
+    principal,
+    action in [Action::"Write", Action::"Edit"],
+    resource
+);

--- a/plugins/protect-mcp/test/run-tests.sh
+++ b/plugins/protect-mcp/test/run-tests.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# run-tests.sh — exercise protect-mcp hooks against the fixtures in this directory.
+#
+# Requires: bash, node (>= 18), npx. Fetches protect-mcp and @veritasacta/verify
+# from the npm registry on first run, then caches them.
+#
+# Exit codes:
+#   0   all tests passed
+#   1   one or more tests failed
+#   77  required tools missing (treated as "skipped" by automake / CI)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# --- Preflight ---------------------------------------------------------------
+
+need() {
+    command -v "$1" >/dev/null 2>&1 || {
+        echo "SKIP: '$1' not found. Install Node.js 18+ (provides node and npx)."
+        exit 77
+    }
+}
+need node
+need npx
+need python3
+
+# Temp workspace for produced receipts. Cleaned at the end.
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+RECEIPTS_DIR="$WORKDIR/receipts"
+mkdir -p "$RECEIPTS_DIR"
+
+PASS=0
+FAIL=0
+
+if [ -t 1 ]; then
+    GREEN='\033[0;32m'; RED='\033[0;31m'; NC='\033[0m'
+else
+    GREEN=''; RED=''; NC=''
+fi
+
+pass() { echo -e "${GREEN}PASS${NC}: $1"; PASS=$((PASS+1)); }
+fail() { echo -e "${RED}FAIL${NC}: $1"; FAIL=$((FAIL+1)); }
+
+check_exit() {
+    local actual="$1" expected="$2" label="$3"
+    if [ "$actual" -eq "$expected" ]; then pass "$label"; else fail "$label (exit $actual, expected $expected)"; fi
+}
+
+extract() { python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get(sys.argv[2],''))" "$1" "$2"; }
+
+# --- Test 1: PreToolUse allows safe Read -------------------------------------
+echo ""
+echo "=== Test 1: PreToolUse permit on Read ==="
+INPUT=fixtures/pretool-allow-read.json
+npx --yes protect-mcp@latest evaluate \
+    --policy fixtures/test-policy.cedar \
+    --tool "$(extract "$INPUT" tool_name)" \
+    --input "$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1]))["tool_input"]))' "$INPUT")" \
+    --fail-on-missing-policy false >/dev/null 2>&1
+check_exit $? 0 "Read is permitted by test-policy.cedar"
+
+# --- Test 2: PreToolUse allows safe Bash -------------------------------------
+echo ""
+echo "=== Test 2: PreToolUse permit on Bash git ==="
+INPUT=fixtures/pretool-allow-bash-safe.json
+npx --yes protect-mcp@latest evaluate \
+    --policy fixtures/test-policy.cedar \
+    --tool "$(extract "$INPUT" tool_name)" \
+    --input "$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1]))["tool_input"]))' "$INPUT")" \
+    --fail-on-missing-policy false >/dev/null 2>&1
+check_exit $? 0 "Bash 'git status' is permitted"
+
+# --- Test 3: PreToolUse denies destructive Bash ------------------------------
+echo ""
+echo "=== Test 3: PreToolUse forbid on Bash rm -rf ==="
+INPUT=fixtures/pretool-deny-bash-destructive.json
+npx --yes protect-mcp@latest evaluate \
+    --policy fixtures/test-policy.cedar \
+    --tool "$(extract "$INPUT" tool_name)" \
+    --input "$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1]))["tool_input"]))' "$INPUT")" \
+    --fail-on-missing-policy false >/dev/null 2>&1
+check_exit $? 2 "Bash 'rm -rf /' is denied with exit 2"
+
+# --- Test 4: PreToolUse denies Write -----------------------------------------
+echo ""
+echo "=== Test 4: PreToolUse forbid on Write ==="
+INPUT=fixtures/pretool-deny-write.json
+npx --yes protect-mcp@latest evaluate \
+    --policy fixtures/test-policy.cedar \
+    --tool "$(extract "$INPUT" tool_name)" \
+    --input "$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1]))["tool_input"]))' "$INPUT")" \
+    --fail-on-missing-policy false >/dev/null 2>&1
+check_exit $? 2 "Write is denied with exit 2"
+
+# --- Test 5: PostToolUse produces a receipt ---------------------------------
+echo ""
+echo "=== Test 5: PostToolUse sign produces a receipt ==="
+KEY="$WORKDIR/test.key"
+npx --yes protect-mcp@latest keygen --out "$KEY" >/dev/null 2>&1 || \
+    echo "note: keygen subcommand not available; falling back to default key generation inside sign"
+
+INPUT=fixtures/posttool-signing-input.json
+TOOL_NAME="$(extract "$INPUT" tool_name)"
+TOOL_INPUT_JSON="$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1]))["tool_input"]))' "$INPUT")"
+TOOL_OUTPUT_JSON="$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1]))["tool_output"]))' "$INPUT")"
+
+SIGN_ARGS=(--tool "$TOOL_NAME" --input "$TOOL_INPUT_JSON" --output "$TOOL_OUTPUT_JSON" --receipts "$RECEIPTS_DIR/")
+[ -f "$KEY" ] && SIGN_ARGS+=(--key "$KEY")
+
+npx --yes protect-mcp@latest sign "${SIGN_ARGS[@]}" >/dev/null 2>&1
+SIGN_RC=$?
+RECEIPT_FILE="$(ls "$RECEIPTS_DIR"/*.json 2>/dev/null | head -n1 || true)"
+
+if [ "$SIGN_RC" -eq 0 ] && [ -n "$RECEIPT_FILE" ] && [ -f "$RECEIPT_FILE" ]; then
+    pass "Receipt produced at $(basename "$RECEIPT_FILE")"
+else
+    fail "Sign command did not produce a receipt (exit $SIGN_RC)"
+fi
+
+# --- Test 6: Receipt matches expected schema --------------------------------
+echo ""
+echo "=== Test 6: Receipt schema validation ==="
+if [ -n "$RECEIPT_FILE" ]; then
+    python3 - "$RECEIPT_FILE" expected/receipt-schema.json <<'PY'
+import json, sys
+r = json.load(open(sys.argv[1]))
+s = json.load(open(sys.argv[2]))
+missing = [f for f in s["required"] if f not in r]
+if missing:
+    print(f"missing required fields: {missing}"); sys.exit(1)
+if r.get("receipt_version") != "1.0":
+    print(f"wrong version: {r.get('receipt_version')}"); sys.exit(1)
+if r.get("decision") not in ("allow","deny"):
+    print(f"invalid decision: {r.get('decision')}"); sys.exit(1)
+sys.exit(0)
+PY
+    check_exit $? 0 "Receipt conforms to expected schema"
+else
+    fail "No receipt available to validate"
+fi
+
+# --- Test 7: @veritasacta/verify accepts the receipt ------------------------
+echo ""
+echo "=== Test 7: Offline verification with @veritasacta/verify ==="
+if [ -n "$RECEIPT_FILE" ]; then
+    npx --yes @veritasacta/verify "$RECEIPT_FILE" >/dev/null 2>&1
+    check_exit $? 0 "Valid receipt verifies with exit 0"
+else
+    fail "No receipt available to verify"
+fi
+
+# --- Test 8: Tampered receipt fails verification ----------------------------
+echo ""
+echo "=== Test 8: Tamper detection ==="
+if [ -n "$RECEIPT_FILE" ]; then
+    TAMPERED="$WORKDIR/tampered.json"
+    python3 -c '
+import json, sys
+r = json.load(open(sys.argv[1]))
+# Flip the decision (a signed field). Signature will no longer validate.
+r["decision"] = "deny" if r.get("decision") == "allow" else "allow"
+json.dump(r, open(sys.argv[2], "w"))
+' "$RECEIPT_FILE" "$TAMPERED"
+    npx --yes @veritasacta/verify "$TAMPERED" >/dev/null 2>&1
+    check_exit $? 1 "Tampered receipt rejected with exit 1"
+else
+    fail "No receipt available to tamper with"
+fi
+
+# --- Summary ----------------------------------------------------------------
+echo ""
+echo "─────────────────────────────────────────────"
+echo "  $PASS passed, $FAIL failed"
+echo "─────────────────────────────────────────────"
+[ "$FAIL" -eq 0 ]

--- a/plugins/protect-mcp/test/verify-fixtures.sh
+++ b/plugins/protect-mcp/test/verify-fixtures.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# verify-fixtures.sh — static validation of the test fixtures in this directory.
+#
+# Does not execute any protect-mcp command. Useful in CI where installing the
+# full Node toolchain is out of scope. Pairs with run-tests.sh for local dev.
+
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+command -v python3 >/dev/null 2>&1 || { echo "SKIP: python3 required"; exit 77; }
+
+PASS=0
+FAIL=0
+
+check() {
+    if [ "$1" -eq 0 ]; then echo "PASS: $2"; PASS=$((PASS+1)); else echo "FAIL: $2"; FAIL=$((FAIL+1)); fi
+}
+
+# Every JSON fixture parses as JSON
+for f in fixtures/*.json expected/*.json; do
+    python3 -c "import json; json.load(open('$f'))" 2>/dev/null
+    check $? "$f is valid JSON"
+done
+
+# Every pretool fixture has required fields
+for f in fixtures/pretool-*.json; do
+    python3 -c "
+import json, sys
+d = json.load(open('$f'))
+for k in ('tool_name', 'tool_input', 'session_id'):
+    assert k in d, f'missing {k}'
+" 2>/dev/null
+    check $? "$f has required pretool fields"
+done
+
+# Expected schema references a real JSON Schema draft
+python3 -c "
+import json
+s = json.load(open('expected/receipt-schema.json'))
+assert '\$schema' in s and 'json-schema.org' in s['\$schema']
+assert 'required' in s and len(s['required']) >= 6
+" 2>/dev/null
+check $? "expected/receipt-schema.json is well-formed"
+
+# Cedar policy file exists and is non-empty
+test -s fixtures/test-policy.cedar
+check $? "fixtures/test-policy.cedar is non-empty"
+
+echo ""
+echo "─────────────────────────────────────────────"
+echo "  $PASS passed, $FAIL failed"
+echo "─────────────────────────────────────────────"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Follow-up to #484 closing the test-plan commitment made in that PR. Adds a
`plugins/protect-mcp/test/` directory with deterministic fixtures that
exercise the full evaluate → sign → verify loop, including the tamper
detection path.

## What's inside

| File | Purpose |
|------|---------|
| `fixtures/test-policy.cedar` | Cedar policy exercising both `permit` and `forbid` semantics |
| `fixtures/pretool-allow-read.json` | Input that should be permitted |
| `fixtures/pretool-allow-bash-safe.json` | `git status` — permitted |
| `fixtures/pretool-deny-bash-destructive.json` | `rm -rf /` — denied |
| `fixtures/pretool-deny-write.json` | Unscoped `Write` — denied |
| `fixtures/posttool-signing-input.json` | Input for receipt signing |
| `expected/receipt-schema.json` | JSON Schema pinned to draft-farley-acta-signed-receipts required fields |
| `run-tests.sh` | Full round-trip (8 tests, requires node >= 18 + python3) |
| `verify-fixtures.sh` | Static validation, python3-only, safe for sandboxed CI |
| `README.md` | Layout, running instructions, extension guide |

## Test matrix (run-tests.sh)

| # | Scenario | Expected exit |
|---|----------|----------------|
| 1 | PreToolUse on `Read` | 0 (permit) |
| 2 | PreToolUse on `Bash git status` | 0 (permit) |
| 3 | PreToolUse on `Bash rm -rf /` | 2 (forbid) |
| 4 | PreToolUse on `Write` | 2 (forbid) |
| 5 | PostToolUse signing produces a receipt file | 0 |
| 6 | Produced receipt conforms to the schema | 0 |
| 7 | `@veritasacta/verify` accepts the receipt | 0 |
| 8 | Tampered receipt is rejected | 1 |

**Test 8 is the critical regression guard.** Flipping the `decision` field
in a signed receipt must invalidate the Ed25519 signature, so
`@veritasacta/verify` must exit 1 rather than 0. This locks in the tamper
detection property that the plugin claims.

## Why two scripts

`run-tests.sh` needs `npx` and fetches `protect-mcp` + `@veritasacta/verify`
from the npm registry on first run. That is fine for local dev and well-
provisioned CI, but not always available in sandboxed checks.

`verify-fixtures.sh` is `python3`-only and purely local: validates JSON shape,
required fields, and cedar non-emptiness. It is the safe static gate that can
run anywhere. Both scripts use exit code 77 for "required tool missing," the
autotools convention that most CI frameworks interpret as "skipped."

## What I verified

- `bash plugins/protect-mcp/test/verify-fixtures.sh` passes locally (12/12)
- `run-tests.sh` structure mirrors what the existing hook commands accept
  (same `--policy`, `--tool`, `--input`, `--output`, `--receipts`, `--key`
  flags as `hooks/hooks.json`)
- Every fixture is valid JSON against Python's `json.load`
- `expected/receipt-schema.json` is valid JSON Schema draft-07 and requires
  all fields emitted by `protect-mcp@latest sign`

## Notes

- No changes to the plugin itself, no changes to `marketplace.json` or
  `hooks.json`, no new runtime dependencies
- Scripts are marked executable (`chmod +x`)
- The Cedar policy in `fixtures/` is narrower than the production example
  in `skills/protect-mcp-setup/SKILL.md`; it is optimized for test
  determinism rather than real-world coverage

Closes the `test plan` checklist from #484. Happy to iterate on scope or
rename/restructure to match any existing test conventions in the marketplace.