### PR TITLE
chore(protect-mcp): pin protect-mcp@0.5.5 and @veritasacta/verify@0.3.0

### DIFF
--- a/plugins/protect-mcp/hooks/hooks.json
+++ b/plugins/protect-mcp/hooks/hooks.json
@@ -5,7 +5,7 @@
         "matcher": ".*",
         "hook": {
           "type": "command",
-          "command": "npx protect-mcp@latest evaluate --policy \"${PROTECT_MCP_POLICY:-./protect.cedar}\" --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --fail-on-missing-policy false"
+          "command": "npx protect-mcp@0.5.5 evaluate --policy \"${PROTECT_MCP_POLICY:-./protect.cedar}\" --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --fail-on-missing-policy false"
         }
       }
     ],
@@ -14,7 +14,7 @@
         "matcher": ".*",
         "hook": {
           "type": "command",
-          "command": "npx protect-mcp@latest sign --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --output \"$TOOL_OUTPUT\" --receipts \"${PROTECT_MCP_RECEIPTS:-./receipts/}\" --key \"${PROTECT_MCP_KEY:-./protect-mcp.key}\""
+          "command": "npx protect-mcp@0.5.5 sign --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --output \"$TOOL_OUTPUT\" --receipts \"${PROTECT_MCP_RECEIPTS:-./receipts/}\" --key \"${PROTECT_MCP_KEY:-./protect-mcp.key}\""
         }
       }
     ]

--- a/plugins/protect-mcp/test/run-tests.sh
+++ b/plugins/protect-mcp/test/run-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # run-tests.sh — exercise protect-mcp hooks against the fixtures in this directory.
 #
-# Requires: bash, node (>= 18), npx. Fetches protect-mcp and @veritasacta/verify
+# Requires: bash, node (>= 18), npx. Fetches protect-mcp and @veritasacta/verify@0.3.0
 # from the npm registry on first run, then caches them.
 #
 # Exit codes:
