### PR TITLE
meigen-ai-design: bump to 1.0.5, pin npm to meigen@1.2.13

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -963,7 +963,7 @@
       "name": "meigen-ai-design",
       "source": "./plugins/meigen-ai-design",
       "description": "AI image generation with creative workflow orchestration, prompt engineering, and curated inspiration library via MCP server",
-      "version": "1.0.2",
+      "version": "1.0.5",
       "author": {
         "name": "MeiGen",
         "url": "https://github.com/jau123"

--- a/plugins/meigen-ai-design/.claude-plugin/plugin.json
+++ b/plugins/meigen-ai-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "meigen-ai-design",
-  "version": "1.0.2",
+  "version": "1.0.5",
   "description": "AI image generation with creative workflow orchestration, parallel multi-direction output, prompt engineering, and a 1,300+ curated inspiration library. Requires MeiGen MCP server (supports MeiGen Cloud, local ComfyUI, and OpenAI-compatible APIs).",
   "author": {
     "name": "MeiGen",

--- a/plugins/meigen-ai-design/README.md
+++ b/plugins/meigen-ai-design/README.md
@@ -11,7 +11,7 @@ This plugin requires the **meigen** MCP server. Install it by adding to your pro
   "mcpServers": {
     "meigen": {
       "command": "npx",
-      "args": ["-y", "meigen@1.2.10"]
+      "args": ["-y", "meigen@1.2.13"]
     }
   }
 }


### PR DESCRIPTION
Supersedes #508 (please close).

Bumps the pinned npm package version to `meigen@1.2.13`, which adds support for the `MEIGEN_OUTPUT_DIR` env var so users can override the default `~/Pictures/meigen` save path (helpful for sandboxed hosts). No behavior changes for existing users — default path is unchanged.

Changes:
- `plugins/meigen-ai-design/.claude-plugin/plugin.json`: version 1.0.2 → 1.0.5
- `.claude-plugin/marketplace.json`: version 1.0.2 → 1.0.5
- `plugins/meigen-ai-design/README.md`: pinned `meigen@1.2.10` → `meigen@1.2.13`

[npm release notes](https://www.npmjs.com/package/meigen/v/1.2.13) · [GitHub issue #5](https://github.com/jau123/MeiGen-AI-Design-MCP/issues/5)