### PR TITLE
meigen-ai-design: bump to 1.0.7, pin npm to meigen@1.3.1 (supersedes #525)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -963,7 +963,7 @@
       "name": "meigen-ai-design",
       "source": "./plugins/meigen-ai-design",
       "description": "AI image generation with creative workflow orchestration, prompt engineering, and curated inspiration library via MCP server",
-      "version": "1.0.5",
+      "version": "1.0.7",
       "author": {
         "name": "MeiGen",
         "url": "https://github.com/jau123"

--- a/plugins/meigen-ai-design/.claude-plugin/plugin.json
+++ b/plugins/meigen-ai-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "meigen-ai-design",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "description": "AI image generation with creative workflow orchestration, parallel multi-direction output, prompt engineering, and a 1,300+ curated inspiration library. Requires MeiGen MCP server (supports MeiGen Cloud, local ComfyUI, and OpenAI-compatible APIs).",
   "author": {
     "name": "MeiGen",

--- a/plugins/meigen-ai-design/README.md
+++ b/plugins/meigen-ai-design/README.md
@@ -11,7 +11,7 @@ This plugin requires the **meigen** MCP server. Install it by adding to your pro
   "mcpServers": {
     "meigen": {
       "command": "npx",
-      "args": ["-y", "meigen@1.2.13"]
+      "args": ["-y", "meigen@1.3.1"]
     }
   }
 }


### PR DESCRIPTION
**Supersedes #525** — please close that one in favor of this PR. #525 bumps to 1.0.6 / meigen@1.3.0; this one rolls the npm pin forward to 1.3.1 (capability expansion, additive only) so users get the most recent release.

## Summary

Bumps `meigen-ai-design` to **1.0.7** and pins the npm package to **meigen@1.3.1**.

## What's new in meigen@1.3.1

- **Veo 3.1 capability expansion**: fast/pro tiers + 4/6/8s durations + 720p/1080p/4K resolutions at the same price per tier+duration.
- **Seedance 2.0 reference-video continuation**: new `referenceVideo` + `referenceVideoDuration` paired params for semantic continuation of a previous clip.

No schema breaking changes — every new field is optional. Existing 1.3.0 / 1.2.x calls continue to work unchanged.

Full release notes: https://github.com/jau123/MeiGen-AI-Design-MCP/releases/tag/v1.3.1

## Files changed

- `plugins/meigen-ai-design/.claude-plugin/plugin.json` — version 1.0.5 → 1.0.7
- `plugins/meigen-ai-design/README.md` — pinned npx version meigen@1.2.13 → meigen@1.3.1
- `.claude-plugin/marketplace.json` — meigen-ai-design entry version 1.0.5 → 1.0.7

No description / structure changes — minimal diff (3 files, 3 lines).

## Re: the CodeRabbit comment on #525

CodeRabbit's "plugin.json should contain only name" advice on #525 doesn't match the repository's actual convention — every plugin in `plugins/*/.claude-plugin/plugin.json` uses the same 5-field shape (name + version + description + author + license). Examples: `plugins/conductor/`, `plugins/documentation-standards/`, `plugins/protect-mcp/`. Leaving this PR consistent with the rest of the repo.