### PR TITLE
meigen-ai-design: bump to 1.0.6, pin npm to meigen@1.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -963,7 +963,7 @@
       "name": "meigen-ai-design",
       "source": "./plugins/meigen-ai-design",
       "description": "AI image generation with creative workflow orchestration, prompt engineering, and curated inspiration library via MCP server",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "author": {
         "name": "MeiGen",
         "url": "https://github.com/jau123"

--- a/plugins/meigen-ai-design/.claude-plugin/plugin.json
+++ b/plugins/meigen-ai-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "meigen-ai-design",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "AI image generation with creative workflow orchestration, parallel multi-direction output, prompt engineering, and a 1,300+ curated inspiration library. Requires MeiGen MCP server (supports MeiGen Cloud, local ComfyUI, and OpenAI-compatible APIs).",
   "author": {
     "name": "MeiGen",

--- a/plugins/meigen-ai-design/README.md
+++ b/plugins/meigen-ai-design/README.md
@@ -11,7 +11,7 @@ This plugin requires the **meigen** MCP server. Install it by adding to your pro
   "mcpServers": {
     "meigen": {
       "command": "npx",
-      "args": ["-y", "meigen@1.2.13"]
+      "args": ["-y", "meigen@1.3.0"]
     }
   }
 }


### PR DESCRIPTION
## Summary

Bumps `meigen-ai-design` to **1.0.6** and pins the npm package to **meigen@1.3.0**.

## 1.3.0 highlights

- **`generate_video`** MCP tool — Seedance 2.0 (fast/pro), Happyhorse 1.0, Veo 3.1. Text-to-video + first/last frame image-to-video.
- **Standalone CLI** — `npx meigen gen --prompt "..."` works without an MCP host.
- **`/meigen:setup`** is now a real slash command (was broken before).
- **Multi-host support** — Cursor, Codex CLI, Windsurf, Roo Code, Hermes Agent integration docs.
- **SSRF defense-in-depth** for `referenceImages` URLs (file://, private IPs, cloud metadata blocked).
- **Linux XDG paths** + Windows shell compat in the setup wizard.
- **Midjourney V8.1 unified** replaces V7 + Niji 7 in user-facing docs.

Full release notes: https://github.com/jau123/MeiGen-AI-Design-MCP/releases/tag/v1.3.0

## Files changed

- `plugins/meigen-ai-design/.claude-plugin/plugin.json` — version 1.0.5 → 1.0.6
- `plugins/meigen-ai-design/README.md` — pinned npx version meigen@1.2.13 → meigen@1.3.0
- `.claude-plugin/marketplace.json` — meigen-ai-design entry version 1.0.5 → 1.0.6

No description / structure changes.