### PR TITLE
meigen-ai-design: bump to 1.0.2 (meigen@1.2.10)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -963,7 +963,7 @@
       "name": "meigen-ai-design",
       "source": "./plugins/meigen-ai-design",
       "description": "AI image generation with creative workflow orchestration, prompt engineering, and curated inspiration library via MCP server",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "author": {
         "name": "MeiGen",
         "url": "https://github.com/jau123"

--- a/plugins/meigen-ai-design/.claude-plugin/plugin.json
+++ b/plugins/meigen-ai-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "meigen-ai-design",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "AI image generation with creative workflow orchestration, parallel multi-direction output, prompt engineering, and a 1,300+ curated inspiration library. Requires MeiGen MCP server (supports MeiGen Cloud, local ComfyUI, and OpenAI-compatible APIs).",
   "author": {
     "name": "MeiGen",

--- a/plugins/meigen-ai-design/README.md
+++ b/plugins/meigen-ai-design/README.md
@@ -11,7 +11,7 @@ This plugin requires the **meigen** MCP server. Install it by adding to your pro
   "mcpServers": {
     "meigen": {
       "command": "npx",
-      "args": ["-y", "meigen@1.2.8"]
+      "args": ["-y", "meigen@1.2.10"]
     }
   }
 }


### PR DESCRIPTION
## Summary

Syncs the `meigen-ai-design` plugin with upstream MeiGen MCP **v1.2.10** — a pricing hotfix over 1.2.9.

- Bump pinned MCP server: `meigen@1.2.8` → `meigen@1.2.10`
- Bump plugin version and marketplace entry: `1.0.1` → `1.0.2`

(This PR supersedes #502, which I closed. That PR pinned `meigen@1.2.9`, which has since been deprecated on npm due to a pricing regression — details below. Apologies for the churn.)

## What changed upstream

From [MeiGen MCP v1.2.10](https://github.com/jau123/MeiGen-AI-Design-MCP/releases/tag/v1.2.10):

### The pricing fix
`meigen@1.2.9` introduced GPT Image 2.0 as the new default model but left the server-side `resolution` fallback at 2K, silently doubling credit cost for users who did not pass `resolution` explicitly. `meigen@1.2.10` sets `gpt-image-2*` to default to **1K / medium = 10 credits**, matching the MeiGen platform product default. `1.2.9` has been deprecated on npm.

### New parameters exposed via `generate_image`
- `resolution`: `"1K"` (default) / `"2K"` / `"4K"` — opt-in upgrade for posters, prints, wallpapers
- `quality`: `"low"` (≈ 2 credits @ 1K) / `"medium"` (default) — opt-in cost saving for drafts / thumbnails

Pricing matrix for gpt-image-2: 1K/low ≈ 2, 1K/medium = 10, 2K/medium ≈ 25, 4K/medium ≈ 40 credits.

### Host LLM guidance
`SERVER_INSTRUCTIONS` gains a "GPT Image 2.0 resolution / quality" section in Phase 2, telling the host LLM to stay on 1K unless the use case (poster / print / large wallpaper) justifies the higher tier — avoids silent over-spending on casual chat imagery.

### Better model discovery
`list_models` now surfaces each model's supported `resolutions` and `quality` tiers (when the MeiGen API reports them), with a graceful fallback to `4K: Yes/No` for legacy models.

## What did not change

No changes to:
- Agents (`gallery-researcher`, `prompt-crafter`, `image-generator`)
- Commands (`/meigen-ai-design:gen`, `/meigen-ai-design:find`)
- Required environment variables or setup steps

Purely a pinned-MCP version bump plus the implicit default-resolution fix that flows through the pinned MCP server.

## Test plan

- [x] `meigen@1.2.10` verified on npm: https://www.npmjs.com/package/meigen/v/1.2.10
- [x] `meigen@1.2.9` deprecated on npm (install emits upgrade warning)
- [x] Plugin installs cleanly via `/plugin install meigen-ai-design@claude-code-workflows`
- [x] `generate_image` without a `resolution` argument now routes to 1K (10 credits)

---

Thanks again for maintaining this marketplace — happy to adjust the PR messaging or scope.