### PR TITLE
meigen-ai-design: bump to 1.0.2 (meigen@1.2.9)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -963,7 +963,7 @@
       "name": "meigen-ai-design",
       "source": "./plugins/meigen-ai-design",
       "description": "AI image generation with creative workflow orchestration, prompt engineering, and curated inspiration library via MCP server",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "author": {
         "name": "MeiGen",
         "url": "https://github.com/jau123"

--- a/plugins/meigen-ai-design/.claude-plugin/plugin.json
+++ b/plugins/meigen-ai-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "meigen-ai-design",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "AI image generation with creative workflow orchestration, parallel multi-direction output, prompt engineering, and a 1,300+ curated inspiration library. Requires MeiGen MCP server (supports MeiGen Cloud, local ComfyUI, and OpenAI-compatible APIs).",
   "author": {
     "name": "MeiGen",

--- a/plugins/meigen-ai-design/README.md
+++ b/plugins/meigen-ai-design/README.md
@@ -11,7 +11,7 @@ This plugin requires the **meigen** MCP server. Install it by adding to your pro
   "mcpServers": {
     "meigen": {
       "command": "npx",
-      "args": ["-y", "meigen@1.2.8"]
+      "args": ["-y", "meigen@1.2.9"]
     }
   }
 }


### PR DESCRIPTION
## Summary

Syncs the `meigen-ai-design` plugin with the upstream MeiGen MCP server release **v1.2.9**.

- Bump pinned MCP server: `meigen@1.2.8` → `meigen@1.2.9`
- Bump plugin version and marketplace entry: `1.0.1` → `1.0.2`

## What changed upstream

From [MeiGen MCP v1.2.9](https://github.com/jau123/MeiGen-AI-Design-MCP/releases/tag/v1.2.9):

- **Default cloud model switched** from Nanobanana 2 (5 credits) to **GPT Image 2.0** (10 credits) — significantly better text rendering for posters, logos, and typography-heavy imagery. Users who prefer the previous default can still pass `model: "nanobanana-2"` explicitly to `generate_image`.
- **Retired GPT Image 1.5** from the MeiGen model catalog.
- Cleaned up OpenAI-compatible provider documentation — generic "your model ID" wording, removed stale `dall-e-3` / `flux-schnell` examples that didn't reflect reality.

## What did not change

No changes to:
- Agents (`gallery-researcher`, `prompt-crafter`, `image-generator`)
- Commands (`/meigen-ai-design:gen`, `/meigen-ai-design:find`)
- Required environment variables or setup steps
- Plugin structure or dependencies

This is purely a version pin bump plus the implicit default-model behavior change that flows through the pinned MCP server.

## Test plan

- [x] `meigen@1.2.9` verified on npm: https://www.npmjs.com/package/meigen/v/1.2.9
- [x] Plugin installs cleanly via `/plugin install meigen-ai-design@claude-code-workflows`
- [x] `generate_image` without a `model` argument now routes to GPT Image 2.0

---

Thanks for maintaining this marketplace — happy to adjust the PR if you'd like different messaging or scope.