### PR TITLE
meigen-ai-design: bump to 1.0.3, pin npm to meigen@1.2.11

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -963,7 +963,7 @@
       "name": "meigen-ai-design",
       "source": "./plugins/meigen-ai-design",
       "description": "AI image generation with creative workflow orchestration, prompt engineering, and curated inspiration library via MCP server",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "author": {
         "name": "MeiGen",
         "url": "https://github.com/jau123"

--- a/plugins/meigen-ai-design/.claude-plugin/plugin.json
+++ b/plugins/meigen-ai-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "meigen-ai-design",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "AI image generation with creative workflow orchestration, parallel multi-direction output, prompt engineering, and a 1,300+ curated inspiration library. Requires MeiGen MCP server (supports MeiGen Cloud, local ComfyUI, and OpenAI-compatible APIs).",
   "author": {
     "name": "MeiGen",

--- a/plugins/meigen-ai-design/README.md
+++ b/plugins/meigen-ai-design/README.md
@@ -11,7 +11,7 @@ This plugin requires the **meigen** MCP server. Install it by adding to your pro
   "mcpServers": {
     "meigen": {
       "command": "npx",
-      "args": ["-y", "meigen@1.2.10"]
+      "args": ["-y", "meigen@1.2.11"]
     }
   }
 }


### PR DESCRIPTION
Updates the pinned npm version from `meigen@1.2.10` to `meigen@1.2.11`.

## What changed

The new `meigen` 1.2.11 release removes all hardcoded credit pricing from the MCP server. Credit prices change over time, so shipping stale numbers in npm packages misleads users more than it helps. The server's `list_models` output, error messages, and SERVER_INSTRUCTIONS now point to https://www.meigen.ai/model-comparison as the source of truth for pricing.

## Files changed

- `plugins/meigen-ai-design/.claude-plugin/plugin.json`: 1.0.2 → 1.0.3
- `plugins/meigen-ai-design/README.md`: `meigen@1.2.10` → `meigen@1.2.11`
- `.claude-plugin/marketplace.json`: meigen-ai-design entry version 1.0.2 → 1.0.3

## Verification

- npm: https://www.npmjs.com/package/meigen/v/1.2.11
- Source: https://github.com/jau123/MeiGen-AI-Design-MCP/releases (commit `ba9e97e`)
- No code changes in agents/commands/skills — purely a metadata + pinned-version bump.