### PR TITLE
Add Mutagent: prompt eval & optimization skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1082,6 +1082,21 @@
       "license": "MIT",
       "category": "workflows",
       "keywords": ["pipeline", "automation", "orchestration", "code-review", "qa", "playwright", "multi-agent", "dev-workflow"]
+    },
+    {
+      "name": "mutagent",
+      "source": "./plugins/mutagent",
+      "description": "Eval-driven prompt and agent optimization for AI engineers — capture traces, curate datasets, score against rubrics, and optimize prompts against measurable targets. Native tracing adapters for Mastra, LangChain, LangGraph, and Vercel AI SDK. Backed by the open-source @mutagent/cli (MIT).",
+      "version": "0.1.185",
+      "author": {
+        "name": "Mutagent",
+        "email": "bcyb@mutagent.io",
+        "url": "https://github.com/mutagent-io"
+      },
+      "homepage": "https://github.com/mutagent-io/skills",
+      "license": "MIT",
+      "category": "ai-ml",
+      "keywords": ["mutagent", "prompt-optimization", "evaluation", "evals", "tracing", "observability", "agent-engineering", "rubric-scoring"]
     }
   ]
 }

--- a/plugins/mutagent/.claude-plugin/plugin.json
+++ b/plugins/mutagent/.claude-plugin/plugin.json
@@ -1,23 +1,3 @@
 {
-  "name": "mutagent",
-  "version": "0.1.185",
-  "description": "Eval-driven prompt and agent optimization for AI engineers — capture traces, curate datasets, score against rubrics, and optimize prompts against measurable targets. Native tracing adapters for Mastra, LangChain, LangGraph, and Vercel AI SDK.",
-  "author": {
-    "name": "Mutagent",
-    "email": "bcyb@mutagent.io",
-    "url": "https://github.com/mutagent-io"
-  },
-  "homepage": "https://github.com/mutagent-io/skills",
-  "repository": "https://github.com/mutagent-io/skills.git",
-  "license": "MIT",
-  "keywords": [
-    "mutagent",
-    "prompt-optimization",
-    "evaluation",
-    "evals",
-    "tracing",
-    "observability",
-    "agent-engineering",
-    "rubric-scoring"
-  ]
+  "name": "mutagent"
 }

--- a/plugins/mutagent/.claude-plugin/plugin.json
+++ b/plugins/mutagent/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "mutagent",
+  "version": "0.1.185",
+  "description": "Eval-driven prompt and agent optimization for AI engineers — capture traces, curate datasets, score against rubrics, and optimize prompts against measurable targets. Native tracing adapters for Mastra, LangChain, LangGraph, and Vercel AI SDK.",
+  "author": {
+    "name": "Mutagent",
+    "email": "bcyb@mutagent.io",
+    "url": "https://github.com/mutagent-io"
+  },
+  "homepage": "https://github.com/mutagent-io/skills",
+  "repository": "https://github.com/mutagent-io/skills.git",
+  "license": "MIT",
+  "keywords": [
+    "mutagent",
+    "prompt-optimization",
+    "evaluation",
+    "evals",
+    "tracing",
+    "observability",
+    "agent-engineering",
+    "rubric-scoring"
+  ]
+}

--- a/plugins/mutagent/skills/mutagent-cli/SKILL.md
+++ b/plugins/mutagent/skills/mutagent-cli/SKILL.md
@@ -142,7 +142,7 @@ If your runtime has no interactive-question tool, fall back to:
 3. Do NOT auto-fill answers from context (Rule 3)
 
 The `_directive.askUserQuestions` schema is described in
