### PR TITLE
fix(protect-mcp): use current hook schema (hooks array)  

### DIFF
--- a/plugins/protect-mcp/hooks/hooks.json
+++ b/plugins/protect-mcp/hooks/hooks.json
@@ -3,19 +3,23 @@
     "PreToolUse": [
       {
         "matcher": ".*",
-        "hook": {
-          "type": "command",
-          "command": "npx protect-mcp@0.5.5 evaluate --policy \"${PROTECT_MCP_POLICY:-./protect.cedar}\" --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --fail-on-missing-policy false"
-        }
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx protect-mcp@0.5.5 evaluate --policy \"${PROTECT_MCP_POLICY:-./protect.cedar}\" --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --fail-on-missing-policy false"
+          }
+        ]
       }
     ],
     "PostToolUse": [
       {
         "matcher": ".*",
-        "hook": {
-          "type": "command",
-          "command": "npx protect-mcp@0.5.5 sign --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --output \"$TOOL_OUTPUT\" --receipts \"${PROTECT_MCP_RECEIPTS:-./receipts/}\" --key \"${PROTECT_MCP_KEY:-./protect-mcp.key}\""
-        }
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx protect-mcp@0.5.5 sign --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --output \"$TOOL_OUTPUT\" --receipts \"${PROTECT_MCP_RECEIPTS:-./receipts/}\" --key \"${PROTECT_MCP_KEY:-./protect-mcp.key}\""
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
The protect-mcp hooks.json uses an outdated schema with `"hook": {...}` (singular object).                                                                                        Current Claude Code expects `"hooks": [...]` (array of hook objects) inside each matcher.                                                                                         
                                                                                                                                                                                    
 On load, Claude Code reports:                                                                                                                                                     
    protect-mcp@claude-code-workflows [protect-mcp]: Hook load failed:                                                                                                              
    path: hooks.PreToolUse.0.hooks — expected array, received undefined                                                                                                             
    path: hooks.PostToolUse.0.hooks — expected array, received undefined   

This PR renames `hook` → `hooks` and wraps each command object in an array,                                                                                                       
 matching the schema used by other plugins in this marketplace (e.g. block-no-verify).                                                                                                         
                                                                                                                                                                                    