@@ -55,7 +55,7 @@ extract() { python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d
 echo ""
 echo "=== Test 1: PreToolUse permit on Read ==="
 INPUT=fixtures/pretool-allow-read.json
-npx --yes protect-mcp@latest evaluate \
+npx --yes protect-mcp@0.5.5 evaluate \
     --policy fixtures/test-policy.cedar \
     --tool "$(extract "$INPUT" tool_name)" \
     --input "$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1]))["tool_input"]))' "$INPUT")" \
@@ -66,7 +66,7 @@ check_exit $? 0 "Read is permitted by test-policy.cedar"
 echo ""
 echo "=== Test 2: PreToolUse permit on Bash git ==="
 INPUT=fixtures/pretool-allow-bash-safe.json
-npx --yes protect-mcp@latest evaluate \
+npx --yes protect-mcp@0.5.5 evaluate \
     --policy fixtures/test-policy.cedar \
     --tool "$(extract "$INPUT" tool_name)" \
     --input "$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1]))["tool_input"]))' "$INPUT")" \
@@ -77,7 +77,7 @@ check_exit $? 0 "Bash 'git status' is permitted"
 echo ""
 echo "=== Test 3: PreToolUse forbid on Bash rm -rf ==="
 INPUT=fixtures/pretool-deny-bash-destructive.json
-npx --yes protect-mcp@latest evaluate \
+npx --yes protect-mcp@0.5.5 evaluate \
     --policy fixtures/test-policy.cedar \
     --tool "$(extract "$INPUT" tool_name)" \
     --input "$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1]))["tool_input"]))' "$INPUT")" \
@@ -88,7 +88,7 @@ check_exit $? 2 "Bash 'rm -rf /' is denied with exit 2"
 echo ""
 echo "=== Test 4: PreToolUse forbid on Write ==="
 INPUT=fixtures/pretool-deny-write.json
-npx --yes protect-mcp@latest evaluate \
+npx --yes protect-mcp@0.5.5 evaluate \
     --policy fixtures/test-policy.cedar \
     --tool "$(extract "$INPUT" tool_name)" \
     --input "$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1]))["tool_input"]))' "$INPUT")" \
@@ -99,7 +99,7 @@ check_exit $? 2 "Write is denied with exit 2"
 echo ""
 echo "=== Test 5: PostToolUse sign produces a receipt ==="
 KEY="$WORKDIR/test.key"
-npx --yes protect-mcp@latest keygen --out "$KEY" >/dev/null 2>&1 || \
+npx --yes protect-mcp@0.5.5 keygen --out "$KEY" >/dev/null 2>&1 || \
     echo "note: keygen subcommand not available; falling back to default key generation inside sign"
 
 INPUT=fixtures/posttool-signing-input.json
@@ -110,7 +110,7 @@ TOOL_OUTPUT_JSON="$(python3 -c 'import json,sys; print(json.dumps(json.load(open
 SIGN_ARGS=(--tool "$TOOL_NAME" --input "$TOOL_INPUT_JSON" --output "$TOOL_OUTPUT_JSON" --receipts "$RECEIPTS_DIR/")
 [ -f "$KEY" ] && SIGN_ARGS+=(--key "$KEY")
 
-npx --yes protect-mcp@latest sign "${SIGN_ARGS[@]}" >/dev/null 2>&1
+npx --yes protect-mcp@0.5.5 sign "${SIGN_ARGS[@]}" >/dev/null 2>&1
 SIGN_RC=$?
 RECEIPT_FILE="$(ls "$RECEIPTS_DIR"/*.json 2>/dev/null | head -n1 || true)"
 
@@ -146,7 +146,7 @@ fi
 echo ""
 echo "=== Test 7: Offline verification with @veritasacta/verify ==="
 if [ -n "$RECEIPT_FILE" ]; then
-    npx --yes @veritasacta/verify "$RECEIPT_FILE" >/dev/null 2>&1
+    npx --yes @veritasacta/verify@0.3.0 "$RECEIPT_FILE" >/dev/null 2>&1
     check_exit $? 0 "Valid receipt verifies with exit 0"
 else
     fail "No receipt available to verify"
@@ -164,7 +164,7 @@ r = json.load(open(sys.argv[1]))
 r["decision"] = "deny" if r.get("decision") == "allow" else "allow"
 json.dump(r, open(sys.argv[2], "w"))
 ' "$RECEIPT_FILE" "$TAMPERED"
-    npx --yes @veritasacta/verify "$TAMPERED" >/dev/null 2>&1
+    npx --yes @veritasacta/verify@0.3.0 "$TAMPERED" >/dev/null 2>&1
     check_exit $? 1 "Tampered receipt rejected with exit 1"
 else
     fail "No receipt available to tamper with"


### PR DESCRIPTION
Follow-up to the pinning suggestion @wshobson raised on #494. Replaces every `npx protect-mcp@latest` in executed paths with `npx protect-mcp@0.5.5`, and every `npx @veritasacta/verify` in the test runner with `npx @veritasacta/verify@0.3.0`. The tamper-detection test can no longer be silently flipped by an upstream npm publish.

## What this changes

| File | Pins applied |
|------|--------------|
| `plugins/protect-mcp/hooks/hooks.json` | 2 × `protect-mcp@latest` → `protect-mcp@0.5.5` (PreToolUse + PostToolUse) |
| `plugins/protect-mcp/test/run-tests.sh` | 6 × `protect-mcp@latest` → `protect-mcp@0.5.5`, 3 × `@veritasacta/verify` → `@veritasacta/verify@0.3.0` |

Header comment at the top of `run-tests.sh` updated to mention the pinned `@veritasacta/verify` version so the dependency is visible without reading the full script.

## What this deliberately does NOT change

- **`README.md`** and **`skills/protect-mcp-setup/SKILL.md`** — the `npx protect-mcp@latest` references there are documentation of the pattern a user should use in their own project, and "latest" is genuinely the right advice for a downstream consumer. The test infrastructure is the only executed path where pinning affects reproducibility.
- **`marketplace.json`** — not touched at all, so no conflict with #495 or #496.
- **`review-agent-governance`** and **`signed-audit-trails`** plugins — still in review. I will file a follow-up to pin those once they land.

## How bumps work

When `protect-mcp` ships a new version with a breaking change, the bump is a two-file sed:

```bash
perl -i -pe 's/protect-mcp\@0\.5\.5/protect-mcp\@0.6.0/g' \
  plugins/protect-mcp/hooks/hooks.json \
  plugins/protect-mcp/test/run-tests.sh
./plugins/protect-mcp/test/run-tests.sh   # confirm tamper test still passes
```

Deliberate bumps from here on, not automatic.

## Verification

- [x] `python3 -m json.tool hooks.json` passes
- [x] `bash -n run-tests.sh` passes syntax check
- [x] No other files touched; clean 2-file diff
- [x] `npm view protect-mcp version` confirmed 0.5.5 is current stable
- [x] `npm view @veritasacta/verify version` confirmed 0.3.0 is current stable

## Why this closes the loop from #494

On #494 you said: *"run-tests.sh uses `npx protect-mcp@latest`, so an upstream release could silently turn the tamper-detection guard green or red without any repo change. Pinning to a specific `protect-mcp@x.y.z` (and bumping deliberately) would make the guard fully reproducible. Not blocking — happy to land as-is."*

This is exactly that pin. The tamper-detection guard is now reproducible at `protect-mcp@0.5.5` + `@veritasacta/verify@0.3.0`, and future changes to those packages require a deliberate bump here.

## Out of scope (follow-ups after this and #495/#496)

- Pin the same versions in `review-agent-governance` and `signed-audit-trails` once they land.
- Add a note to the README pointing at this commit as the "how to update pinned versions" reference.

Thanks for the suggestion; small but real tightening of the test contract.