-[`concepts/eval-criteria.md`](./concepts/eval-criteria.md) §
+[`references/concepts/eval-criteria.md`](./references/concepts/eval-criteria.md) §
 "Per-field rubric collection" and follows
 [Claude Code's AskUserQuestion tool shape](https://docs.claude.com/en/docs/claude-code/sdk).
 
@@ -164,7 +164,7 @@ The `_directive.askUserQuestions` schema is described in
 
 1. **`--json` on EVERY command.** No exceptions. Agents use JSON mode exclusively.
 2. **`<command> --help` BEFORE first use of any command.** The CLI is the source of truth for flags -- this SKILL never inlines them.
-3. **NEVER auto-generate eval criteria -- collect from user.** Ask the user for each rubric field. See [concepts/eval-criteria.md](./concepts/eval-criteria.md) for the rubric format.
+3. **NEVER auto-generate eval criteria -- collect from user.** Ask the user for each rubric field. See [references/concepts/eval-criteria.md](./references/concepts/eval-criteria.md) for the rubric format.
 4. **Explore-before-modify.** Run `mutagent explore --json` before any write operation. Present findings, get user confirmation. Never mutate without discovery first.
 5. **Cost transparency before `optimize start`.** Run `mutagent usage --json` and show the result to the user. Get explicit confirmation before any optimization job.
 6. **Before optimizing, run `mutagent providers list --models` to verify available models.** This calls `/providers/catalog` and shows which models are available per provider. Use the output to pick valid `--exec-model` and `--eval-model` values.
@@ -175,8 +175,8 @@ The `_directive.askUserQuestions` schema is described in
 
 | Signal | Use | CLI surface | Skill workflow |
 |---|---|---|---|
-| Single LLM call -> text/JSON output | Prompt Optimization | `mutagent prompts *` | [workflows/optimization.md](./workflows/optimization.md) |
-| Multi-turn / tool-calling / state graph | Agent (WIP) | `mutagent agents *` (CRUD only) | [workflows/agents.md](./workflows/agents.md) (stub) |
+| Single LLM call -> text/JSON output | Prompt Optimization | `mutagent prompts *` | [references/workflows/optimization.md](./references/workflows/optimization.md) |
+| Multi-turn / tool-calling / state graph | Agent (WIP) | `mutagent agents *` (CRUD only) | [references/workflows/agents.md](./references/workflows/agents.md) (stub) |
 
 When in doubt: run `mutagent explore --json` (it classifies discovered code under `prompts[]` vs `agents[]`).
 
@@ -194,16 +194,16 @@ Match the user's first request. Load ONLY the matching subfile(s) per the table.
 
 | User said / signal detected | Load subfile(s) | Why |
 |---|---|---|
-| "trace", "observe", "integrate", "add framework" | [workflows/tracing.md](./workflows/tracing.md) | Non-destructive, fastest first-value path |
-| "optimize", "improve", "tune", "upload prompt" | [workflows/optimization.md](./workflows/optimization.md) | Full create->dataset->eval->optimize loop (orchestrator) |
-| "create dataset", "add examples", "test cases", "edge cases", "hard cases", "expand dataset", "dataset items" | [workflows/dataset-curation.md](./workflows/dataset-curation.md) (HOW) + [concepts/dataset-design.md](./concepts/dataset-design.md) (WHY) | Standalone dataset curation (no optimization context needed) |
-| "create evaluation", "create rubric", "evaluate prompt", "judge", "score this prompt", "rubric design", "MVC", "Output Standards" | [workflows/eval-creation.md](./workflows/eval-creation.md) (HOW) + [concepts/eval-criteria.md](./concepts/eval-criteria.md) (WHY) | Standalone evaluation rubric creation (no optimization context needed) |
-| "explore", "scan", "find prompts", "what prompts", "discover" | [workflows/exploration.md](./workflows/exploration.md) | Read-only discovery + taxonomy |
-| `AgentExecutor`, `StateGraph`, `createReactAgent`, `tool_calls`, `@tool`, `langgraph`, `crewai`, `autogen`, `openai/agents`, multi-turn | [workflows/agents.md](./workflows/agents.md) | WIP path -- surface partnership link |
-| "how do variables work", "single vs double braces", delimiter | [concepts/prompt-variables.md](./concepts/prompt-variables.md) | Delimiter inference contract (concept-only; prompt creation lives inline in optimization.md step 4) |
-| "what makes a good eval" (concept question only, no creation intent) | [concepts/eval-criteria.md](./concepts/eval-criteria.md) | INPUT MVC + OUTPUT Standards (no workflow load) |
-| "what makes a good dataset" (concept question only, no creation intent) | [concepts/dataset-design.md](./concepts/dataset-design.md) | Dataset curation principles + case categories (no workflow load) |
-| "scorecard", "interpret results", "what does X score mean" | [concepts/scorecard-output.md](./concepts/scorecard-output.md) | Interpretation only (no workflow needed) |
+| "trace", "observe", "integrate", "add framework" | [references/workflows/tracing.md](./references/workflows/tracing.md) | Non-destructive, fastest first-value path |
+| "optimize", "improve", "tune", "upload prompt" | [references/workflows/optimization.md](./references/workflows/optimization.md) | Full create->dataset->eval->optimize loop (orchestrator) |
+| "create dataset", "add examples", "test cases", "edge cases", "hard cases", "expand dataset", "dataset items" | [references/workflows/dataset-curation.md](./references/workflows/dataset-curation.md) (HOW) + [references/concepts/dataset-design.md](./references/concepts/dataset-design.md) (WHY) | Standalone dataset curation (no optimization context needed) |
+| "create evaluation", "create rubric", "evaluate prompt", "judge", "score this prompt", "rubric design", "MVC", "Output Standards" | [references/workflows/eval-creation.md](./references/workflows/eval-creation.md) (HOW) + [references/concepts/eval-criteria.md](./references/concepts/eval-criteria.md) (WHY) | Standalone evaluation rubric creation (no optimization context needed) |
+| "explore", "scan", "find prompts", "what prompts", "discover" | [references/workflows/exploration.md](./references/workflows/exploration.md) | Read-only discovery + taxonomy |
+| `AgentExecutor`, `StateGraph`, `createReactAgent`, `tool_calls`, `@tool`, `langgraph`, `crewai`, `autogen`, `openai/agents`, multi-turn | [references/workflows/agents.md](./references/workflows/agents.md) | WIP path -- surface partnership link |
+| "how do variables work", "single vs double braces", delimiter | [references/concepts/prompt-variables.md](./references/concepts/prompt-variables.md) | Delimiter inference contract (concept-only; prompt creation lives inline in optimization.md step 4) |
+| "what makes a good eval" (concept question only, no creation intent) | [references/concepts/eval-criteria.md](./references/concepts/eval-criteria.md) | INPUT MVC + OUTPUT Standards (no workflow load) |
+| "what makes a good dataset" (concept question only, no creation intent) | [references/concepts/dataset-design.md](./references/concepts/dataset-design.md) | Dataset curation principles + case categories (no workflow load) |
+| "scorecard", "interpret results", "what does X score mean" | [references/concepts/scorecard-output.md](./references/concepts/scorecard-output.md) | Interpretation only (no workflow needed) |
 | "check models", "what models", "available models", "which models" | run `mutagent providers list --models --json` | Discovery: shows catalog per provider before model selection |
 | Unclear / first time | run `mutagent explore --json` first, then reroute | Discovery before action |
 
@@ -213,15 +213,15 @@ Match the user's first request. Load ONLY the matching subfile(s) per the table.
 
 | File | WHEN to load | WHY | ENFORCEMENT |
 |---|---|---|---|
-| [workflows/tracing.md](./workflows/tracing.md) | User wants to add framework tracing / observability | Non-destructive append-only integration sequence | Must run explore first (Rule 4) |
-| [workflows/optimization.md](./workflows/optimization.md) | User wants to optimize or evaluate a prompt | Full loop: explore -> upload -> dataset -> eval -> optimize -> apply | Must check usage before optimize (Rule 5); must collect rubrics from user (Rule 3) |
-| [workflows/dataset-curation.md](./workflows/dataset-curation.md) | User wants to create/expand a dataset (standalone) | Focused dataset curation without full optimization context | Hard cases first; ask per-field questions |
-| [workflows/eval-creation.md](./workflows/eval-creation.md) | User wants to create/edit evaluation rubric (standalone) | Focused per-field rubric collection without full optimization context | INPUT MVC + OUTPUT Standards split; ask per-field questions; collect from user (Rule 3) |
-| [workflows/exploration.md](./workflows/exploration.md) | User wants to scan codebase, identify prompts vs agents | Read-only discovery; output taxonomy to user | Run only; no writes |
-| [workflows/agents.md](./workflows/agents.md) | Multi-turn / tool-calling code detected | WIP -- do NOT attempt optimizer, surface partnership link | Show WIP card to user verbatim |
-| [concepts/prompt-variables.md](./concepts/prompt-variables.md) | Any question about `{var}` vs `{{var}}`, delimiter inference | Brace convention + conversion rules | Load before `prompts create` in optimization workflow |
-| [concepts/eval-criteria.md](./concepts/eval-criteria.md) | Any question about rubric design, MVC, Output Standards | granular rubric format -- INPUT-param vs OUTPUT-param scope | Load before `evaluation create --guided` in optimization workflow |
-| [concepts/dataset-design.md](./concepts/dataset-design.md) | Any question about dataset quality, case categories, hard cases | Dataset design principles -- parallel structure to eval-criteria.md | Load before `dataset add --guided` |
+| [references/workflows/tracing.md](./references/workflows/tracing.md) | User wants to add framework tracing / observability | Non-destructive append-only integration sequence | Must run explore first (Rule 4) |
+| [references/workflows/optimization.md](./references/workflows/optimization.md) | User wants to optimize or evaluate a prompt | Full loop: explore -> upload -> dataset -> eval -> optimize -> apply | Must check usage before optimize (Rule 5); must collect rubrics from user (Rule 3) |
+| [references/workflows/dataset-curation.md](./references/workflows/dataset-curation.md) | User wants to create/expand a dataset (standalone) | Focused dataset curation without full optimization context | Hard cases first; ask per-field questions |
+| [references/workflows/eval-creation.md](./references/workflows/eval-creation.md) | User wants to create/edit evaluation rubric (standalone) | Focused per-field rubric collection without full optimization context | INPUT MVC + OUTPUT Standards split; ask per-field questions; collect from user (Rule 3) |
+| [references/workflows/exploration.md](./references/workflows/exploration.md) | User wants to scan codebase, identify prompts vs agents | Read-only discovery; output taxonomy to user | Run only; no writes |
+| [references/workflows/agents.md](./references/workflows/agents.md) | Multi-turn / tool-calling code detected | WIP -- do NOT attempt optimizer, surface partnership link | Show WIP card to user verbatim |
+| [references/concepts/prompt-variables.md](./references/concepts/prompt-variables.md) | Any question about `{var}` vs `{{var}}`, delimiter inference | Brace convention + conversion rules | Load before `prompts create` in optimization workflow |
+| [references/concepts/eval-criteria.md](./references/concepts/eval-criteria.md) | Any question about rubric design, MVC, Output Standards | granular rubric format -- INPUT-param vs OUTPUT-param scope | Load before `evaluation create --guided` in optimization workflow |
+| [references/concepts/dataset-design.md](./references/concepts/dataset-design.md) | Any question about dataset quality, case categories, hard cases | Dataset design principles -- parallel structure to eval-criteria.md | Load before `dataset add --guided` |
 
 ---
 

--- a/plugins/mutagent/skills/mutagent-cli/SKILL.md
+++ b/plugins/mutagent/skills/mutagent-cli/SKILL.md
@@ -1,0 +1,326 @@
+---
+name: mutagent-cli
+description: |
+  MutagenT CLI - AI Prompt Optimization Platform CLI.
+  Guides coding agents through prompt upload, evaluation creation,
+  dataset curation, optimization, and framework integration.
+  Triggers: "mutagent", "optimize prompt", "upload prompt", "integrate tracing",
+  "create evaluation", "upload dataset", "explore prompts", "mutagent cli",
+  "eval", "dataset", "guided", "how do I optimize", "improve my prompt",
+  "set up tracing", "add observability".
+SKILL_VERSION: 0.1.178
+SKILL_MIN_CLI_VERSION: 0.1.163
+---
+
+# MutagenT CLI Skill
+
+> Installed to dev environments via `mutagent skills install`. Bundled with the
+> CLI binary so it stays version-aligned. This published copy is the canonical
+> reference — edit upstream and re-publish, never the installed copy.
+
+---
+
+## CLI Prerequisite Check (RUN FIRST)
+
+Before executing ANY workflow step, verify the CLI is installed and version-compatible:
+
+**Step 1 -- Check CLI presence:**
+```bash
+mutagent --version --json
+```
+
+**Step 2 -- If command not found (error / not on PATH):**
+
+This is the **Path 2 onboarding case**: the Skill was installed first (e.g. from a skill registry, manually, or bundled in someone else's CLAUDE.md), but the CLI itself isn't installed yet. Do NOT just dump install instructions and stop -- proactively **offer to install it**.
+
+**2a. Detect the user's package manager** (best-effort — check in this order):
+```bash
+# In the user's project root (cwd):
+test -f bun.lockb && echo "bun"
+test -f pnpm-lock.yaml && echo "pnpm"
+test -f yarn.lock && echo "yarn"
+test -f package-lock.json && echo "npm"
+# Fallback: which bun || which pnpm || which yarn || which npm
+```
+If multiple lockfiles exist, prefer in order: `bun > pnpm > yarn > npm`.
+If no lockfile and the user is in a non-JS project (e.g. Python, Go), ask which they prefer.
+
+**2b. Ask the user via AskUserQuestion** (do NOT auto-install without consent):
+
+> "The MutagenT CLI is not installed yet. I can install it globally via `<detected-pm>`. Proceed?"
+
+Options to present:
+1. **Yes, install globally with `<detected-pm>`** (Recommended) -- runs `<pm> add -g @mutagent/cli` (or `npm install -g @mutagent/cli` for npm)
+2. **Yes, but use a different package manager** -- prompt for choice (npm / bun / pnpm / yarn)
+3. **No, I'll install it myself** -- show the four install commands as a verbatim block; STOP and wait for the user to install
+4. **Skip — I have it installed via a different path** -- ask the user to add it to PATH and re-invoke
+
+**2c. On user approval (option 1 or 2)**, run the install command in a Bash tool call:
+```bash
+# bun
+bun add -g @mutagent/cli
+# npm
+npm install -g @mutagent/cli
+# pnpm
+pnpm add -g @mutagent/cli
+# yarn
+yarn global add @mutagent/cli
+```
+Show the install output to the user verbatim. After it completes, **re-run Step 1** (`mutagent --version --json`) to confirm the CLI is now on PATH. If the post-install version check still fails (e.g. global bin not on PATH), tell the user:
+> "Install succeeded but `mutagent` isn't on PATH yet. Common fixes:
+> - bun: `export PATH=\"$HOME/.bun/bin:$PATH\"`
+> - npm: check `npm config get prefix` and add `<prefix>/bin` to PATH
+> - pnpm: `pnpm setup` then restart your shell
+> - yarn: `yarn global bin` and add that path to PATH"
+> Then ask the user to restart their shell or source the relevant rc file, and re-invoke me.
+
+**2d. On rejection (option 3 or 4)**, output the four install commands as a verbatim block and STOP. Do NOT proceed with any workflow until the user confirms the CLI is installed and re-invokes the skill.
+
+```bash
+# Pick one (Recommended in order: bun > pnpm > yarn > npm)
+bun add -g @mutagent/cli
+pnpm add -g @mutagent/cli
+yarn global add @mutagent/cli
+npm install -g @mutagent/cli
+```
+
+**Why proactive install (not just "stop and tell")**: a user invoking this Skill has already shown intent to use MutagenT. Forcing them to context-switch to a separate terminal, copy-paste an install command, and re-invoke the agent is friction that often loses the user. Asking once + installing on consent is the smoother path. The opt-out (option 3/4) preserves user control.
+
+**Step 3 -- Version compatibility check:**
+Parse `_compat.cliVersion` from the `--version --json` output and compare against
+`SKILL_MIN_CLI_VERSION` (above in this file's frontmatter, currently `0.1.163`).
+
+- If `cliVersion >= SKILL_MIN_CLI_VERSION`: all good, proceed normally.
+- If `cliVersion < SKILL_MIN_CLI_VERSION`: emit a **PROMINENT PERSISTENT WARN** to the user:
+
+  > Warning: **CLI version mismatch**: Your `mutagent` CLI is `{cliVersion}` but this Skill
+  > requires `>= 0.1.163`. Some features may not work correctly.
+  > Upgrade: `npm install -g @mutagent/cli@latest`
+
+  **DO NOT BLOCK** -- proceed with the requested workflow after showing the warn.
+  Re-emit this warn at the start of every subsequent Skill invocation until the user upgrades.
+
+**Per decision D4 (locked 2026-05-03)**: version mismatch is warn-only, never a hard block.
+
+---
+
+## MANDATORY: Verbatim Card Display Protocol
+
+If a mutagent CLI response contains `_directive.renderedCard`, your FIRST action
+MUST be to copy that text byte-for-byte into your chat reply BEFORE running any
+further command, asking any question, or doing any other work.
+
+The card also appears on stderr (auto-echoed by the CLI via `echoDirectiveToStderr`)
+but you MUST STILL render it in chat -- bash/stderr blocks may be collapsed in the
+user's UI and they cannot read them.
+
+- Do NOT summarize, paraphrase, or truncate any line of the card.
+- Do NOT skip the card to "save tokens."
+- Do NOT delay rendering until "after the next step."
+- This applies whether `_directive.display` is `'status_card'` or absent -- the
+  trigger is the presence of `renderedCard`, not the display tag.
+- Failure to display the card verbatim = protocol violation.
+
+This rule applies to: prompt/agent/dataset/evaluation create+update+delete,
+provider add+update+delete, and optimize start/status/results.
+
+---
+
+## Agent Runtime — interactive question handling
+
+This skill emits `_directive.askUserQuestions` arrays for guided flows
+(eval-creation, dataset-curation, init). On Claude Code, use the
+**AskUserQuestion** tool to present each question to the user. On other
+coding-agent runtimes (Cursor, Aider, Continue, etc.), use the equivalent
+inquiry/prompt mechanism your runtime provides.
+
+If your runtime has no interactive-question tool, fall back to:
+1. Echo each question's `question` field verbatim into chat
+2. Wait for the user's reply before proceeding to the next question
+3. Do NOT auto-fill answers from context (Rule 3)
+
+The `_directive.askUserQuestions` schema is described in
+[`concepts/eval-criteria.md`](./concepts/eval-criteria.md) §
+"Per-field rubric collection" and follows
+[Claude Code's AskUserQuestion tool shape](https://docs.claude.com/en/docs/claude-code/sdk).
+
+---
+
+## SKILL vs CLI -- responsibility split
+
+| Layer | Owner | Responsibility |
+|---|---|---|
+| **SKILL** (this file + subfiles) | here | journeys, routing, 5 rules, enforcement |
+| **CLI** | `mutagent <cmd>` | commands, flags, `--json`, `_directive.*`, `_links` |
+| Platform | api.mutagent.io | storage, optimization, eval execution, `{variable}` rendering |
+
+**Rule**: SKILL never duplicates CLI flag lists -- always `mutagent <cmd> --help` for flags.
+
+---
+
+## 5 Core Rules -- NON-NEGOTIABLE
+
+1. **`--json` on EVERY command.** No exceptions. Agents use JSON mode exclusively.
+2. **`<command> --help` BEFORE first use of any command.** The CLI is the source of truth for flags -- this SKILL never inlines them.
+3. **NEVER auto-generate eval criteria -- collect from user.** Ask the user for each rubric field. See [concepts/eval-criteria.md](./concepts/eval-criteria.md) for the rubric format.
+4. **Explore-before-modify.** Run `mutagent explore --json` before any write operation. Present findings, get user confirmation. Never mutate without discovery first.
+5. **Cost transparency before `optimize start`.** Run `mutagent usage --json` and show the result to the user. Get explicit confirmation before any optimization job.
+6. **Before optimizing, run `mutagent providers list --models` to verify available models.** This calls `/providers/catalog` and shows which models are available per provider. Use the output to pick valid `--exec-model` and `--eval-model` values.
+
+---
+
+## Prompt vs Agent -- pick the right loop
+
+| Signal | Use | CLI surface | Skill workflow |
+|---|---|---|---|
+| Single LLM call -> text/JSON output | Prompt Optimization | `mutagent prompts *` | [workflows/optimization.md](./workflows/optimization.md) |
+| Multi-turn / tool-calling / state graph | Agent (WIP) | `mutagent agents *` (CRUD only) | [workflows/agents.md](./workflows/agents.md) (stub) |
+
+When in doubt: run `mutagent explore --json` (it classifies discovered code under `prompts[]` vs `agents[]`).
+
+---
+
+## Journey Router -- route by user intent
+
+> **Concept files = WHY/WHAT pre-reads. Workflow files = HOW step sequences.**
+> Load BOTH when intent matches both axes (e.g., "create rubric" loads
+> `concepts/eval-criteria.md` for the rubric design framework AND
+> `workflows/eval-creation.md` for the step-by-step CLI sequence). Each topic's
+> concept ↔ workflow pairing is shown in the Subfile Map below.
+
+Match the user's first request. Load ONLY the matching subfile(s) per the table. Do NOT preload the whole set.
+
+| User said / signal detected | Load subfile(s) | Why |
+|---|---|---|
+| "trace", "observe", "integrate", "add framework" | [workflows/tracing.md](./workflows/tracing.md) | Non-destructive, fastest first-value path |
+| "optimize", "improve", "tune", "upload prompt" | [workflows/optimization.md](./workflows/optimization.md) | Full create->dataset->eval->optimize loop (orchestrator) |
+| "create dataset", "add examples", "test cases", "edge cases", "hard cases", "expand dataset", "dataset items" | [workflows/dataset-curation.md](./workflows/dataset-curation.md) (HOW) + [concepts/dataset-design.md](./concepts/dataset-design.md) (WHY) | Standalone dataset curation (no optimization context needed) |
+| "create evaluation", "create rubric", "evaluate prompt", "judge", "score this prompt", "rubric design", "MVC", "Output Standards" | [workflows/eval-creation.md](./workflows/eval-creation.md) (HOW) + [concepts/eval-criteria.md](./concepts/eval-criteria.md) (WHY) | Standalone evaluation rubric creation (no optimization context needed) |
+| "explore", "scan", "find prompts", "what prompts", "discover" | [workflows/exploration.md](./workflows/exploration.md) | Read-only discovery + taxonomy |
+| `AgentExecutor`, `StateGraph`, `createReactAgent`, `tool_calls`, `@tool`, `langgraph`, `crewai`, `autogen`, `openai/agents`, multi-turn | [workflows/agents.md](./workflows/agents.md) | WIP path -- surface partnership link |
+| "how do variables work", "single vs double braces", delimiter | [concepts/prompt-variables.md](./concepts/prompt-variables.md) | Delimiter inference contract (concept-only; prompt creation lives inline in optimization.md step 4) |
+| "what makes a good eval" (concept question only, no creation intent) | [concepts/eval-criteria.md](./concepts/eval-criteria.md) | INPUT MVC + OUTPUT Standards (no workflow load) |
+| "what makes a good dataset" (concept question only, no creation intent) | [concepts/dataset-design.md](./concepts/dataset-design.md) | Dataset curation principles + case categories (no workflow load) |
+| "scorecard", "interpret results", "what does X score mean" | [concepts/scorecard-output.md](./concepts/scorecard-output.md) | Interpretation only (no workflow needed) |
+| "check models", "what models", "available models", "which models" | run `mutagent providers list --models --json` | Discovery: shows catalog per provider before model selection |
+| Unclear / first time | run `mutagent explore --json` first, then reroute | Discovery before action |
+
+---
+
+## Subfile Map
+
+| File | WHEN to load | WHY | ENFORCEMENT |
+|---|---|---|---|
+| [workflows/tracing.md](./workflows/tracing.md) | User wants to add framework tracing / observability | Non-destructive append-only integration sequence | Must run explore first (Rule 4) |
+| [workflows/optimization.md](./workflows/optimization.md) | User wants to optimize or evaluate a prompt | Full loop: explore -> upload -> dataset -> eval -> optimize -> apply | Must check usage before optimize (Rule 5); must collect rubrics from user (Rule 3) |
+| [workflows/dataset-curation.md](./workflows/dataset-curation.md) | User wants to create/expand a dataset (standalone) | Focused dataset curation without full optimization context | Hard cases first; ask per-field questions |
+| [workflows/eval-creation.md](./workflows/eval-creation.md) | User wants to create/edit evaluation rubric (standalone) | Focused per-field rubric collection without full optimization context | INPUT MVC + OUTPUT Standards split; ask per-field questions; collect from user (Rule 3) |
+| [workflows/exploration.md](./workflows/exploration.md) | User wants to scan codebase, identify prompts vs agents | Read-only discovery; output taxonomy to user | Run only; no writes |
+| [workflows/agents.md](./workflows/agents.md) | Multi-turn / tool-calling code detected | WIP -- do NOT attempt optimizer, surface partnership link | Show WIP card to user verbatim |
+| [concepts/prompt-variables.md](./concepts/prompt-variables.md) | Any question about `{var}` vs `{{var}}`, delimiter inference | Brace convention + conversion rules | Load before `prompts create` in optimization workflow |
+| [concepts/eval-criteria.md](./concepts/eval-criteria.md) | Any question about rubric design, MVC, Output Standards | granular rubric format -- INPUT-param vs OUTPUT-param scope | Load before `evaluation create --guided` in optimization workflow |
+| [concepts/dataset-design.md](./concepts/dataset-design.md) | Any question about dataset quality, case categories, hard cases | Dataset design principles -- parallel structure to eval-criteria.md | Load before `dataset add --guided` |
+
+---
+
+## Output handling
+
+After every CLI command:
+- **Show the command output to the user.** Command output appears in bash blocks that users may not see -- always present the key results in your chat response.
+- **For evaluation create `--guided`**: the CLI provides per-field questions in `_directive.askUserQuestions`. Ask the user each question in turn. Do not skip any field. Do not pre-fill answers.
+- **For `optimize results`**: present the before/after scorecard to the user and confirm whether to apply, view diff, or reject.
+
+---
+
+## Anti-patterns -- NEVER do these
+
+- Run any command without `--json`
+- Auto-generate eval criteria -- always collect from the user
+- Skip any schema field when collecting evaluation rubrics
+- Skip `mutagent explore --json` before any write operation
+- Run `optimize start` without first showing `usage --json` to the user
+- Increase `--max-iterations` above 1 without explicit user consent (each iteration = LLM spend)
+- Run a multi-turn agent through the prompt optimizer
+- Skip showing command output results to the user
+- Inline CLI flags from memory -- always read `--help` first
+
+---
+
+## State Tracking
+
+- `.mutagent/mutation-context.md` -- codebase index of discovered/uploaded prompts. Update after explore, create, dataset ops.
+- `mutagent auth status --json` -- auth + workspace state.
+
+---
+
+## Login (two paths)
+
+- **CI / automated**: `export MUTAGENT_API_KEY=mt_... && mutagent login --json` -- no browser, no prompts.
+- **Onboarding a user**: `mutagent login --browser --json` -- CLI prints auth URL to stdout, polls 5 min. **Surface the URL verbatim to the user.** `--non-interactive` is NOT needed when `--browser` is set.
+
+`mutagent login` is canonical. `mutagent auth login` is a back-compat alias.
+
+---
+
+## Error Recovery -- Agent-Aware Bug Reporting
+
+When ANY mutagent CLI command returns a non-zero exit code or an error response,
+follow this protocol:
+
+1. **Show the error to the user** (always) -- reproduce the exact command and output.
+2. **ASK the user** if they want to file a bug report with session context.
+3. **On user approval**, run:
+   ```bash
+   echo '{"command":"<failed-cmd>","error":"<error-text>","steps":[...]}' \
+     | mutagent feedback send --category bug --context - -m "<one-line summary>"
+   ```
+   - The `--context -` flag reads structured JSON from stdin.
+   - Include: the failed command, error message, and recent steps that led to it.
+   - Use `--json` for structured confirmation: `mutagent feedback send ... --json`
+
+4. **After a rejected or failed optimization attempt**, ALSO OFFER this proactively:
+   > "The optimization attempt failed/was rejected. Would you like to file a bug report
+   > so the MutagenT team can investigate? I'll include the session context."
+   On approval, pipe the optimizer job ID, error, and iteration context to `--context -`.
+
+### Context payload shape
+
+The `--context` flag accepts your JSON payload (caller intent). The CLI wraps
+auto-captured fields under the reserved `_auto` key so they never overwrite
+top-level keys you supply:
+
+```json
+{
+  "command": "mutagent prompts optimize start ...",
+  "error": "ApiError: 428 Precondition Required",
+  "jobId": "opt_abc123",
+  "promptId": "prompt_xyz",
+  "steps": ["prompts create", "dataset add", "evaluation create", "optimize start"],
+  "_auto": {
+    "cliVersion": "0.2.1",
+    "platform": "darwin",
+    "nodeVersion": "v20.11.0",
+    "workspaceId": "ws_your_workspace",
+    "timestamp": "2026-04-15T10:00:00.000Z"
+  }
+}
+```
+
+`_auto` is always populated by the CLI -- do **not** set it manually. Your
+top-level keys are never overwritten; if you supply `workspaceId: "ws_agent_B"`,
+the CLI's current workspace A goes into `_auto.workspaceId`, not the top level.
+
+### If `mutagent feedback send` itself fails
+
+If the feedback command returns a non-zero exit code, DO NOT retry silently. Show the user:
+
+1. The output of `mutagent auth status` (confirms login state).
+2. The fallback: open https://app.mutagent.io and use the in-app feedback form.
+3. Offer to copy the prepared bug report to the clipboard (if running in a macOS/Linux
+   terminal with `pbcopy` / `xclip`).
+
+---
+
+## Extensibility
+
+Add `workflows/custom-<name>.md` with frontmatter `triggers: ["phrase"]` -- auto-discovered by the decision tree fallback row. No rebuild needed.

--- a/plugins/mutagent/skills/mutagent-cli/SKILL.md
+++ b/plugins/mutagent/skills/mutagent-cli/SKILL.md
@@ -4,10 +4,12 @@ description: |
   MutagenT CLI - AI Prompt Optimization Platform CLI.
   Guides coding agents through prompt upload, evaluation creation,
   dataset curation, optimization, and framework integration.
-  Triggers: "mutagent", "optimize prompt", "upload prompt", "integrate tracing",
-  "create evaluation", "upload dataset", "explore prompts", "mutagent cli",
-  "eval", "dataset", "guided", "how do I optimize", "improve my prompt",
-  "set up tracing", "add observability".
+  Use this skill when the user wants to optimize a prompt, upload a prompt,
+  create an evaluation, integrate tracing, upload a dataset, explore prompts,
+  or run the mutagent CLI. Trigger phrases: "mutagent", "optimize prompt",
+  "upload prompt", "integrate tracing", "create evaluation", "upload dataset",
+  "explore prompts", "mutagent cli", "eval", "dataset", "guided",
+  "how do I optimize", "improve my prompt", "set up tracing", "add observability".
 SKILL_VERSION: 0.1.178
 SKILL_MIN_CLI_VERSION: 0.1.163
 ---
@@ -158,7 +160,7 @@ The `_directive.askUserQuestions` schema is described in
 
 ---
 
-## 5 Core Rules -- NON-NEGOTIABLE
+## 6 Core Rules -- NON-NEGOTIABLE
 
 1. **`--json` on EVERY command.** No exceptions. Agents use JSON mode exclusively.
 2. **`<command> --help` BEFORE first use of any command.** The CLI is the source of truth for flags -- this SKILL never inlines them.

--- a/plugins/mutagent/skills/mutagent-cli/references/concepts/dataset-design.md
+++ b/plugins/mutagent/skills/mutagent-cli/references/concepts/dataset-design.md
@@ -1,0 +1,207 @@
+---
+name: mutagent-cli-concepts-dataset-design
+description: |
+  Canonical source for MutagenT dataset design principles.
+  The Golden Rule: hard cases > easy cases; edge cases are mandatory.
+  Covers case categories (Edge / Hard / Representative / Adversarial),
+  format requirements (input/expectedOutput shape), and anti-patterns.
+  Parallel structure to concepts/eval-criteria.md for cognitive parity.
+triggers:
+  - "dataset design"
+  - "dataset quality"
+  - "what makes a good dataset"
+  - "hard cases"
+  - "edge cases"
+  - "test cases"
+  - "expectedOutput"
+  - "dataset items"
+  - "guided dataset"
+---
+
+# Concept -- Dataset Design
+
+> **Parallel to** [concepts/eval-criteria.md](./eval-criteria.md) -- same section
+> structure so agents can navigate both consistently.
+>
+> **Canonical source** for dataset curation principles.
+
+## The Golden Rule
+
+**Hard cases that expose prompt weaknesses FIRST. Easy cases that always pass LAST.**
+
+A dataset where every item produces correct output tells you nothing about where the
+prompt fails. The optimizer needs failure signal to improve. Prioritize inputs that:
+
+1. Are ambiguous (multiple valid interpretations)
+2. Are adversarial (designed to trigger a known failure mode)
+3. Are at the boundary of what the prompt should handle
+4. Are drawn from actual production failure cases
+
+**One edge case that causes a failure is worth 10 easy cases that succeed.**
+
+---
+
+## NEVER skip expectedOutput on labelable items
+
+This is the dataset equivalent of Rule 3 (never auto-generate eval criteria).
+
+- If you know what the correct output should be for a given input, you MUST include `expectedOutput`.
+- The optimizer uses `expectedOutput` as the ground-truth signal for G-Eval scoring.
+- Omitting `expectedOutput` on a labelable item forces the evaluator to use LLM judgment alone -- much noisier.
+- **Only omit `expectedOutput`** when correct output is genuinely subjective / context-dependent AND no rubric can distinguish good from bad.
+
+Ask the user for expected outputs field by field -- do NOT auto-generate them.
+
+---
+
+## NEVER auto-generate dataset items
+
+This is the counterpart to Rule 3 (never auto-generate eval criteria). Reasons:
+
+- Auto-generated items tend to be representative cases (easy) rather than hard cases.
+- The user knows what production inputs look like and where the prompt fails; the agent does not.
+- Synthetic easy cases produce noisy optimization signal -- the optimizer improves scores on the easy
+  cases but the real prompt weaknesses go uncovered.
+- Collect items from the user via AskUserQuestion, one category at a time.
+
+---
+
+## Case Categories
+
+Collect in this priority order -- hardest categories first:
+
+### 1. Edge Cases (HIGH priority)
+
+Boundary inputs that test the limits of what the prompt should handle.
+
+| What to ask | Examples |
+|---|---|
+| Empty or null inputs | `""`, `null`, `0`, `[]` |
+| Very long inputs (token limits) | paragraph-length where field should be short |
+| Malformed inputs | wrong type, wrong format, garbled text |
+| Unicode / special characters | emoji, RTL text, control chars, escaped quotes |
+| Missing required sub-fields | object with some required fields absent |
+
+**Collect at minimum**: 1-2 edge cases per input field.
+
+### 2. Hard Cases (HIGH priority)
+
+Inputs that are valid but expose known prompt weaknesses or require nuanced reasoning.
+
+| What to ask | Examples |
+|---|---|
+| Ambiguous inputs | "What does this mean?" (multiple valid answers) |
+| Adversarial inputs | phrasing designed to trigger hallucination or refusal |
+| Domain traps | technical jargon with multiple meanings in context |
+| Instruction conflicts | input that triggers contradictory rules in the prompt |
+| Near-miss inputs | almost correct format but slightly off |
+
+**Collect at minimum**: 2-3 hard cases total.
+
+### 3. Representative Cases (MEDIUM priority)
+
+Typical production inputs -- what the prompt handles 80% of the time.
+
+| What to ask | Examples |
+|---|---|
+| Common use cases | most frequent user inputs |
+| Standard formats | well-formed, expected-length, standard vocabulary |
+| Baseline quality | inputs where the prompt should succeed reliably |
+
+**Collect after** hard and edge cases are covered.
+
+### 4. Adversarial Cases (LOW priority, if relevant)
+
+Inputs designed to test security / safety / guardrails.
+
+| What to ask | Examples |
+|---|---|
+| Prompt injection attempts | "Ignore previous instructions and..." |
+| Off-topic requests | completely unrelated to the prompt's domain |
+| Jailbreak patterns | attempts to bypass constraints |
+
+Only collect if the prompt has explicit safety constraints.
+
+---
+
+## Format Requirements
+
+Every dataset item MUST have:
+
+```json
+{
+  "input": {
+    "<inputSchema_field_1>": "<value>",
+    "<inputSchema_field_2>": "<value>"
+  },
+  "expectedOutput": {
+    "<outputSchema_field_1>": "<expected_value>",
+    "<outputSchema_field_2>": "<expected_value>"
+  }
+}
+```
+
+Rules:
+- `input` keys MUST match the prompt's `inputSchema.properties` exactly (no extras, no missing required fields).
+- `expectedOutput` keys MUST match the prompt's `outputSchema.properties`.
+- String values in `expectedOutput` should be the verbatim correct answer (not a description of it).
+- Numeric scores in `expectedOutput` should match what the evaluator would award for a perfect response.
+- Upload as a JSON array: `[{item1}, {item2}, ...]`
+
+### Minimum dataset size
+
+- **5 items minimum** for any optimization run.
+- **At least 2 items** must be hard or edge cases.
+- More items = better signal, especially for per-criterion scoring.
+- `mutagent prompts dataset add --help` has the upload command flags.
+
+---
+
+## Anti-patterns
+
+| Anti-pattern | Why it's bad | Fix |
+|---|---|---|
+| All easy cases (prompt always succeeds) | No failure signal for optimizer | Add hard/edge cases first |
+| No edge cases | Optimizer never sees boundary behavior | Ask user about failure modes |
+| Fictional inputs that won't happen in production | Optimization targets unrealistic scenarios | Anchor to real usage patterns |
+| Missing `expectedOutput` on labelable items | Optimizer uses LLM judgment alone (noisy) | Ask user for expected outputs |
+| Duplicate items | Wastes dataset budget, skews scores | Check for duplicates before upload |
+| Items that are identical to training data | May overfit | Include diverse failure modes |
+
+---
+
+## Cross-references
+
+- [SKILL.md](../../SKILL.md) -- 5 rules + journey router
+- [workflows/dataset-curation.md](../workflows/dataset-curation.md) -- standalone dataset curation workflow (HOW; this file is WHY)
+- [workflows/optimization.md](../workflows/optimization.md) -- full loop that includes dataset add step
+- [concepts/eval-criteria.md](./eval-criteria.md) -- parallel concept doc for evaluation criteria
+
+---
+
+## CLI commands
+
+```bash
+# Discovery (no LLM cost)
+mutagent prompts dataset --help                                   # list dataset subcommands
+mutagent prompts dataset add --help                               # read flags before first use (Rule 2)
+mutagent prompts dataset list <prompt-id> --json                  # list datasets attached to a prompt
+mutagent prompts dataset get <dataset-id> --json                  # inspect single dataset's items + metadata
+
+# Creation -- guided (no LLM cost; just storage)
+mutagent prompts dataset add <prompt-id> --guided --json          # get _directive.askUserQuestions (per-field collection)
+mutagent prompts dataset add <prompt-id> -d '<json>' --name "<name>" --json  # upload items
+                                                                  # -d accepts inline JSON OR @path/to/file.json OR - (stdin)
+
+# Mutations
+mutagent prompts dataset update <dataset-id> -d '<json>' --json   # replace items in existing dataset
+mutagent prompts dataset delete <dataset-id> --json               # delete dataset (idempotent; --force skips confirm)
+```
+
+**Flag glossary** (dataset-specific):
+- `--guided` -- emit per-field `askUserQuestions` directive instead of expecting `-d` upfront. Use when collecting from user.
+- `-d <json>` / `--data <json>` -- supply items payload inline. Accepts: inline JSON, `@path` (read from file), `-` (read from stdin).
+- `--name "<name>"` -- human-readable label for the dataset (shows in dashboard).
+- `--json` -- structured output (Rule 1: always use). Returns `_directive` + `_links`.
+
+**Cost note**: dataset creation/edit/delete commands incur ZERO LLM cost. They are pure storage operations against the platform API. LLM cost is only incurred when `mutagent prompts optimize start` runs the exec model against these dataset items.

--- a/plugins/mutagent/skills/mutagent-cli/references/concepts/eval-criteria.md
+++ b/plugins/mutagent/skills/mutagent-cli/references/concepts/eval-criteria.md
@@ -1,0 +1,329 @@
+---
+name: mutagent-cli-concepts-eval-criteria
+description: |
+  Canonical source for MutagenT evaluation-criteria framing:
+  INPUT-param criteria → Minimum Viable Context (MVC);
+  OUTPUT-param criteria → Output Standards.
+  Granular rubric discipline (match anchors to the dimension's observable quality levels; binary scoring (1.0/0.0) for yes/no checks):
+  grounded, observable, never vague.
+  Includes current platform validation rules for criterion shape.
+triggers:
+  - "evaluation criteria"
+  - "eval criteria"
+  - "rubric"
+  - "how do I evaluate"
+  - "minimum viable context"
+  - "output standards"
+  - "evaluationParameter"
+  - "guided eval"
+---
+
+# Concept — Guided Evaluation Criteria
+
+> **Canonical source** for the INPUT vs OUTPUT framing used by the MutagenT
+> evaluation engine.
+
+## The golden rule
+
+**Every evaluation criterion is scoped to EITHER the inputs OR the outputs of
+the prompt. Never both in one criterion.**
+
+Mixing them produces vague criteria ("is the output good given the inputs?")
+that the optimizer cannot act on. When collecting rubrics from the user,
+explicitly frame each question around one of these two scopes.
+
+---
+
+## NEVER auto-generate criteria
+
+This is Rule 3 of the [5 Core Rules](../../SKILL.md). Reasons:
+
+- Auto-generated rubrics are vague by default ("score based on accuracy")
+- The optimizer cannot act on vague criteria — it needs observable tiers
+- The user knows what "correct" means for their domain; the agent does not
+- Generic rubrics produce noisy scores that mislead the optimizer
+
+**Always use AskUserQuestion to collect rubrics, one per variable/dimension.**
+
+When `evaluation create --guided --json` runs, the CLI provides a list of
+fields that need rubrics. Ask the user about EVERY field in that list.
+Do not skip any field. Do not pre-fill answers. The user must provide each rubric.
+
+---
+
+## Your rubric is the instruction to the G-Eval LLM
+
+The rubric text in each criterion's `description` field is read verbatim by
+the LLM-as-Judge (G-Eval). **The more precise your anchor descriptions, the
+more consistent and accurate the scores. Vague rubrics produce vague scores.**
+
+A rubric like "0.8 if mostly good, 0.2 if mostly bad" gives the judge no
+grounding — it will invent its own interpretation. A rubric with concrete
+tier definitions, observable characteristics, and specific examples locks the
+judge's interpretation to yours.
+
+The target quality bar is the G-Eval system's own internal scoring guidelines:
+each tier has a **named level**, a **score range**, a **definition**, **observable
+characteristics**, and a **concrete example**. Your rubrics should aspire to
+that same precision for the dimensions that matter most to your domain.
+
+---
+
+## Input-param criteria → Minimum Viable Context (MVC)
+
+**Scope**: the `{variables}` the prompt template consumes. Each `{variable}` is
+an **input param**. The criterion asks: *is the information required for the
+prompt to succeed actually present?*
+
+### Rubric format (match anchors to observable quality levels)
+
+Each anchor must be **observable** (a human can assign it by reading one input
+row) and **grounded** (describes a concrete property, not a feeling).
+
+```
+"Evaluate the completeness and usability of the {variable} input field.
+
+Score 0.95-1.00 (Exceptional):
+  All required context is present with rich, unambiguous detail. The prompt
+  can produce a high-quality output without any hedging or assumption.
+  Observable: full narrative prose, field-specific depth (e.g., >= 500 chars),
+  no placeholder text, no ambiguous referents.
+  Example: {document} = 800-word technical article with clear subject,
+  context, and argument — summarizer has everything it needs.
+
+Score 0.80-0.90 (Adequate):
+  All required context is present but with minor gaps or imprecision that
+  may cause hedging. The prompt can attempt a reasonable answer.
+  Observable: complete field with minor quality shortfalls
+  (e.g., 150-499 chars, one ambiguous term).
+  Example: {document} = 200-word product description with one unclear
+  abbreviation — summarizer can work but may flag the ambiguity.
+
+Score 0.60-0.70 (Marginal):
+  Most required context is present; the prompt can attempt an answer but
+  the output will be noticeably incomplete or generic.
+  Observable: partial field content, missing secondary context
+  (e.g., 50-149 chars, missing key metadata).
+  Example: {document} = three-sentence product blurb with no technical
+  specifics — summarizer produces a generic response.
+
+Score 0.40-0.50 (Insufficient):
+  Partial context only. The prompt will produce a low-quality or generic
+  response that cannot be acted on.
+  Observable: very short field (< 50 chars), or content present but off-topic.
+  Example: {document} = "See attached" — summarizer has nothing to work with.
+
+Score 0.20-0.30 (Minimal):
+  Only a stub or placeholder. The prompt will fail or produce a useless
+  response.
+  Observable: summary stubs, auto-generated filler, one-word answers.
+  Example: {document} = "TBD" or "N/A" — useless for any summarization.
+
+Score 0.00-0.10 (Absent):
+  Critical context is missing. The prompt cannot succeed regardless of model.
+  Observable: empty string, null, filename without content, TODO marker.
+  Example: {document} = "" or null or 'document.pdf'."
+```
+
+> **Binary checks use two-anchor scoring (1.0 / 0.0) — the criterion is either satisfied or not** (e.g., "Is the
+> document non-empty?"). For any spectrum dimension — quality, completeness,
+> accuracy — use as many scoring anchors as the dimension has meaningfully distinguishable quality levels, so the optimizer has fine-grained signal to
+> act on. Binary checks (yes/no) need 2 anchors. Spectrum dimensions (quality, completeness, accuracy) typically need 4-8, depending on how many distinct quality levels a human could reliably tell apart.
+
+### Discipline rules
+
+- **Grounded**: every tier must describe an observable property of the input
+  data, not a feeling.
+- **Observable**: a human reader should assign a tier by looking at a single
+  input row — no model output needed.
+- **Per-variable**: one criterion per `{variable}`. This localizes optimizer signal.
+
+### Before asking the user
+
+Enumerate variables using the delimiter inferred by `mutagent explore --json`:
+- `delimiter: "single"` → `{foo}` — platform canonical
+- `delimiter: "double"` → `{{foo}}` — framework template; convert before upload
+
+See [concepts/prompt-variables.md](./prompt-variables.md) for the full inference contract.
+
+### Example (compact inline format)
+
+For `"Summarize {document} for {audience}"`, the full-depth rubric above can
+be condensed to inline form for the JSON `description` field:
+
+```json
+[
+  {
+    "name": "document-present",
+    "evaluationParameter": "document",
+    "description": "Evaluate the usability of the document input. Score 0.95-1.00 (Exceptional): rich prose >= 500 chars, full context, no ambiguity — summarizer has everything it needs. Score 0.80-0.90 (Adequate): complete prose >= 100 chars, minor gaps — summarizer can work but may hedge one point. Score 0.60-0.70 (Marginal): short but usable text 50-99 chars — output will be generic. Score 0.40-0.50 (Insufficient): very short snippet < 50 chars or off-topic content — output will be low-quality. Score 0.20-0.30 (Minimal): summary stub, placeholder, or filler text — prompt cannot produce a useful response. Score 0.00-0.10 (Absent): empty, null, filename, or TODO — prompt cannot succeed."
+  },
+  {
+    "name": "audience-concrete",
+    "evaluationParameter": "audience",
+    "description": "Evaluate how concretely the audience is specified. Score 0.95-1.00 (Exceptional): concrete persona with role, seniority, and domain context (e.g., 'junior Python devs at an early-stage startup') — summarizer can tailor depth and vocabulary precisely. Score 0.80-0.90 (Adequate): concrete role with seniority but no domain ('junior Python devs') — good but summarizer must assume domain. Score 0.60-0.70 (Marginal): role with seniority but no discipline ('senior engineers') — summarizer must assume tech stack. Score 0.40-0.50 (Insufficient): broad category without seniority ('engineers') — output will be generic. Score 0.20-0.30 (Minimal): vague group ('technical people', 'our team') — barely actionable. Score 0.00-0.10 (Absent): empty, 'general', 'everyone', or null — no tailoring possible."
+  }
+]
+```
+
+#### Binary exception
+
+Some dimensions are genuinely binary — no spectrum exists. For these, 1.0/0.0
+is correct and adding extra anchors would be artificial:
+
+```json
+{
+  "name": "language-valid",
+  "evaluationParameter": "language",
+  "description": "Score 1.0 if the value is a valid BCP-47 language tag (e.g. 'en', 'fr-CA'). Score 0.0 if empty, null, or not a valid BCP-47 tag. No intermediate states exist — a tag is either valid or it is not."
+}
+```
+
+---
+
+## Output-param criteria → Output Standards
+
+**Scope**: the model's response shape and content. Pick the dimensions relevant
+to the task and write one criterion per dimension.
+
+### Common dimensions
+
+- **Content correctness** — right answer, right facts, right tone
+- **Structural correctness** — matches `outputSchema`, required fields, enums, length
+- **Groundedness** — facts in the output traceable to facts in the input
+- **Format compliance** — JSON validity, markdown shape, regex match
+
+### Full-depth example: summary_accuracy
+
+This rubric demonstrates the gold-standard format for an OUTPUT criterion that
+evaluates a complex, multi-dimensional field (the factual accuracy of a generated
+summary against its source document):
+
+```json
+{
+  "name": "summary-accuracy",
+  "evaluationParameter": "summary",
+  "description": "Evaluate the factual accuracy of the generated summary against the source document.\n\nScore 0.95-1.00 (Flawless):\n  Every claim in the summary traces directly to the source. No additions, no omissions of key facts, no distortions. A fact-checker would approve without notes.\n  Observable: each stated figure, date, or claim appears verbatim or with lossless paraphrase in the source; nothing is added that the source does not support.\n  Example: Source describes Q3 revenue of €4.2M with 12% YoY growth. Summary states exactly these figures in proper context.\n\nScore 0.80-0.90 (Accurate):\n  All major facts correct. 1-2 minor simplifications that do not mislead (e.g., rounding €4.2M to 'over €4M').\n  Observable: core claims verified; minor imprecision in secondary detail does not change the reader's understanding.\n  Example: Summary captures the revenue figure but describes growth as 'double-digit' instead of the precise 12%.\n\nScore 0.60-0.70 (Mostly Accurate):\n  Core narrative correct but 2-3 details are imprecise or missing. Reader gets the right general picture but would fail a quiz on specifics.\n  Observable: main conclusion correct; at least one number or attribution is off or absent.\n  Example: Summary states revenue grew but omits the percentage and rounds the figure to the nearest million.\n\nScore 0.40-0.50 (Partially Accurate):\n  Mix of correct and incorrect claims. Key facts present but some figures wrong or attributed to wrong context.\n  Observable: overall topic correct; at least one material claim contradicts or misattributes source data.\n  Example: Revenue figure correct but growth rate stated as 20% (source says 12%); quarter attribution swapped.\n\nScore 0.20-0.30 (Largely Inaccurate):\n  Summary contradicts source on important points or invents claims not present in the original.\n  Observable: multiple fabricated or inverted facts; reader would form a wrong understanding of the source.\n  Example: Summary inverts the YoY direction ('revenue declined') when the source reports growth.\n\nScore 0.00-0.10 (Fabricated):\n  Summary bears no factual relationship to the source document, is empty, or is a boilerplate placeholder.\n  Observable: empty string; '[Summary goes here]'; figures invented wholesale with no source basis.\n  Example: summary field is empty, or contains figures from a completely different document."
+}
+```
+
+### Simpler example: input_completeness (fewer tiers, still full depth)
+
+Not every criterion needs 6 tiers. For an input check where the spectrum is
+narrower, 5 tiers can be right — as long as each tier has definition,
+observables, and an example:
+
+```json
+{
+  "name": "context-completeness",
+  "evaluationParameter": "context",
+  "description": "Evaluate whether the input context provides sufficient information for the task.\n\nScore 0.95-1.00 (Comprehensive):\n  All required fields populated with specific, actionable detail. A human could complete the task using only this context without asking clarifying questions.\n  Observable: every required field present and non-empty; values are specific rather than generic placeholders.\n  Example: data extraction task where source_text, target_fields, and output_format are all fully specified with concrete values.\n\nScore 0.80-0.90 (Sufficient):\n  All required fields present with adequate detail. 1-2 optional fields missing but the task can proceed without them.\n  Observable: required fields complete; one optional field absent or using a safe default.\n  Example: translation task where source_text and target_language are present, but tone_style is unspecified — translation can proceed with neutral tone.\n\nScore 0.60-0.70 (Workable):\n  Core information present but some fields are vague or use placeholder language. The model can attempt the task but output will lack specificity.\n  Observable: required fields present but one uses generic language ('some text', 'relevant context'); output will be shallow.\n  Example: code review task where the code snippet is present but the review_focus field says 'check for issues' instead of specifying which aspects to evaluate.\n\nScore 0.40-0.50 (Thin):\n  Only basic identifiers present (name, category). Critical context fields are empty or contain single-word entries. Output will be generic.\n  Observable: task topic identifiable but most content fields empty or trivially short; model must hallucinate detail to respond.\n  Example: summarization task where source_document is only a title with no body text.\n\nScore 0.00-0.20 (Unusable):\n  Missing critical fields. The model cannot produce a meaningful output from this input alone.\n  Observable: required fields absent or null; no basis for task execution.\n  Example: data extraction task where source_text is empty or null."
+}
+```
+
+### Inline compact format (for production use)
+
+The full-depth format above is for documentation and teaching. In production
+`description` fields (which are single-line strings), compress as follows:
+
+```json
+{
+  "name": "summary-correctness",
+  "evaluationParameter": "summary",
+  "description": "Evaluate the correctness of the summary field against the source document and required format. Score 0.95-1.00 (Exceptional): valid JSON, all 3 required fields present, all key arguments covered accurately, no hallucinated facts, prose is precise and well-structured. Score 0.80-0.90 (Strong): valid JSON, all fields present, one argument understated but not wrong — does not change the conclusion. Score 0.60-0.70 (Adequate): valid JSON, all fields present, 1-2 arguments missing but no hallucinations — output is usable but incomplete. Score 0.40-0.50 (Weak): valid JSON, 1-2 required fields missing, or one argument hedged incorrectly — output is partially wrong. Score 0.20-0.30 (Poor): valid JSON but substantive content missing or severely incomplete — output provides little value. Score 0.00-0.10 (Failure): invalid JSON, any fabricated facts, or empty output."
+}
+```
+
+---
+
+## Platform validation rules (current)
+
+When creating an evaluation via `mutagent prompts evaluation create -d '<json>'`,
+each criterion must pass these platform-enforced checks:
+
+| Field | Required | Validation |
+|---|---|---|
+| `name` | yes | slug-like, no spaces, `[a-z0-9-_]` |
+| `description` | yes | non-empty, ideally >= 20 chars with tier definitions |
+| `evaluationParameter` | yes | must match a variable name from the prompt OR an output field name |
+
+**Common validation failures:**
+- `evaluationParameter` references a variable not in the prompt template → rejected
+- `description` is too short or vague → accepted by platform but produces poor scores
+- Multiple criteria with the same `evaluationParameter` → accepted but wasteful
+
+---
+
+## How to apply when creating an evaluation
+
+1. **Read the prompt template.** Enumerate `{variables}` (input params) +
+   expected output shape (from `outputSchema` or the code's parse logic).
+2. **Ask the user**: "Evaluate INPUTS (is context sufficient) or OUTPUTS
+   (is response correct) first?" — let the user pick the scope.
+3. **Collect criteria**: use AskUserQuestion to collect from user, never auto-generate — one per variable (INPUT) or per dimension (OUTPUT),
+   always with a granular rubric (anchors matched to the dimension's observable quality levels) describing observable behavior. Use binary scoring (1.0/0.0) only
+   for genuinely binary checks (membership tests, exact-match fields).
+4. **Map to platform shape**:
+   ```typescript
+   {
+     name: string;                // short, slug-like
+     description: string;         // the rubric verbatim
+     evaluationParameter: string; // the variable name OR output field
+   }
+   ```
+5. **Upload** via `mutagent prompts evaluation create <id> -d '<json>' --json`.
+
+The `--guided` flag walks the user through this flow interactively — use it
+when the user is new to the concept. Follow the CLI's next-step guidance in
+the output to collect rubrics in the correct order.
+
+---
+
+## Anti-patterns
+
+- **Auto-generating criteria** — Rule 3: NEVER. Always collect from user.
+- **Mixing input and output in one criterion** — breaks signal; split into two.
+- **Vague rubrics** — "0.8 if mostly good" → rewrite with named tier, definition, observables, example.
+- **Too few anchors for spectrum dimensions** — using only two or three scoring levels for quality/completeness dimensions starves the optimizer of signal; use as many anchors as the dimension has meaningfully distinguishable quality levels so the gradient is meaningful.
+- **One-liner anchors** — "1.0 = good, 0.6 = partial, 0.0 = bad" gives G-Eval no grounding to distinguish similar outputs. Each anchor needs a definition + observable + example.
+- **One criterion for many variables** — reduces signal, slows optimization.
+- **Scoring the model, not the data** — MVC scores the INPUT data quality.
+
+---
+
+## Cross-references
+
+- [SKILL.md](../../SKILL.md) → 5 rules (Rule 3: never auto-generate)
+- [workflows/optimization.md](../workflows/optimization.md) → steps 7-9 (where this concept is applied)
+- [concepts/prompt-variables.md](./prompt-variables.md) → delimiter inference (used in MVC step)
+
+---
+
+## CLI commands
+
+```bash
+# Discovery (no LLM cost)
+mutagent prompts evaluation --help                                # list eval subcommands
+mutagent prompts evaluation create --help                         # read flags before first use (Rule 2)
+mutagent prompts evaluation list <prompt-id> --json               # list existing evaluations on a prompt
+mutagent prompts evaluation get <eval-id> --json                  # inspect single evaluation's criteria + metadata
+
+# Creation -- guided (no LLM cost; just storage)
+mutagent prompts evaluation create <prompt-id> --guided --json    # get _directive.askUserQuestions + decisionTree (per-field collection)
+mutagent prompts evaluation create <prompt-id> -d '<json>' --name "<name>" --json  # upload criteria
+                                                                  # -d accepts inline JSON OR @path/to/file.json OR - (stdin)
+
+# Mutations
+mutagent prompts evaluation update <eval-id> -d '<json>' --json   # update existing criteria
+mutagent prompts evaluation delete <eval-id> --json               # delete evaluation (idempotent; --force skips confirm)
+```
+
+**Flag glossary** (eval-specific):
+- `--guided` -- emit per-field `askUserQuestions` directive instead of expecting `-d` upfront.
+- `-d <json>` / `--data <json>` -- supply criteria payload inline. Accepts: inline JSON, `@path` (file), `-` (stdin).
+- `--name "<name>"` -- human-readable label (shows in dashboard).
+- `--json` -- structured output (Rule 1: always use). Returns `_directive` + `_links` + `_compat`.
+
+**Cost note**: eval creation/edit/delete commands incur ZERO LLM cost. Pure storage operations. LLM cost is incurred only when `mutagent prompts optimize start` runs the judge model against this evaluation.
+
+**Workflow cross-link**: for the standalone HOW (step-by-step CLI sequence), see [workflows/eval-creation.md](../workflows/eval-creation.md).

--- a/plugins/mutagent/skills/mutagent-cli/references/concepts/prompt-variables.md
+++ b/plugins/mutagent/skills/mutagent-cli/references/concepts/prompt-variables.md
@@ -1,0 +1,183 @@
+---
+name: mutagent-cli-concepts-prompt-variables
+description: |
+  Prompt template variable delimiter inference contract.
+  Platform canonical is single-brace {variable}. Third-party frameworks vary
+  (Handlebars / Mustache / Liquid / Jinja2 use double {{variable}}).
+  `mutagent explore` infers the delimiter per file and surfaces it in
+  `--json` output as `delimiter: "single" | "double"`.
+  Includes conversion rules for upload and apply phases.
+triggers:
+  - "prompt variables"
+  - "template variables"
+  - "single vs double brace"
+  - "{variable}"
+  - "{{variable}}"
+  - "delimiter"
+  - "inferPromptVariables"
+  - "brace convention"
+  - "convert variables"
+---
+
+# Concept — Prompt Variables
+
+## Platform canonical
+
+**MutagenT platform uses single-brace `{variable}`.** The platform renders
+prompts by substituting `{name}` with the provided value at optimization /
+evaluation time.
+
+## Third-party framework variance
+
+Real-world codebases use different delimiters depending on which prompt
+framework the user already has installed:
+
+| Framework | Delimiter | Example |
+|---|---|---|
+| **MutagenT platform** (canonical) | single | `{document}` |
+| **LangChain** `PromptTemplate` | single | `{document}` |
+| **LangChain** `ChatPromptTemplate` + Mustache | double | `{{document}}` |
+| **Handlebars** | double | `{{document}}` |
+| **Mustache** | double | `{{document}}` |
+| **LiquidJS** | double | `{{ document }}` |
+| **Jinja2** (Python) | double | `{{ document }}` |
+
+---
+
+## Brace conversion — upload and apply
+
+Getting this wrong breaks templates after optimization. Follow the two-phase rule:
+
+### Phase 1 — Upload (code → MutagenT)
+
+If the code has `{{double}}` braces:
+1. Warn the user: "Your template uses `{{double}}` braces (Handlebars/LangChain Mustache). MutagenT uses `{single}` braces. I'll convert before uploading."
+2. Convert `{{name}}` → `{name}` in the prompt content passed to `mutagent prompts create`.
+3. Record the original delimiter in `.mutagent/mutation-context.md` so the apply phase knows to convert back.
+
+If the code has `{single}` braces: no conversion needed — upload as-is.
+
+### Phase 2 — Apply (MutagenT → code)
+
+After optimization, the platform returns a prompt with `{single}` braces.
+
+If the original codebase used `{{double}}` braces:
+1. Convert `{name}` → `{{name}}` in the optimized prompt before writing to the source file.
+2. Confirm with the user before saving.
+
+If the original codebase used `{single}` braces: write the optimized prompt as-is.
+
+**Summary table:**
+
+| Code uses | Upload | Optimized output | Write back to code |
+|---|---|---|---|
+| `{single}` | as-is | `{single}` | as-is |
+| `{{double}}` | convert to `{single}` | `{single}` | convert back to `{{double}}` |
+
+---
+
+## Per-file inference — `mutagent explore`
+
+The CLI's `mutagent explore` command calls `inferPromptVariables()` on every
+matching source file and **infers the delimiter per file** rather than
+globally. A single repository may contain both LangChain `PromptTemplate`
+(single) and Handlebars email templates (double) side by side.
+
+### Inference algorithm
+
+1. **Strip fenced markdown code blocks** first (` ``` ... ``` `). Avoids false
+   positives from prompts that document JSON examples in fenced blocks.
+2. **Count `{{name}}` matches** → `doubleHits`.
+3. **Count `{name}` matches** that are NOT adjacent to `{` (not part of `{{...}}`)
+   and NOT followed by `"` (JSON-key skip) → `singleHits`.
+4. **Majority wins**: `doubleHits > singleHits` → `double`, else `single`.
+5. **Tie-break**: singleHits === doubleHits (including the 0/0 case) →
+   `single` (platform canonical).
+
+### Escaped-JSON caveat
+
+Prompts like `"Return {\"status\": \"ok\"}"` — the `{` is followed by `"`, so
+the single-brace regex deliberately skips it. Never treat literal JSON keys as
+template variables.
+
+---
+
+## How to use the delimiter field
+
+`mutagent explore --json` surfaces the inferred delimiter per discovered prompt:
+
+```json
+{
+  "prompts": [
+    {
+      "file": "src/prompts/summarize.ts",
+      "line": 12,
+      "preview": "const prompt = `Summarize {document} for {audience}`;",
+      "reason": "template-variable",
+      "confidence": "high",
+      "delimiter": "single"
+    },
+    {
+      "file": "src/emails/welcome.hbs",
+      "line": 3,
+      "preview": "<p>Hello {{name}}, welcome to {{product}}!</p>",
+      "reason": "template-variable",
+      "confidence": "high",
+      "delimiter": "double"
+    }
+  ]
+}
+```
+
+Use the delimiter field to:
+- Enumerate variables correctly (don't treat `{{foo}}` as two `{foo}` tokens).
+- Decide whether to convert before upload (Phase 1 above).
+- Drive the [concepts/eval-criteria.md](./eval-criteria.md) → MVC step (one criterion per variable).
+
+---
+
+## Edge cases
+
+- **Empty prompt** — no variables → tie (0/0) → `single` (canonical).
+- **Mixed delimiters in one file** — majority wins, tied files default to `single`.
+  Warn the user: their codebase probably has two prompt systems co-existing.
+- **Nested braces** `{{{ foo }}}` — Handlebars triple-brace (no-escape). Currently
+  matched by the double regex as `{{ foo }}`; outer `}` ignored. Fine for inference.
+
+---
+
+## Cross-references
+
+- [SKILL.md](../../SKILL.md) → 5 rules + journey router
+- [workflows/optimization.md](../workflows/optimization.md) → step 3 (delimiter drives variable enumeration) and step 15 (apply conversion)
+- [concepts/eval-criteria.md](./eval-criteria.md) → MVC (Minimum Viable Context) — uses delimiter to enumerate input params
+
+---
+
+## CLI commands
+
+```bash
+# Discovery (no LLM cost, read-only)
+mutagent explore --help                                          # read flags before first use (Rule 2)
+mutagent explore --json                                          # scans codebase; emits "delimiter" field per prompt
+mutagent prompts get <id> --json                                 # inspect uploaded prompt's stored form (incl. delimiter)
+
+# Creation (no LLM cost, just storage)
+mutagent prompts create --help                                   # read brace format rules before creating
+mutagent prompts create --name "<name>" --raw "<prompt>" --json  # upload prompt (use single-brace {var} convention)
+mutagent prompts create --name "<name>" --raw-file <path> --json # upload from file (preferred for multi-line prompts)
+
+# Mutations
+mutagent prompts update <id> --raw "<prompt>" --json             # replace stored prompt body
+mutagent prompts delete <id> --json                              # delete prompt (idempotent; --force skips confirm)
+```
+
+**Flag glossary** (prompt-create-specific):
+- `--raw "<text>"` -- inline prompt body. Use for short single-line prompts.
+- `--raw-file <path>` -- read prompt body from file. Preferred for multi-line / templated prompts; preserves whitespace.
+- `--name "<name>"` -- human-readable label (shows in dashboard + explore output).
+- `--json` -- structured output (Rule 1: always use). Returns `_directive` (status_card) + `_links` + `_compat`.
+
+**Cost note**: prompt creation/edit/delete commands incur ZERO LLM cost. Pure storage. Only `mutagent prompts optimize start` and `mutagent prompts playground` (interactive testing) incur LLM cost.
+
+**Brace convention reminder**: use single-brace `{var}` for variables you'll later supply via dataset items. Use double-brace `{{literal}}` only when you need a literal `{var}` substring rendered (rare). The CLI's `mutagent explore` infers delimiter automatically -- see § "Delimiter inference" above for the rules.

--- a/plugins/mutagent/skills/mutagent-cli/references/concepts/scorecard-output.md
+++ b/plugins/mutagent/skills/mutagent-cli/references/concepts/scorecard-output.md
@@ -1,0 +1,260 @@
+---
+name: mutagent-cli-concepts-scorecard-output
+description: |
+  Per-iteration structured scorecard emitted by the optimizer.
+  Covers the ScorecardData shape, where agents see it (watch vs results),
+  how to consume NDJSON streams, cost-gate patterns, and criterion drill-down.
+triggers:
+  - "scorecard"
+  - "scorecard output"
+  - "optimize scorecard"
+  - "scorecard data"
+  - "iteration scorecard"
+  - "nextAction"
+  - "stop-stagnation"
+  - "cumulativeUsd"
+  - "optimizer results json"
+  - "watch optimizer"
+---
+
+# Concept — Scorecard Output
+
+> Per-iteration structured scorecard emitted by the optimizer, available
+> progressively via `--watch` and as a post-hoc digest via `optimize results`.
+
+## What it is
+
+Every completed optimizer iteration produces a `ScorecardData` record: a
+structured snapshot of scores, criterion pass-rates, cumulative cost, and the
+optimizer's own next-action decision. The scorecard is the primary signal
+surface for agents monitoring or reacting to a running optimization job.
+
+Two delivery modes:
+
+- **Progressive (streaming)** — emitted once per completed iteration over the
+  WebSocket event bus while the job runs.
+- **Post-hoc (batch)** — the full collection of per-iteration scorecards
+  returned in the `/api/optimization/:id/results` response after the job
+  finishes (or to inspect a paused job).
+
+---
+
+## Where an agent sees it
+
+### 1. `optimize start --watch --json`
+
+Streams NDJSON to stdout while the job runs. Each iteration emits one line:
+
+```
+{ "type": "scorecard.update", "iteration": 1, "scorecard": { ...ScorecardData } }
+```
+
+Other line types (e.g. `job.started`, `stage.completed`) may appear in the
+stream — branch on `type === "scorecard.update"` to isolate scorecard events.
+
+### 2. `optimize watch <id> --json`
+
+Attaches to an already-running job and streams the same NDJSON shape. Useful
+when the agent started the job in a previous session or on behalf of a
+background process.
+
+### 3. `optimize results <id> --json`
+
+Returns the complete result digest after job completion:
+
+```json
+{
+  "job": { "id": "...", "status": "completed", ... },
+  "prompt": { ... },
+  "scorecard": {
+    "rendered": "<ASCII scorecard string>",
+    "data": [ ...ScorecardData[] ]
+  }
+}
+```
+
+The `scorecard.data` array contains one entry per completed iteration in
+chronological order. `scorecard.rendered` is the ASCII terminal render of the
+final iteration (same bytes as the terminal output), included as a convenience
+for agents that want to surface a human-readable summary without re-rendering.
+
+---
+
+## `ScorecardData` shape
+
+The optimizer emits this shape on each iteration (TypeScript):
+
+```typescript
+interface ScorecardData {
+  jobId: string;
+  iteration: number;
+  totalIterations: number | null;  // null when maxIterations not configured
+  timestamp: string;               // ISO-8601
+  stage: string;                   // always "result-analysis" for completed iterations
+
+  scores: {
+    bestScore: number;             // highest score seen across all iterations so far
+    currentScore: number;          // score for this iteration
+    targetScore: number | null;    // convergence threshold; null if not set
+  };
+
+  criteria: Array<{
+    name: string;                  // criterion name from the evaluation rubric
+    scoreAvg: number;              // mean LLM score for this criterion this iteration
+    passRate: number;              // fraction of dataset items passing (0.0–1.0)
+  }>;
+
+  costs: {
+    iterationUsd: number;          // LLM cost for this iteration only
+    cumulativeUsd: number;         // total cost from job start through this iteration
+  };
+
+  durations: {
+    iterationMs: number;           // wall-clock duration of this iteration
+    stageBreakdown: Record<string, number>; // token counts keyed by stage name
+  };
+
+  nextAction:
+    | 'continue'          // optimizer will run another iteration
+    | 'stop-converged'    // currentScore >= targetScore
+    | 'stop-budget'       // cost or token budget exhausted
+    | 'stop-stagnation'   // stagnationCount >= patience threshold
+    | 'stop-max-iter';    // iteration count reached maxIterations
+}
+```
+
+Key fields at a glance:
+
+| Field | Why it matters |
+|---|---|
+| `scores.bestScore` | The best the optimizer has achieved — compare to `targetScore` to estimate progress |
+| `scores.currentScore` | This iteration's score — use to detect regressions |
+| `scores.targetScore` | Convergence threshold; `null` means run until `maxIterations` |
+| `criteria[].passRate` | Per-criterion health — values below `0.5` flag a specific rubric as blocking |
+| `costs.cumulativeUsd` | Running cost — gate against any user-approved budget |
+| `nextAction` | The optimizer's own routing decision — surface `stop-stagnation` proactively |
+
+---
+
+## How an agent should use it
+
+### Per-iteration monitoring (streaming)
+
+While consuming `optimize start --watch --json` or `optimize watch <id> --json`:
+
+1. **Score trend** — compare `scores.currentScore` against the previous
+   iteration's `currentScore`. A sustained downward trend (3+ iterations)
+   warrants surfacing to the user before the budget is spent.
+
+2. **`nextAction` gate** — if `nextAction === "stop-stagnation"`, the optimizer
+   has detected a plateau and is about to halt. Surface this to the user with
+   the current `scores.bestScore` and `costs.cumulativeUsd` so they can decide
+   whether to continue with a higher patience budget or accept the result.
+
+3. **Cost gate** — if `costs.cumulativeUsd` crosses a threshold the user
+   approved for, alert immediately. The optimizer does not know about
+   user-defined soft budgets; the agent is the enforcement layer.
+
+### Post-hoc analysis (`optimize results`)
+
+1. **Criterion drill-down** — iterate `scorecard.data` (all iterations) and
+   collect `criteria[].passRate` per criterion. Any criterion with a mean
+   `passRate < 0.5` across iterations did not benefit from optimization and
+   should be flagged back to the user as potentially mis-specified or
+   conflicting with another criterion.
+
+2. **Best-iteration identification** — find the entry where
+   `scores.currentScore === Math.max(...data.map(d => d.scores.currentScore))`.
+   This is the iteration the optimizer treats as `bestIteration`. Compare its
+   `criteria` snapshot to the final iteration to detect regressions in
+   individual rubrics even when the composite score improved.
+
+3. **Cost/iteration trade-off** — divide `costs.cumulativeUsd` by
+   `iteration` to get average cost per iteration. Present this when asking the
+   user whether to re-run with more iterations.
+
+---
+
+## Parsing example
+
+Minimal Node.js / Bun snippet — consume NDJSON from `optimize start --watch --json`
+and branch on `nextAction`:
+
+```js
+import { spawn } from 'node:child_process';
+import * as readline from 'node:readline';
+
+const proc = spawn('mutagent', ['optimize', 'start', JOB_ID, '--watch', '--json']);
+const rl = readline.createInterface({ input: proc.stdout });
+
+rl.on('line', (line) => {
+  let event;
+  try { event = JSON.parse(line); } catch { return; }
+  if (event.type !== 'scorecard.update') return;
+
+  const { scorecard } = event;
+  const { scores, costs, criteria, nextAction } = scorecard;
+
+  console.log(`Iter ${scorecard.iteration}: score=${scores.currentScore.toFixed(3)} cost=$${costs.cumulativeUsd.toFixed(4)}`);
+
+  if (nextAction === 'stop-stagnation') {
+    // Surface to user — optimizer is about to halt without converging
+    console.warn(`[ALERT] Optimizer stagnated at score ${scores.bestScore}. Consider raising patience.`);
+  }
+
+  const weakCriteria = criteria.filter(c => c.passRate < 0.5).map(c => c.name);
+  if (weakCriteria.length > 0) {
+    console.warn(`[ALERT] Low-pass criteria: ${weakCriteria.join(', ')}`);
+  }
+});
+```
+
+---
+
+## Cross-references
+
+- [concepts/eval-criteria.md](./eval-criteria.md) — how evaluation criteria are
+  defined; `criteria[].name` in `ScorecardData` maps to `name` in the rubric.
+- [workflows/optimization.md](../workflows/optimization.md) — full optimization
+  loop; the scorecard is produced at Step 8 (watch) and Step 9 (results).
+
+---
+
+## CLI commands
+
+```bash
+# Discovery (no LLM cost)
+mutagent prompts optimize --help                                # list optimize subcommands
+mutagent prompts optimize start --help                          # read flags before first use (Rule 2)
+
+# 💰 LLM COST -- requires usage check (Rule 5) + provider catalog check (Rule 6)
+mutagent prompts optimize start <id> --dataset <d> --evaluation <e> --json
+                                                                # start job (cost = exec_model × items × iterations
+                                                                # + judge_model × items × iterations)
+mutagent prompts optimize start <id> --dataset <d> --evaluation <e> --watch --json
+                                                                # start + stream NDJSON events to stdout
+
+# Polling / watching (no LLM cost; just reads job state)
+mutagent prompts optimize status <job-id> --json                # poll progress snapshot (includes bestScore)
+mutagent prompts optimize watch <job-id> --json                 # attach to running job (NDJSON stream)
+mutagent prompts optimize results <job-id> --json               # full scorecard after completion (emits verbatim card)
+mutagent prompts optimize results <job-id> --diff --json        # view prompt diff (no apply)
+
+# Mutation (no LLM cost itself; modifies stored prompt)
+mutagent prompts optimize results <job-id> --apply --json       # apply optimized prompt -> updates stored version
+                                                                # (irreversible without manual revert via prompts update)
+```
+
+**Flag glossary** (optimize-specific):
+- `--dataset <d>` -- dataset ID (from `prompts dataset list`). Items run through both exec and judge models.
+- `--evaluation <e>` -- evaluation ID (from `prompts evaluation list`). Drives the judge model's scoring rubric.
+- `--watch` -- after start, stream NDJSON events instead of returning immediately. Equivalent to `start` then `watch`.
+- `--max-iterations N` -- bound the optimizer loop. **Defaults to 1**; never raise without explicit user consent (each iteration = full eval × dataset round-trip).
+- `--exec-model <model>` / `--eval-model <model>` -- override defaults. Validate first via `mutagent providers list --models --json` (Rule 6).
+- `--apply` -- write optimized prompt back to stored version. Cannot be undone via flag; use `prompts update` to revert.
+- `--diff` -- view before/after diff without applying.
+- `--json` -- structured output (Rule 1: always use). Returns `_directive` + `_links` + `_compat`.
+
+**Cost note**: `optimize start` is the ONLY cost-incurring command in this family. Always run `mutagent usage --json` first (Rule 5) to surface remaining quota; show the result to the user; require explicit confirmation. The `--max-iterations` default of 1 keeps cost bounded.
+
+**Verbatim card protocol**: `optimize start`, `optimize status`, and `optimize results` all emit `_directive.renderedCard` -- the agent MUST echo the rendered card verbatim into chat before any next action (per SKILL.md § "MANDATORY: Verbatim Card Display Protocol"). The card also auto-echoes to stderr via `echoDirectiveToStderr`, but bash blocks may be collapsed in the user's UI.

--- a/plugins/mutagent/skills/mutagent-cli/references/workflows/agents.md
+++ b/plugins/mutagent/skills/mutagent-cli/references/workflows/agents.md
@@ -1,0 +1,158 @@
+---
+name: mutagent-cli-workflows-agents
+description: |
+  Agent path (multi-turn, tool-calling) — WORK IN PROGRESS.
+  Agent optimization & evaluation are actively in development.
+  This workflow short-circuits to a partnership link, offers read-only CRUD,
+  and optionally extracts a sub-prompt back to the Optimization path.
+triggers:
+  - "agent"
+  - "langchain agent"
+  - "langgraph"
+  - "crewai"
+  - "autogen"
+  - "openai agents"
+  - "tool calling"
+  - "multi-turn"
+  - "AgentExecutor"
+  - "createReactAgent"
+  - "StateGraph"
+---
+
+# Workflow — Agents (WIP)
+
+> **This path is WORK IN PROGRESS.** Agent optimization and evaluation are
+> actively in development. Do NOT run a multi-turn agent through the prompt
+> optimizer — the platform will reject it, and scores would be meaningless for
+> a tool-calling loop.
+
+Read the **5 rules** in [SKILL.md](../../SKILL.md) before executing.
+
+---
+
+## When this workflow applies
+
+Load this file when the journey router in [SKILL.md](../../SKILL.md) matched one of these
+signals in the user's code:
+
+- `AgentExecutor`, `createReactAgent`, `createToolCallingAgent`, `createStructuredChatAgent`
+- `from "openai/agents"` or `from "@openai/agents"`
+- `from "crewai"`, `from "autogen"`, `from "autogen_agentchat"`
+- `from "@langchain/langgraph"`, `StateGraph(`
+- `tool_calls` / `toolCalls` property access
+- `@tool` decorator (Python)
+- `tools: [...]` array in an LLM call config
+- `function_call` / `tool_choice` fields
+- `while` loop + LLM call
+
+`mutagent explore --json` flags these under `agents[]` (not `prompts[]`).
+
+---
+
+## Required card (show this verbatim to the user)
+
+When the agent path is triggered, copy this card into your chat response
+verbatim — do NOT paraphrase, do NOT collapse into a bash block:
+
+```
+I see you have an Agent (multi-turn / tool-calling). Agent Optimization &
+Evaluations are actively in development in MutagenT. For early access and
+to partner with us on the roadmap:
+→ https://www.mutagent.io/agents-partnership
+```
+
+---
+
+## Sequence
+
+```
+1. Run `mutagent explore --json` if you haven't already.
+   → Confirm agents[] is non-empty.
+   → Show command output to user.
+
+2. Show the WIP card above verbatim in your chat response.
+
+3. Use AskUserQuestion to explain that agent code cannot be directly optimized:
+   "Your code looks like a multi-turn agent. I can't run it
+   through the prompt optimizer yet. Would you like to:
+   (a) Join early access → https://www.mutagent.io/agents-partnership
+   (b) Inspect existing agents in MutagenT (read-only CRUD)
+   (c) Extract a single sub-prompt inside the agent loop and optimize it"
+
+4. Branch:
+   (a) → surface the URL verbatim. STOP.
+   (b) → `mutagent agents list --json` ; `mutagent agents get <id> --json`
+          → show results to user. STOP (no mutations available).
+   (c) → extract one sub-prompt, then route to [workflows/optimization.md](./optimization.md)
+          treating the sub-prompt as a standalone Prompt.
+```
+
+---
+
+## Branch (c) — extracting a sub-prompt
+
+Multi-turn agents often contain inner prompts that ARE suitable for the
+Optimization path:
+
+- a planner prompt ("given this user goal, list the tools you'd call")
+- a summarizer prompt ("given these tool results, write the final answer")
+- a classifier prompt ("which tool should handle this input?")
+
+Each of these is a single-shot prompt with a clear output schema. Extract ONE,
+treat it as a standalone Prompt.
+
+When extracting:
+1. Identify the exact string literal or template that becomes the sub-prompt.
+2. Enumerate its `{variables}` per [concepts/prompt-variables.md](../concepts/prompt-variables.md).
+3. Confirm with user: "I'll optimize the planner prompt only, not the full agent. Sound right?"
+4. On confirmation → load [workflows/optimization.md](./optimization.md) from step 3 (prompts create).
+
+Do NOT try to extract the whole agent loop at once.
+
+---
+
+## What NOT to do
+
+- **Do not** call `mutagent prompts optimize start` on an agent file.
+- **Do not** upload an agent's full system prompt + tool definitions as a single "prompt".
+- **Do not** suggest "try it anyway" — the WIP status is deliberate.
+- **Do not** skip showing the WIP card to the user — they need the partnership URL.
+
+---
+
+## CLI commands
+
+```bash
+# Discovery (no LLM cost, read-only)
+mutagent explore --json                                # detect agents[] in codebase via taxonomy classifier
+mutagent agents --help                                 # list available agent subcommands (CRUD + WIP banner)
+mutagent agents list --json                            # CRUD: list registered agents
+mutagent agents get <id> --json                        # CRUD: inspect single agent (config + metadata)
+
+# Mutations (no LLM cost; just storage)
+mutagent agents create --name "<name>" --json          # register a new agent
+mutagent agents update <id> --json                     # update agent config
+mutagent agents delete <id> --json                     # delete agent (idempotent; --force skips confirm)
+
+# NOT YET AVAILABLE -- shows AGENTS_WIP_BANNER if attempted
+mutagent agents optimize <id>                          # WIP -- tracked separately; see partnership link below
+```
+
+**Flag glossary** (agent-specific):
+- `--name "<name>"` -- human-readable label (shows in dashboard).
+- `--force` -- skip interactive confirmation on delete (auto-skipped in `--json` mode).
+- `--json` -- structured output (Rule 1: always use). Returns `_directive` (status_card) + `_links` + `_compat`.
+
+**Cost note**: all current `mutagent agents *` commands are CRUD (zero LLM cost). Agent optimization (`mutagent agents optimize`) is NOT yet available -- when shipped it will incur LLM cost similar to `prompts optimize start`. Current behavior on `mutagent agents optimize`: returns `AGENTS_WIP_BANNER` directive pointing to the partnership link.
+
+**Partnership link**: <https://www.mutagent.io/agents-partnership> -- for early access to multi-turn / tool-calling agent optimization.
+
+---
+
+## Cross-references
+
+- [SKILL.md](../../SKILL.md) → 5 rules + journey router
+- [workflows/exploration.md](./exploration.md) → where `agents[]` entries are first detected
+- [workflows/optimization.md](./optimization.md) → branch (c) destination
+- [concepts/prompt-variables.md](../concepts/prompt-variables.md) → `{foo}` vs `{{foo}}` for sub-prompt extraction
+- Partnership link: https://www.mutagent.io/agents-partnership

--- a/plugins/mutagent/skills/mutagent-cli/references/workflows/dataset-curation.md
+++ b/plugins/mutagent/skills/mutagent-cli/references/workflows/dataset-curation.md
@@ -1,0 +1,193 @@
+---
+name: mutagent-cli-workflows-dataset-curation
+description: |
+  Standalone dataset curation workflow. Use when the user wants to create
+  or expand a dataset WITHOUT running the full optimization loop.
+  Covers guided and manual dataset creation, per-field question collection,
+  hard-cases-first priority, and upload via CLI.
+  Cross-linked from workflows/optimization.md dataset step.
+triggers:
+  - "create dataset"
+  - "add examples"
+  - "test cases"
+  - "edge cases"
+  - "hard cases"
+  - "expand dataset"
+  - "dataset items"
+  - "curate dataset"
+  - "build dataset"
+  - "dataset curation"
+---
+
+# Workflow -- Dataset Curation (Standalone)
+
+> **When to use this workflow vs optimization.md**:
+>
+> Use THIS workflow when the user wants ONLY to create or expand a dataset,
+> without immediately running optimization. Common signals:
+> - "I want to add more test cases"
+> - "Let's build a dataset for this prompt"
+> - "Add some edge cases"
+> - "Expand the existing dataset"
+>
+> Use [workflows/optimization.md](./optimization.md) when the user wants the
+> full loop: create prompt -> dataset -> eval -> optimize. That workflow has
+> an inline dataset step that cross-links back here.
+
+Read the **5 rules** in [SKILL.md](../../SKILL.md) before executing.
+
+---
+
+## When this workflow applies
+
+- User explicitly wants to curate/build a dataset (no immediate optimization intent)
+- User wants to add hard cases / edge cases to an existing dataset
+- User wants to understand what good dataset items look like before committing to optimization
+- User has a prompt uploaded already and wants to build test coverage
+
+---
+
+## Required pre-read
+
+Load [concepts/dataset-design.md](../concepts/dataset-design.md) before collecting items.
+It defines:
+- The Golden Rule (hard cases first)
+- 4 case categories (Edge / Hard / Representative / Adversarial)
+- Format requirements (`input` + `expectedOutput` shape)
+- Anti-patterns to avoid
+
+The CLI's `--guided` directive also contains a self-sufficient inline version of these
+rules in `_directive.instruction` -- safe to execute even without the Skill loaded.
+
+---
+
+## Workflow steps
+
+```
+1. mutagent explore --json
+   -> confirm which prompt you're building a dataset for
+   -> show command output to user
+   -> ask: "Which prompt would you like to build a dataset for?"
+
+2. mutagent prompts get <prompt-id> --json
+   -> inspect inputSchema + outputSchema fields
+   -> understand what input and output shapes look like
+
+3. mutagent prompts dataset add --help
+   -> read flags (Rule 2: always --help before first use)
+
+4. mutagent prompts dataset add <prompt-id> --guided --json
+   -> CLI returns _directive.askUserQuestions with per-field questions
+   -> follow the instruction in _directive.instruction
+
+5. For EACH question in _directive.askUserQuestions:
+   -> use AskUserQuestion to collect the answer from the user
+   -> prioritize hard/edge case questions first (they come first in the list)
+   -> do NOT skip any question
+   -> do NOT auto-fill answers
+
+6. Construct dataset items from collected answers:
+   -> format: [{"input": {...}, "expectedOutput": {...}}, ...]
+   -> minimum 5 items; at least 2 must be hard/edge cases
+   -> verify all input keys match promptSchema.inputSchema.properties
+   -> verify all expectedOutput keys match promptSchema.outputSchema.properties
+
+7. Ask user to review the constructed items before upload:
+   "Here are the 7 dataset items I constructed. Review them before upload?"
+   -> show items in a readable format
+   -> accept corrections
+
+8. mutagent prompts dataset add <prompt-id> -d '[...]' --name "<name>" --json
+   -> upload the reviewed items
+   -> show command output to user (confirm datasetId)
+   -> record datasetId in .mutagent/mutation-context.md
+
+9. Ask: "What would you like to do next?"
+   -> Option A: Add more items (loop back to step 4)
+   -> Option B: Create an evaluation -> route to evaluation create --guided
+   -> Option C: Start optimization -> route to workflows/optimization.md step 10
+   -> Option D: Done
+```
+
+---
+
+## Guided mode output shape
+
+`mutagent prompts dataset add <prompt-id> --guided --json` returns:
+
+```json
+{
+  "promptId": "...",
+  "promptName": "...",
+  "schemaFields": { "input": ["field1", "field2"], "output": ["result"] },
+  "suggestedCategories": [
+    { "name": "Edge Cases", "description": "...", "priority": "high" },
+    { "name": "Hard Cases", "description": "...", "priority": "high" },
+    { "name": "Representative Cases", "description": "...", "priority": "medium" }
+  ],
+  "templateItem": {
+    "input": { "field1": "<value>", "field2": "<value>" },
+    "expectedOutput": { "result": "<expected>" }
+  },
+  "guidance": {
+    "minItems": 5,
+    "priorityRule": "Hard cases that expose prompt weaknesses > easy cases that always pass",
+    "steps": [...]
+  },
+  "_directive": {
+    "instruction": "...",   // self-sufficient conceptual rules (bootstrappable without Skill)
+    "next": ["mutagent prompts dataset add <id> -d '<json>' --name '<name>' --json"],
+    "askUserQuestions": [   // inside _directive (not a sibling)
+      { "field": "_general", "question": "What are the hardest inputs for this prompt?" },
+      { "field": "_edge_cases", "question": "What edge cases have caused failures?" },
+      { "field": "field1", "source": "inputSchema", "question": "What values should "field1" have?" },
+      ...
+    ]
+  },
+  "_compat": { "cliVersion": "...", "skillVersion": "...", "skillMinCliVersion": "..." }
+}
+```
+
+Key: `askUserQuestions` is inside `_directive` (not a top-level sibling). Parse `_directive.askUserQuestions`.
+
+---
+
+## Cost control
+
+Dataset curation has NO LLM cost on its own -- it's a pure storage operation.
+Only `mutagent prompts optimize start` incurs LLM cost. Safe to run freely.
+
+---
+
+## Common pitfalls
+
+For the canonical anti-pattern list (WHY each is bad + how to fix), see [concepts/dataset-design.md](../concepts/dataset-design.md) § Anti-patterns. Workflow-specific execution mistakes:
+
+- **Uploading items with wrong field names** -> schema mismatch error from optimizer (not caught by concept-level rules)
+- **Forgetting to ask the user to review before upload** -> user can't correct mistakes (workflow step 7)
+- **Skipping the explore step** -> uploading to the wrong prompt (workflow step 1)
+
+---
+
+## Cross-references
+
+- [SKILL.md](../../SKILL.md) -- 5 rules + journey router
+- [concepts/dataset-design.md](../concepts/dataset-design.md) -- Golden Rule, case categories, format requirements, anti-patterns (WHY; this file is HOW)
+- [workflows/optimization.md](./optimization.md) -- full loop; dataset step cross-links here
+- [workflows/eval-creation.md](./eval-creation.md) -- parallel workflow doc (for evaluation side)
+- [concepts/prompt-variables.md](../concepts/prompt-variables.md) -- brace convention (for input field values)
+
+---
+
+## CLI commands
+
+```bash
+# Workflow execution sequence (commands appear inline in steps above; this is a quick reference)
+mutagent explore --json                                            # step 1: discover prompts
+mutagent prompts get <prompt-id> --json                            # step 2: inspect schemas
+mutagent prompts dataset add --help                                # step 3: read flags (Rule 2)
+mutagent prompts dataset add <prompt-id> --guided --json           # step 4: get _directive.askUserQuestions
+mutagent prompts dataset add <prompt-id> -d '<json>' --name "<name>" --json  # step 8: upload reviewed items
+```
+
+For the full flag glossary + cost notes, see [concepts/dataset-design.md](../concepts/dataset-design.md) § CLI commands.

--- a/plugins/mutagent/skills/mutagent-cli/references/workflows/eval-creation.md
+++ b/plugins/mutagent/skills/mutagent-cli/references/workflows/eval-creation.md
@@ -1,0 +1,207 @@
+---
+name: mutagent-cli-workflows-eval-creation
+description: |
+  Standalone evaluation rubric creation workflow. Use when the user wants to
+  define eval criteria for a prompt WITHOUT immediately running optimization.
+  Covers guided per-field rubric collection (INPUT MVC + OUTPUT Standards),
+  full-depth granular rubrics, and upload via CLI.
+  Cross-linked from workflows/optimization.md eval step.
+triggers:
+  - "create evaluation"
+  - "create rubric"
+  - "evaluate prompt"
+  - "evaluation criteria"
+  - "rubric design"
+  - "MVC"
+  - "Output Standards"
+  - "score this prompt"
+  - "judge this prompt"
+  - "eval guided"
+---
+
+# Workflow -- Evaluation Creation (Standalone)
+
+> **When to use this workflow vs optimization.md**:
+>
+> Use THIS workflow when the user wants ONLY to define an evaluation rubric for
+> a prompt, without immediately running optimization. Common signals:
+> - "I want to score this prompt"
+> - "Let's define eval criteria for this prompt"
+> - "Create a rubric for this prompt"
+> - "How should we judge this prompt's outputs?"
+>
+> Use [workflows/optimization.md](./optimization.md) when the user wants the
+> full loop: create prompt -> dataset -> eval -> optimize. That workflow has
+> an inline eval step that cross-links back here.
+
+Read the **5 rules** in [SKILL.md](../../SKILL.md) before executing.
+
+---
+
+## When this workflow applies
+
+- User explicitly wants to create or edit an evaluation rubric (no immediate optimization intent)
+- User wants to add criteria to an existing prompt (with or without an existing dataset)
+- User wants to understand how rubric design works before committing to optimization
+- User has a prompt uploaded already and wants quality scoring before iteration
+
+---
+
+## Required pre-read
+
+Load [concepts/eval-criteria.md](../concepts/eval-criteria.md) before collecting criteria.
+It defines:
+- The Golden Rule (INPUT MVC vs OUTPUT Standards split)
+- 6-tier MVC anchor framework for INPUT-scoped criteria
+- Output Standards format for OUTPUT-scoped criteria
+- Format requirements (`name`, `description`, `evaluationParameter`)
+- Anti-patterns to avoid
+
+The CLI's `--guided` directive also contains a self-sufficient inline version of these
+rules in `_directive.instruction` -- safe to execute even without the Skill loaded.
+
+---
+
+## Workflow steps
+
+```
+1. mutagent explore --json
+   -> confirm which prompt you're creating an evaluation for
+   -> show command output to user
+   -> ask: "Which prompt would you like to evaluate?"
+
+2. mutagent prompts get <prompt-id> --json
+   -> inspect inputSchema + outputSchema fields
+   -> understand what input parameters and output shape look like
+   -> these drive the per-field rubric collection in step 4
+
+3. mutagent prompts evaluation create --help
+   -> read flags (Rule 2: always --help before first use)
+
+4. mutagent prompts evaluation create <prompt-id> --guided --json
+   -> CLI returns _directive.askUserQuestions with per-field questions
+   -> follow the instruction in _directive.instruction
+   -> the instruction inlines the INPUT MVC vs OUTPUT Standards framing
+      (bootstrappable -- works even if concepts/eval-criteria.md isn't loaded)
+
+5. For EACH question in _directive.askUserQuestions:
+   -> use AskUserQuestion to collect the answer from the user
+   -> INPUT-scoped fields (source: "inputSchema") -> ask MVC rubric:
+      what's minimum viable context the input MUST contain?
+   -> OUTPUT-scoped fields (source: "outputSchema") -> ask Output Standards:
+      what does correct vs incorrect look like for this field?
+   -> do NOT skip any field
+   -> do NOT auto-fill answers (Rule 3: never auto-generate criteria)
+
+6. Construct rubric items from collected answers:
+   -> format: [{"name": "...", "description": "...", "evaluationParameter": "..."}, ...]
+   -> one rubric per schema field unless user opts to merge fields
+   -> use 6-tier full-depth descriptions for complex INPUT criteria
+      (see concepts/eval-criteria.md for examples)
+   -> use simpler 2-3-tier descriptions for OUTPUT correctness criteria
+
+7. Ask user to review the constructed criteria before upload:
+   "Here are the N evaluation criteria I drafted. Review before upload?"
+   -> show criteria in a readable format (table or numbered list)
+   -> accept corrections; loop step 5-7 if user wants edits
+
+8. mutagent prompts evaluation create <prompt-id> -d '<json>' --name "<name>" --json
+   -> upload the reviewed criteria
+   -> show command output to user (confirm evaluationId)
+   -> record evaluationId in .mutagent/mutation-context.md
+
+9. Ask: "What would you like to do next?"
+   -> Option A: Add more criteria (loop back to step 4)
+   -> Option B: Add a dataset -> route to workflows/dataset-curation.md
+   -> Option C: Start optimization -> route to workflows/optimization.md step 10
+   -> Option D: Done
+```
+
+---
+
+## Guided mode output shape
+
+`mutagent prompts evaluation create <prompt-id> --guided --json` returns:
+
+```json
+{
+  "promptId": "...",
+  "promptName": "...",
+  "schemaFields": { "input": ["field1", "field2"], "output": ["result"] },
+  "_directive": {
+    "instruction": "...",   // self-sufficient INPUT MVC + OUTPUT Standards rules (bootstrappable)
+    "next": ["mutagent prompts evaluation create <id> -d '<json>' --name '<name>' --json"],
+    "decisionTree": {
+      "step1": "Confirm input parameters with the user via _directive.askUserQuestions...",
+      "step2": "Define correctness criteria for EVERY field..."
+    },
+    "askUserQuestions": [   // inside _directive (not a sibling)
+      { "field": "field1", "source": "inputSchema", "question": "What MVC anchors define minimum viable context for 'field1'?" },
+      { "field": "result", "source": "outputSchema", "question": "What does a correct 'result' look like vs incorrect?" },
+      ...
+    ]
+  },
+  "_compat": { "cliVersion": "...", "skillVersion": "...", "skillMinCliVersion": "..." }
+}
+```
+
+Key: `askUserQuestions` is inside `_directive` (not a top-level sibling). Parse `_directive.askUserQuestions`. The `decisionTree` field guides multi-step branching.
+
+---
+
+## Cost control
+
+Eval creation has NO LLM cost on its own -- it's a pure storage operation.
+Only `mutagent prompts optimize start` incurs LLM cost (judge model + exec model
+multiplied by dataset items × iterations). Safe to create/edit eval criteria freely.
+
+---
+
+## Common pitfalls
+
+For the canonical anti-pattern list, see [concepts/eval-criteria.md](../concepts/eval-criteria.md) § Anti-patterns. Workflow-specific execution mistakes:
+
+- **Skipping per-field collection** -> rubric incomplete; optimizer scores against a sparse signal
+- **Auto-filling answers from context** instead of asking user -> rubric reflects the agent's assumptions, not the user's domain knowledge (Rule 3 violation)
+- **Merging input + output criteria into one** -> loses INPUT MVC vs OUTPUT Standards distinction; harder to interpret per-criterion scores
+- **Uploading without user review** -> user can't catch misinterpretations of their domain
+- **Wrong `evaluationParameter` value** -> server rejects with schema validation error
+
+---
+
+## Cross-references
+
+- [SKILL.md](../../SKILL.md) -- 5 rules + journey router
+- [concepts/eval-criteria.md](../concepts/eval-criteria.md) -- Golden Rule, MVC/Output Standards, format requirements, anti-patterns
+- [workflows/optimization.md](./optimization.md) -- full loop; eval step cross-links here
+- [workflows/dataset-curation.md](./dataset-curation.md) -- parallel workflow doc (for dataset side)
+- [concepts/scorecard-output.md](../concepts/scorecard-output.md) -- how eval scores surface in optimization scorecard
+
+---
+
+## CLI commands
+
+```bash
+# Discovery (no LLM cost)
+mutagent prompts evaluation --help                                 # list eval subcommands
+mutagent prompts evaluation create --help                          # read flags before first use (Rule 2)
+mutagent prompts evaluation list <prompt-id> --json                # list existing evaluations on a prompt
+mutagent prompts evaluation get <eval-id> --json                   # inspect single evaluation's criteria + metadata
+
+# Creation -- guided (no LLM cost; just storage)
+mutagent prompts evaluation create <prompt-id> --guided --json     # get _directive.askUserQuestions + decisionTree (per-field collection)
+mutagent prompts evaluation create <prompt-id> -d '<json>' --name "<name>" --json  # upload criteria
+                                                                   # -d accepts inline JSON OR @path/to/file.json OR - (stdin)
+
+# Mutations
+mutagent prompts evaluation update <eval-id> -d '<json>' --json    # update existing criteria
+mutagent prompts evaluation delete <eval-id> --json                # delete evaluation (idempotent; --force skips confirm)
+```
+
+**Flag glossary** (eval-specific):
+- `--guided` -- emit per-field `askUserQuestions` directive instead of expecting `-d` upfront. Use when collecting from user.
+- `-d <json>` / `--data <json>` -- supply criteria payload inline. Accepts: inline JSON, `@path` (read from file), `-` (read from stdin).
+- `--name "<name>"` -- human-readable label for the evaluation (shows in dashboard).
+- `--json` -- structured output (Rule 1: always use). Returns `_directive` + `_links`.
+
+**Cost note**: eval creation/edit/delete commands incur ZERO LLM cost. They are pure storage operations against the platform API. LLM cost is only incurred when `mutagent prompts optimize start` runs the judge model against this evaluation.

--- a/plugins/mutagent/skills/mutagent-cli/references/workflows/exploration.md
+++ b/plugins/mutagent/skills/mutagent-cli/references/workflows/exploration.md
@@ -1,0 +1,161 @@
+---
+name: mutagent-cli-workflows-exploration
+description: |
+  Read-only codebase scan workflow. Discovers prompts and agents, classifies
+  each as optimization-eligible (prompt) or WIP (agent), and presents a
+  structured taxonomy to the user before any write operations.
+triggers:
+  - "explore"
+  - "scan codebase"
+  - "find prompts"
+  - "what prompts do I have"
+  - "discover prompts"
+  - "what's in my codebase"
+---
+
+# Workflow — Exploration (Read-Only Discovery)
+
+> **This workflow is read-only.** No writes, no uploads, no mutations.
+> Use it to understand what's in the codebase before deciding next steps.
+
+Read the **5 rules** in [SKILL.md](../../SKILL.md) before executing. Key reminders:
+- `--json` on every command
+- `<command> --help` before first use
+- This workflow ends with a user question — never auto-proceed to writes
+
+---
+
+## When this workflow applies
+
+- User said "explore my codebase", "what prompts do I have", "find prompts", "scan"
+- Intent is unclear and you need to discover before acting
+- User wants to understand what's optimizable before committing to a path
+
+---
+
+## Prompt vs Agent — taxonomy
+
+Before running explore, understand what the CLI will return:
+
+**PROMPT (optimization-eligible)**
+- Single LLM call: input → LLM → output
+- Template with `{variables}` (single) or `{{variables}}` (double brace)
+- Can be evaluated with G-Eval (input/output pair)
+- Can be optimized by Metatuner
+- Appears in `prompts[]` in explore output
+
+**AGENT (NOT directly optimizable)**
+- Multi-turn loop: input → LLM → tool → LLM → ... → output
+- Dynamic branching execution
+- Cannot be optimized like a prompt (no fixed output schema)
+- Requires agent-level evaluation (not yet available)
+- Appears in `agents[]` in explore output
+
+### Agent detection heuristics (what `mutagent explore` flags)
+
+| Pattern | Framework | Classification |
+|---|---|---|
+| `new StateGraph(` / `StateGraph.compile()` | LangGraph | agent |
+| `new Agent(` / `agent.execute()` | Mastra / custom | agent |
+| `AgentExecutor` / `createReactAgent` / `createToolCallingAgent` | LangChain | agent |
+| `from "openai/agents"` / `from "@openai/agents"` | OpenAI Agents SDK | agent |
+| `from "crewai"` / `from "autogen"` | CrewAI / AutoGen | agent |
+| `tools: [...]` + LLM call in a loop | custom | agent |
+| `while` loop + LLM call | custom agent loop | agent |
+| `@tool` decorator (Python) | any | agent |
+| `tool_calls` / `toolCalls` property access | any | agent |
+| Single `openai.chat()` or template string | — | prompt |
+| String with `{variable}` / `{{variable}}` | — | prompt |
+
+---
+
+## Workflow steps
+
+```
+1. mutagent explore --json
+   → quick regex scan: surfaces prompts[], agents[], datasets[], markers[]
+   → this is a STARTING POINT, not the final answer
+
+1b. Use your own Explore/Read/Grep tools to VERIFY each candidate:
+   → Read the actual file — is it really a prompt template or just a string?
+   → Check imports — does it use langchain, openai, @ai-sdk, mastra?
+   → Follow the call chain — single LLM call (prompt) or loop with tools (agent)?
+   → The CLI scan is fast but fragile (regex-based). Your tools understand code.
+
+2. Classify verified results:
+   - prompts[]  → optimization-eligible (single-shot, output schema)
+   - agents[]   → WIP (multi-turn/tool-calling) — route to [workflows/agents.md](./agents.md)
+   - datasets[] → existing local data (uploadable in optimization workflow)
+   - markers[]  → already-uploaded items (show dashboard links)
+
+3. Note the `delimiter` field on each prompt entry:
+   - "single" → {variable} — MutagenT native, no conversion needed
+   - "double" → {{variable}} — framework template, conversion required on upload
+   See [concepts/prompt-variables.md](../concepts/prompt-variables.md) for the conversion rules.
+
+4. Use AskUserQuestion to present findings and ask which prompts to upload:
+   "Here's what I found in your codebase:
+    - N prompt(s) found: [list files]
+    - N agent(s) found: [list files] (WIP — not optimizable yet)
+    - N dataset(s) found: [list]
+    - N already-uploaded: [list]
+    What would you like to do?"
+
+5. Route based on user answer:
+   - "optimize this prompt" → load [workflows/optimization.md](./optimization.md)
+   - "add tracing" → load [workflows/tracing.md](./tracing.md)
+   - "tell me about the agent" → load [workflows/agents.md](./agents.md)
+   - "nothing yet" → STOP (read-only complete)
+```
+
+---
+
+## Output handling
+
+After step 1, show the command output to the user before proceeding to classification. Do NOT proceed to step 2 until the user has seen the results.
+
+---
+
+## Brace convention note
+
+`mutagent explore --json` surfaces `delimiter: "single" | "double"` per discovered prompt. Use this before deciding how to enumerate variables. See [concepts/prompt-variables.md](../concepts/prompt-variables.md) for the full inference contract and conversion rules.
+
+---
+
+## Common pitfalls
+
+- Skipping the classification step → user gets a raw JSON dump instead of a next-action recommendation
+- Treating `agents[]` entries as optimization-eligible → they are NOT; route to [workflows/agents.md](./agents.md)
+- Auto-proceeding to writes after explore → always confirm with user first
+- Ignoring the `delimiter` field → wrong variable enumeration when uploading a double-brace prompt
+
+---
+
+## CLI commands
+
+```bash
+# Discovery -- read-only (no LLM cost)
+mutagent explore --help                                # read flags before first use (Rule 2)
+mutagent explore --json                                # scan cwd for prompts + agents (full scan)
+mutagent explore --path ./src --json                   # scan specific directory subtree
+mutagent explore --markers-only --json                 # show only files with existing .mutagent/* markers
+mutagent explore --classify-only --json                # taxonomy output only (skip variable inference)
+```
+
+**Flag glossary** (explore-specific):
+- `--path <dir>` -- restrict scan to subtree. Useful for monorepos with multiple apps; default is cwd.
+- `--markers-only` -- skip discovery; show only prompts/agents already uploaded (have `.mutagent/*.md` marker file). Use to refresh an existing index.
+- `--classify-only` -- skip per-prompt delimiter inference. Faster scan when you only need the prompts[]/agents[] taxonomy split.
+- `--json` -- structured output (Rule 1: always use). Returns `prompts[]`, `agents[]`, taxonomy, plus per-prompt `delimiter` field.
+
+**Cost note**: `mutagent explore` is fully read-only -- no LLM calls, no platform API mutations. Safe to run repeatedly. The output is a snapshot of cwd at run time; re-run after meaningful code changes.
+
+---
+
+## Cross-references
+
+- [SKILL.md](../../SKILL.md) → 5 rules + journey router
+- [concepts/prompt-variables.md](../concepts/prompt-variables.md) → `{foo}` vs `{{foo}}` inference + conversion
+- [workflows/optimization.md](./optimization.md) → next step after exploration (prompt path)
+- [workflows/tracing.md](./tracing.md) → next step after exploration (integration path)
+- [workflows/agents.md](./agents.md) → next step after exploration (agent path)

--- a/plugins/mutagent/skills/mutagent-cli/references/workflows/optimization.md
+++ b/plugins/mutagent/skills/mutagent-cli/references/workflows/optimization.md
@@ -1,0 +1,268 @@
+---
+name: mutagent-cli-workflows-optimization
+description: |
+  Full prompt optimization journey: explore → prompts create → dataset add →
+  evaluation create (guided) → optimize start → watch/status → results → apply.
+  Enforces 5 rules: --json always, --help before first use, user-collected
+  eval criteria, explore-before-modify, cost transparency before optimize.
+triggers:
+  - "optimize prompt"
+  - "improve prompt"
+  - "tune prompt"
+  - "evaluate prompt"
+  - "upload prompt"
+  - "create evaluation"
+  - "upload dataset"
+  - "run optimizer"
+  - "start optimization"
+---
+
+# Workflow — Optimization (Full Journey)
+
+> **This is the full loop.** Expect 5-10 CLI calls and at least one long-running
+> optimizer job. Each step requires user confirmation. Never auto-run the full
+> chain without presenting findings at each gate.
+
+Read the **5 rules** in [SKILL.md](../../SKILL.md) before executing. All 5 rules apply here:
+- `--json` on every command (Rule 1)
+- `--help` before first use of any command (Rule 2)
+- **NEVER auto-generate eval criteria** — collect from user (Rule 3)
+- `mutagent explore --json` before any write (Rule 4)
+- `mutagent usage --json` before `optimize start` (Rule 5)
+
+---
+
+## When this workflow applies
+
+- User said "optimize prompt", "improve prompt", "tune prompt"
+- User wants to upload a prompt and measure its quality
+- User wants to run the Metatuner optimizer
+
+---
+
+## Required pre-reads (load these before the relevant steps)
+
+| Step | Pre-read | Why |
+|---|---|---|
+| Before `prompts create` | [concepts/prompt-variables.md](../concepts/prompt-variables.md) | Brace convention — single `{var}` vs double `{{var}}` affects how variables are parsed |
+| Before `evaluation create --guided` | [concepts/eval-criteria.md](../concepts/eval-criteria.md) | INPUT MVC + OUTPUT Standards — granular rubric format |
+
+---
+
+## Directive chain
+
+```
+explore → prompts create → dataset add → evaluation create --guided
+  → [Use AskUserQuestion to collect rubrics from the user for each field]
+  → evaluation create -d '<json>'
+  → usage check
+  → [Use AskUserQuestion to confirm optimization cost with user]
+  → optimize start
+  → optimize status (poll)
+  → optimize results
+  → [Use AskUserQuestion to present scorecard: Apply / View Diff / Reject]
+  → On Apply: Edit source file
+```
+
+---
+
+## Full workflow steps
+
+```
+ 1. mutagent explore --json
+    → find candidate prompts in codebase
+    → show command output to user
+    → confirm with user: "Which prompt would you like to optimize?"
+
+ 2. mutagent prompts --help
+    mutagent prompts create --help
+    → read flags before using (Rule 2)
+
+ 3. Load [concepts/prompt-variables.md](../concepts/prompt-variables.md)
+    → determine if prompt uses {single} or {{double}} braces
+    → if double-brace: warn user about conversion requirement
+
+ 4. mutagent prompts create --name <name> [--system-file / --raw-file] --json
+    → show command output to user
+    → record promptId from response
+
+ 5. mutagent prompts dataset add --help
+    → read flags before using
+
+ 6. mutagent prompts dataset add <promptId> -d '[...]' --name "<name>" --json
+    → upload dataset rows (input/output pairs)
+    → show command output to user
+    → record datasetId
+
+ 7. Load [concepts/eval-criteria.md](../concepts/eval-criteria.md)
+    → understand INPUT-param (MVC) vs OUTPUT-param (Standards) scope
+    → for standalone eval-only work outside this optimization context, see
+      [workflows/eval-creation.md](./eval-creation.md) -- this step inlines a brief
+      version of that workflow
+
+ 8. mutagent prompts evaluation create <promptId> --guided --json
+    → the CLI provides a list of fields, each needing a rubric
+    → follow the CLI's next-step guidance in the output
+    → for EVERY field listed (INPUT scope first, then OUTPUT):
+        - ask the user the provided question for that field
+        - wait for user response
+        - do NOT skip any field
+        - do NOT auto-generate any answer
+    → collect at minimum: one INPUT criterion per {variable}, one OUTPUT criterion
+    → for the full step-by-step including review-before-upload + decisionTree handling,
+      see [workflows/eval-creation.md](./eval-creation.md)
+
+ 9. mutagent prompts evaluation create <promptId> -d '<json>' --json
+    → upload the criteria collected in step 8
+    → show command output to user
+    → record evaluationId
+
+10. mutagent usage --json
+    → show usage/quota to user
+    → confirm with user: "This optimization will use N iterations (~X min each).
+       You have Y remaining. Proceed?"
+    → STOP if user declines
+
+11. mutagent prompts optimize start <promptId> \
+      --dataset <datasetId> \
+      --evaluation <evaluationId> \
+      --max-iterations 1 \
+      --json
+    → NEVER set --max-iterations > 1 without explicit user consent
+    → record jobId from response
+
+12. mutagent prompts optimize status <jobId> --json
+    → poll until status = "completed" or "failed"
+    → show progress to user
+
+13. mutagent prompts optimize results <jobId> --json
+    → ALWAYS show before/after scorecard to user
+
+14. Confirm with user: "Here's the before/after scorecard. What would you like to do?
+    (a) Apply — update the prompt in your source file
+    (b) View diff first
+    (c) Reject — keep the original"
+
+15. On Apply (a): Edit the prompt in the user's source file
+    → replace old prompt text with optimized version
+    → if double-brace codebase: convert {variable} back to {{variable}}
+    → confirm with user before saving
+```
+
+---
+
+## Cost control
+
+- Default `--max-iterations 1` is the only value you may use without explicit consent.
+- If user requests more: confirm the number with user → confirm the cost implication.
+- Each iteration = one full G-Eval run over the dataset × LLM calls. This costs real money.
+
+---
+
+## Apply / Reject rules
+
+- **Apply**: edit the source file with the optimized prompt. If the codebase used `{{double}}` braces, convert the optimized `{single}` brace output back to `{{double}}` before writing. See [concepts/prompt-variables.md](../concepts/prompt-variables.md) → Conversion.
+- **Reject**: no file changes. Record the jobId in `.mutagent/mutation-context.md` for future reference.
+- **View diff**: show a unified diff of old vs new prompt text before asking again.
+
+---
+
+## Common pitfalls
+
+- Running `optimize start` before `evaluation create` → optimizer has no scoring signal
+- Mixing INPUT and OUTPUT criteria in the same rubric → vague scores
+- Applying results without showing the before/after scorecard first
+- Forgetting to convert `{single}` back to `{{double}}` after apply in double-brace codebases
+- Starting with `--max-iterations 3` without consent
+
+---
+
+## Guided Dataset Creation
+
+When no local dataset exists, use the guided mode to curate high-quality test data:
+
+```
+mutagent prompts dataset add <prompt-id> --guided --json
+```
+
+The CLI analyzes the prompt's inputSchema + outputSchema and returns:
+- **Suggested categories**: edge cases, hard cases, representative cases
+- **Per-field questions**: what values, what edge cases, what correct output looks like
+- **Template item**: showing the expected shape for each dataset entry
+- **Priority rule**: hard cases that expose prompt weaknesses > easy cases that always pass
+
+Collect answers from the user, then construct 5-10 dataset items covering all categories.
+Ensure at least 2 hard/edge cases per category. Then upload:
+
+```
+mutagent prompts dataset add <prompt-id> -d '<constructed-json>' --name '<name>' --json
+```
+
+For dataset-only work (no optimization needed yet), see [workflows/dataset-curation.md](./dataset-curation.md)
+and [concepts/dataset-design.md](../concepts/dataset-design.md) for the full curation principles.
+
+---
+
+## CLI commands
+
+Run these before the first use of each command (Rule 2: `--help` before first use):
+
+```bash
+mutagent explore --help                                        # codebase scan flags
+mutagent prompts create --help                                 # prompt upload flags + brace convention
+mutagent prompts dataset add --help                            # dataset add flags + --guided semantics
+mutagent prompts evaluation create --help                      # eval create flags + --guided semantics
+mutagent prompts optimize start --help                         # optimize start flags + cost-relevant flags
+mutagent prompts optimize status --help                        # status polling flags
+mutagent prompts optimize results --help                       # results flags + --apply / --diff
+mutagent usage --help                                          # quota query flags
+mutagent providers list --help                                 # provider catalog query flags
+```
+
+Workflow execution sequence (annotated with cost markers):
+
+```bash
+# Discovery + setup (no LLM cost)
+mutagent explore --json                                        # step 1: discover prompts
+mutagent prompts create --name "<name>" --raw-file <path> --json  # step 4: upload prompt
+mutagent prompts dataset add <id> --guided --json              # step 5-6: guided dataset (returns _directive.askUserQuestions)
+mutagent prompts dataset add <id> -d '<json>' --name "<name>" --json  # step 6: upload dataset items
+mutagent prompts evaluation create <id> --guided --json        # step 8: guided eval (returns _directive.askUserQuestions + decisionTree)
+mutagent prompts evaluation create <id> -d '<json>' --name "<name>" --json  # step 9: upload criteria
+
+# Pre-flight checks (no LLM cost)
+mutagent usage --json                                          # step 10: surface quota to user (Rule 5)
+mutagent providers list --models --json                        # verify exec/eval models are available (Rule 6)
+
+# 💰 LLM COST starts here -- requires explicit user confirmation per Rule 5
+mutagent prompts optimize start <id> --dataset <d> --evaluation <e> --max-iterations 1 --json
+                                                               # step 11: start job (cost = exec_model × items × iterations
+                                                               # + judge_model × items × iterations)
+                                                               # --max-iterations defaults to 1; never raise without user consent
+
+# Polling + results (no LLM cost; just reads job state + emits verbatim card)
+mutagent prompts optimize status <job-id> --json               # step 12: poll progress (verbatim card)
+mutagent prompts optimize results <job-id> --json              # step 13: view scorecard (verbatim card)
+mutagent prompts optimize results <job-id> --diff --json       # step 14a: view prompt diff (no apply)
+mutagent prompts optimize results <job-id> --apply --json      # step 14b: apply optimized prompt to stored version
+```
+
+**Cost note**: `optimize start` is the ONLY cost-incurring command in this workflow. All other commands are pure storage/discovery operations. The `--max-iterations` flag bounds total cost (default = 1; never raise silently).
+
+**Verbatim card protocol**: `optimize start`, `optimize status`, and `optimize results` emit `_directive.renderedCard` -- echo verbatim per [SKILL.md § MANDATORY: Verbatim Card Display Protocol](../../SKILL.md).
+
+For per-topic standalone HOW workflows, see:
+- [workflows/dataset-curation.md](./dataset-curation.md) -- standalone dataset curation
+- [workflows/eval-creation.md](./eval-creation.md) -- standalone evaluation rubric creation
+
+---
+
+## Cross-references
+
+- [SKILL.md](../../SKILL.md) → 5 rules + journey router
+- [concepts/prompt-variables.md](../concepts/prompt-variables.md) → brace convention + conversion (critical for steps 3 and 15)
+- [concepts/eval-criteria.md](../concepts/eval-criteria.md) → INPUT MVC + OUTPUT Standards + granular rubric (critical for steps 7-8)
+- [concepts/dataset-design.md](../concepts/dataset-design.md) → dataset curation principles (Golden Rule, case categories, anti-patterns)
+- [workflows/dataset-curation.md](./dataset-curation.md) → standalone dataset curation (when no optimization needed yet)
+- [workflows/exploration.md](./exploration.md) → step 1 of this workflow
+- [workflows/tracing.md](./tracing.md) → parallel or follow-up path

--- a/plugins/mutagent/skills/mutagent-cli/references/workflows/tracing.md
+++ b/plugins/mutagent/skills/mutagent-cli/references/workflows/tracing.md
@@ -1,0 +1,147 @@
+---
+name: mutagent-cli-workflows-tracing
+description: |
+  Framework integration workflow. Adds MutagenT tracing/observability to the
+  user's codebase. Non-destructive (append-only), fastest first-value path.
+  Detects framework via `mutagent explore`, generates snippet via
+  `mutagent integrate`, applies via Edit tool, verifies via traces list.
+triggers:
+  - "add tracing"
+  - "add observability"
+  - "integrate framework"
+  - "integrate mutagent"
+  - "add mutagent to my code"
+  - "instrument my prompts"
+  - "trace my prompts"
+---
+
+# Workflow — Tracing (Framework Integration)
+
+> **Scope**: read + append-only on user code. Never modify existing business
+> logic — only add tracing imports and decorators.
+
+Read the **5 rules** in [SKILL.md](../../SKILL.md) before executing. Key reminders:
+- `--json` on every command
+- `<command> --help` before first use
+- Explore before modify (Rule 4)
+- Show command output to user after every mutation
+
+---
+
+## When this workflow applies
+
+- User said "add tracing", "add observability", "integrate \<framework\>"
+- User wants to see their prompts captured in the MutagenT dashboard
+- Fastest path to first value — prefer this before suggesting optimization
+
+---
+
+## Supported frameworks
+
+`mutagent integrate --help` is the authoritative list. Common entries:
+
+| Framework | Signal in codebase |
+|---|---|
+| LangChain | `from "langchain"`, `PromptTemplate`, `ChatPromptTemplate` |
+| LangGraph | `from "@langchain/langgraph"`, `StateGraph` |
+| OpenAI SDK | `import OpenAI`, `openai.chat.completions.create` |
+| Vercel AI SDK | `import { generateText }` from `"ai"` |
+| Mastra | `from "@mastra/core"` |
+| Custom / raw | any string template with `{variable}` |
+
+---
+
+## Workflow steps
+
+```
+1. mutagent explore --json
+   → detect which framework is in use
+   → show command output to user
+
+2. mutagent integrate --help
+   → read the available frameworks and flags (ALWAYS before step 3)
+
+3. mutagent integrate <framework> --json
+   → get the integration snippet
+
+4. Use AskUserQuestion to confirm before applying code changes: "I'll add the tracing snippet to <file>. Proceed?"
+   → show the snippet preview before applying
+
+5. Apply snippet via Edit tool
+   → code change happens here — append imports + decorators only
+   → never touch existing business logic
+
+6. mutagent traces list --json
+   → verify integration: check traces count > 0
+   → show results and dashboard link to user
+```
+
+---
+
+## Scope guard
+
+This path is **READ + APPEND-ONLY** on the user's code:
+- ✓ Add import at top of file
+- ✓ Wrap existing function call with tracing decorator
+- ✗ Rename variables
+- ✗ Refactor logic
+- ✗ Remove existing code
+
+If the integration snippet requires a significant rewrite, confirm scope with the user before proceeding.
+
+---
+
+## Post-integration state
+
+After step 6:
+- Update `.mutagent/mutation-context.md` with the integration marker
+- Show the dashboard link from traces output so user can verify traces in UI
+- If user wants to optimize the traced prompt → route to [workflows/optimization.md](./optimization.md)
+
+---
+
+## Common pitfalls
+
+- Skipping step 1 and guessing the framework → let `explore` detect it
+- Forgetting step 6 → user has no proof the integration works
+- Editing files outside the `integrate --json` snippet block
+- Not showing command results to the user after mutations
+
+---
+
+## CLI commands
+
+```bash
+# Discovery (no LLM cost, read-only)
+mutagent explore --help                                # read flags before first use (Rule 2)
+mutagent explore --json                                # step 1: detect framework + prompts taxonomy
+mutagent integrate --help                              # list supported frameworks + per-framework flags
+
+# Code generation (no LLM cost; emits integration snippet to stdout)
+mutagent integrate <framework> --json                  # step 3: get integration snippet for the detected framework
+mutagent integrate <framework> --output <path> --json  # write snippet directly to file (instead of stdout)
+
+# Verification (no LLM cost, read-only)
+mutagent traces list --json                            # step 6: verify traces arriving (recent N traces)
+mutagent traces list --prompt-id <id> --json           # filter by prompt
+mutagent traces list --since <ISO-timestamp> --json    # filter by time window (e.g., since first integration)
+mutagent traces get <trace-id> --json                  # inspect single trace's spans + metadata
+```
+
+**Flag glossary** (tracing-specific):
+- `<framework>` -- supported frameworks: `langchain`, `langgraph`, `llamaindex`, `openai-agents`, `crewai`, `autogen`, `vercel-ai`. Run `mutagent integrate --help` for the canonical current list.
+- `--output <path>` -- write the integration snippet directly to a file. Without this flag, the snippet goes to stdout (typical for agent-mediated workflows so the agent can re-emit verbatim to user).
+- `--prompt-id <id>` -- filter trace list to one prompt's traces.
+- `--since <ts>` -- filter by timestamp (ISO-8601). Useful right after first integration to confirm traces are landing.
+- `--json` -- structured output (Rule 1: always use).
+
+**Cost note**: tracing is fully free at the CLI/platform layer -- the platform stores spans for analytics. The only "cost" is the marginal LLM call latency from in-process span emission inside the user's app (typically &lt;5ms per call). No optimizer cost incurred.
+
+---
+
+## Cross-references
+
+- [SKILL.md](../../SKILL.md) → 5 rules + journey router
+- [workflows/exploration.md](./exploration.md) → step 1 of this workflow
+- [workflows/optimization.md](./optimization.md) → natural next step after tracing
+- [concepts/prompt-variables.md](../concepts/prompt-variables.md) → variable inference for traced prompts


### PR DESCRIPTION
Adds the **Mutagent** skill — open-source ([MIT](https://github.com/mutagent-io/skills/blob/main/LICENSE)) Claude Code plugin + bare Agent Skills bundle.

**What it does**: Gives AI engineers an eval-driven loop for prompt and agent optimization — capture traces → curate datasets → score against rubrics → optimize prompts against measurable targets. Native framework tracing adapters for Mastra, LangChain, LangGraph, Vercel AI SDK.

**Why we're adding here**: Fits the agents marketplace as a runtime-agnostic skill — complements the existing `llm-application-dev`, `machine-learning-ops`, and other AI/ML plugins in this collection.

**Conforms to**: Anthropic Agent Skills spec (`SKILL.md` format) · Claude Code plugin marketplace (`.claude-plugin/marketplace.json`).

**Credibility**: 9.6k npm downloads / 30d on `@mutagent/cli`. v0.1.185. Runtime-agnostic (Claude Code, Cursor, Aider, Continue).

**Files added**:
- `plugins/mutagent/.claude-plugin/plugin.json`
- `plugins/mutagent/skills/mutagent-cli/SKILL.md` (verbatim from upstream)
- Single entry in `.claude-plugin/marketplace.json` under `category: "ai-ml"`

Verified locally against `.github/workflows/validate.yml`:
- `marketplace.json` parses
- All 83 plugin.json files parse
- All marketplace `source` entries resolve to existing dirs with `plugin.json`

**Source**: https://github.com/mutagent-io/skills
**npm**: https://www.npmjs.com/package/@mutagent/cli
**Docs**: https://docs.mutagent.io

Happy to adjust naming, placement, category, or trim further to match conventions.