### PR TITLE
docs(security-scanning): remove links to unwritten SAST reference files

### DIFF
--- a/plugins/security-scanning/skills/sast-configuration/SKILL.md
+++ b/plugins/security-scanning/skills/sast-configuration/SKILL.md
@@ -67,18 +67,6 @@ gh extension install github/gh-codeql
 codeql database create mydb --language=python
 ```
 
-## Reference Documentation
-
-- [Semgrep Rule Creation](references/semgrep-rules.md) - Pattern-based security rule development
-- [SonarQube Configuration](references/sonarqube-config.md) - Quality gates and profiles
-- [CodeQL Setup Guide](references/codeql-setup.md) - Query development and workflows
-
-## Templates & Assets
-
-- [semgrep-config.yml](assets/semgrep-config.yml) - Production-ready Semgrep configuration
-- [sonarqube-settings.xml](assets/sonarqube-settings.xml) - SonarQube quality profile template
-- [run-sast.sh](scripts/run-sast.sh) - Automated SAST execution script
-
 ## Integration Patterns
 
 ### CI/CD Pipeline Integration


### PR DESCRIPTION
## Summary

`plugins/security-scanning/skills/sast-configuration/SKILL.md` linked to six files that don't exist:

- `references/semgrep-rules.md`
- `references/sonarqube-config.md`
- `references/codeql-setup.md`
- `assets/semgrep-config.yml`
- `assets/sonarqube-settings.xml`
- `scripts/run-sast.sh`

The directories were created but never populated. Removed the *Reference Documentation* and *Templates & Assets* sections so users no longer hit 404s. The inline configuration examples that remain in the skill body cover the immediate setup needs for Semgrep, SonarQube, and CodeQL.

The original report (#514) only flagged the three `references/` links; the three `assets/`/`scripts/` links in the adjacent section had the same problem and are removed in the same PR.

A repo-wide sweep of all 153 `SKILL.md` files confirms no other dead `references/`, `assets/`, or `scripts/` links remain. The two matches in `plugins/plugin-eval/skills/evaluation-methodology/SKILL.md` are illustrative example text inside a "what a dead link looks like" anti-pattern callout, not real links.

Fixes #514.

## Test plan

- [x] `grep -nE "\(references/|\(assets/|\(scripts/" plugins/security-scanning/skills/sast-configuration/SKILL.md` returns nothing
- [x] Repo-wide dead-link sweep shows only the documented illustrative examples remain