### PR TITLE
meigen-ai-design: bump to 1.0.4, pin npm to meigen@1.2.12

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -963,7 +963,7 @@
       "name": "meigen-ai-design",
       "source": "./plugins/meigen-ai-design",
       "description": "AI image generation with creative workflow orchestration, prompt engineering, and curated inspiration library via MCP server",
-      "version": "1.0.2",
+      "version": "1.0.4",
       "author": {
         "name": "MeiGen",
         "url": "https://github.com/jau123"

--- a/plugins/meigen-ai-design/.claude-plugin/plugin.json
+++ b/plugins/meigen-ai-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "meigen-ai-design",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "AI image generation with creative workflow orchestration, parallel multi-direction output, prompt engineering, and a 1,300+ curated inspiration library. Requires MeiGen MCP server (supports MeiGen Cloud, local ComfyUI, and OpenAI-compatible APIs).",
   "author": {
     "name": "MeiGen",

--- a/plugins/meigen-ai-design/README.md
+++ b/plugins/meigen-ai-design/README.md
@@ -11,7 +11,7 @@ This plugin requires the **meigen** MCP server. Install it by adding to your pro
   "mcpServers": {
     "meigen": {
       "command": "npx",
-      "args": ["-y", "meigen@1.2.10"]
+      "args": ["-y", "meigen@1.2.12"]
     }
   }
 }


### PR DESCRIPTION
Updates the pinned npm version from `meigen@1.2.10` (currently in main) to `meigen@1.2.12`.

## What changed in meigen 1.2.11 → 1.2.12

- **Curated prompt gallery refresh**: 1309 → 1446 entries with restructured categories (Photography, Illustration & 3D, Product & Brand, Food & Drink, Poster Design, UI & Graphic). Retired App/Girl/JSON/Other.
- **quality/resolution docs**: defer to `list_models` for the authoritative per-model list. Schema accepts `high` for OpenAI-compatible providers and gpt-image models that support it.
- **SERVER_INSTRUCTIONS**: stop asserting `1K/medium` as a hard fact — the MeiGen backend is now the source of truth for per-model defaults, so the host LLM no longer makes promises that may be overridden.
- **Insufficient-credits error**: now points users to the plans/top-up page rather than just "purchase credits".

## Files changed

- `plugins/meigen-ai-design/.claude-plugin/plugin.json`: 1.0.2 → 1.0.4
- `plugins/meigen-ai-design/README.md`: `meigen@1.2.10` → `meigen@1.2.12`
- `.claude-plugin/marketplace.json`: meigen-ai-design entry version 1.0.2 → 1.0.4

## Note on PR #507

This PR supersedes #507 (which proposed bumping to 1.2.11). Same set of files, just one more npm version newer. Closing #507 in favor of this one keeps the history clean.