### PR TITLE
fix(plugin-eval): broaden MISSING_TRIGGER pattern to match canonical phrasings

### DIFF
--- a/plugins/plugin-eval/src/plugin_eval/layers/static.py
+++ b/plugins/plugin-eval/src/plugin_eval/layers/static.py
@@ -30,6 +30,25 @@ def anti_pattern_penalty(count: int) -> float:
 # Line count threshold for BLOATED_SKILL (no references/ dir)
 _BLOATED_LINE_THRESHOLD = 800
 
+# Canonical trigger phrasings the model can use to decide when to invoke a skill.
+# Matches:
+#   - Imperative second-person: "Use when …", "Use this skill when …"
+#   - Third-person canonical (Anthropic plugin-dev recommends this form):
+#     "This skill should be used when …", "Used when …"
+#   - Prepositional temporal triggers commonly used in self-audit / hook-adjacent
+#     skills: "Use after …", "Use before …", "Use immediately before …",
+#     "Use whenever …", "Used after …", etc.
+#   - Explicit auto-load self-documentation: "Auto-loads when …"
+#   - Existing explicit markers: "Use proactively", "Trigger when …"
+_TRIGGER_PATTERN = re.compile(
+    r"\b(?:should\s+be\s+)?used?\s+(?:this\s+skill\s+)?(?:immediately\s+)?"
+    r"(?:when|after|before|whenever)\b"
+    r"|\buse\s+proactively\b"
+    r"|\btrigger(?:s)?\s+(?:when|on)\b"
+    r"|\bauto[-\s]?loads?\s+(?:when|on)\b",
+    re.IGNORECASE,
+)
+
 
 class StaticAnalyzer:
     """Deterministic structural analysis of plugin/skill quality."""
@@ -129,17 +148,18 @@ class StaticAnalyzer:
                 )
             )
 
-        # MISSING_TRIGGER: no "Use when..." or "Use this skill when..." phrasing
-        trigger_pattern = (
-            r"\buse\s+(?:this\s+skill\s+)?when\b|\buse\s+proactively\b|\btrigger\s+when\b"
-        )
-        if not re.search(trigger_pattern, skill.description, re.IGNORECASE):
+        # MISSING_TRIGGER: no recognised trigger phrasing in the description.
+        # See `_TRIGGER_PATTERN` for the full list of accepted forms (imperative,
+        # third-person canonical, prepositional, auto-load, etc.).
+        if not _TRIGGER_PATTERN.search(skill.description):
             patterns.append(
                 AntiPattern(
                     flag="MISSING_TRIGGER",
                     description=(
-                        'Skill description lacks a "Use when..." trigger phrase. '
-                        "Without it, the model cannot determine when to invoke the skill."
+                        "Skill description lacks a recognised trigger phrase "
+                        '(e.g. "Use when …", "This skill should be used when …", '
+                        '"Use after …", "Auto-loads when …"). '
+                        "Without one, the model cannot determine when to invoke the skill."
                     ),
                     severity=0.15,
                 )
@@ -412,8 +432,9 @@ class StaticAnalyzer:
         score = 0.0
         desc_lower = description.lower()
 
-        # "Use when" / "Use this skill when" phrases (0.25)
-        if re.search(r"\buse\s+(this\s+skill\s+)?when\b", desc_lower):
+        # Canonical trigger phrasings (0.25). Shares the module-level pattern
+        # used by MISSING_TRIGGER so that broadening one broadens both.
+        if _TRIGGER_PATTERN.search(description):
             score += 0.25
 
         # "Use PROACTIVELY" or "proactively" (0.15)

--- a/plugins/plugin-eval/tests/test_static.py
+++ b/plugins/plugin-eval/tests/test_static.py
@@ -2,8 +2,18 @@ from pathlib import Path
 
 import pytest
 
-from plugin_eval.layers.static import StaticAnalyzer
+from plugin_eval.layers.static import _TRIGGER_PATTERN, StaticAnalyzer
 from plugin_eval.models import LayerResult
+
+
+def _make_skill(tmp_path: Path, description: str, name: str = "test-skill") -> Path:
+    skill_dir = tmp_path / name
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: \"{description}\"\n---\n\n"
+        "# Skill\n\n## Overview\n\nBody.\n"
+    )
+    return skill_dir
 
 
 class TestStaticAnalyzer:
@@ -43,3 +53,72 @@ class TestStaticAnalyzer:
         good = "Test skill for evaluation. Use when testing plugin-eval. Use PROACTIVELY for quality checks."
         weak = "A skill."
         assert analyzer._description_pushiness(good) > analyzer._description_pushiness(weak)
+
+
+class TestTriggerPattern:
+    """Regression coverage for the broadened trigger-phrase matcher.
+
+    plugin-dev's canonical recommendation is third-person ("This skill should be
+    used when …"), and several real-world plugins use prepositional triggers
+    ("Use after …", "Use before …"). The pre-2026 regex only matched the
+    imperative "Use when …" form, which produced false-positive MISSING_TRIGGER
+    flags against Anthropic's own examples.
+    """
+
+    @pytest.mark.parametrize(
+        "description",
+        [
+            "Use when testing plugin-eval.",
+            "Use this skill when scaffolding plugins.",
+            "This skill should be used when the user asks to 'create a hook'.",
+            "Used when several attempts have failed in a row.",
+            "Use after editing the source-of-truth files, before committing.",
+            "Use before declaring a task complete after a hard debugging session.",
+            "Use immediately before a commit, push, or edit-after-failure.",
+            "Use whenever you are asked to plan inside a Paperclip company.",
+            "Auto-loads when working on test files.",
+            "Trigger when a Bash command fails three times in a row.",
+            "Use PROACTIVELY before merging.",
+        ],
+    )
+    def test_pattern_matches_canonical_forms(self, description: str) -> None:
+        assert _TRIGGER_PATTERN.search(description), (
+            f"Expected trigger phrase to match in: {description!r}"
+        )
+
+    @pytest.mark.parametrize(
+        "description",
+        [
+            "A skill.",
+            "Provides hook guidance.",
+            "Returns the current timestamp.",
+            "Performs static analysis on plugin directories.",
+        ],
+    )
+    def test_pattern_rejects_descriptions_without_trigger(self, description: str) -> None:
+        assert not _TRIGGER_PATTERN.search(description), (
+            f"Did not expect trigger match in: {description!r}"
+        )
+
+    def test_third_person_skill_does_not_flag_missing_trigger(self, tmp_path: Path) -> None:
+        """Anthropic plugin-dev's canonical phrasing must not be flagged."""
+        skill_dir = _make_skill(
+            tmp_path,
+            "This skill should be used when the user asks to 'create a hook', "
+            "'add a PreToolUse hook', or 'validate tool use'.",
+        )
+        analyzer = StaticAnalyzer()
+        result = analyzer.analyze_skill(skill_dir)
+        flags = [ap.flag for ap in result.anti_patterns]
+        assert "MISSING_TRIGGER" not in flags
+
+    def test_prepositional_trigger_does_not_flag_missing_trigger(self, tmp_path: Path) -> None:
+        skill_dir = _make_skill(
+            tmp_path,
+            "Self-check before a single risky action. Use immediately before a "
+            "commit, push, edit-after-failure, or skip-a-verification step.",
+        )
+        analyzer = StaticAnalyzer()
+        result = analyzer.analyze_skill(skill_dir)
+        flags = [ap.flag for ap in result.anti_patterns]
+        assert "MISSING_TRIGGER" not in flags


### PR DESCRIPTION
## Problem

The Layer-1 `MISSING_TRIGGER` heuristic in `plugins/plugin-eval/src/plugin_eval/layers/static.py:132` is a literal substring match against `Use when` / `Use this skill when` / `Use proactively` / `Trigger when`. This produces large numbers of false-positive flags against real, well-formed plugins because three common phrasings don't contain the literal `Use when`:

1. **Third-person canonical form** — Anthropic's own `plugin-dev` plugin (specifically the `skill-development` skill) recommends `This skill should be used when …` as the *correct* description style and explicitly calls out the imperative `Use this skill when …` form as a mistake. The canonical phrasing contains `used when`, not `Use when`.

2. **Prepositional temporal triggers** — `Use after …`, `Use before …`, `Use immediately before …`, `Use whenever …`. These are common in self-audit, hook-adjacent, and lifecycle skills where the trigger is a temporal context rather than a generic "when".

3. **Path-triggered self-documentation** — `Auto-loads when …` for skills that use the `paths:` frontmatter for auto-loading and describe that mechanism in their description.

## Evidence

Running plugin-eval against Anthropic's own plugin-dev (the authoritative source on how to write Claude Code plugin skills) produces **7 false-positive `MISSING_TRIGGER` flags** out of 7 skills — every one. The static linter penalises the very phrasing pattern plugin-dev's own skill-development guide recommends.

```text
# Before this PR
plugin-dev composite: 33.82  penalty: 0.50  (7× MISSING_TRIGGER)

# After this PR
plugin-dev composite: 55.18  penalty: 0.75  (0× MISSING_TRIGGER; 5 unrelated flags remain)
```

A separate test against the `functional-emotions` plugin shows a similar pattern: 6 of 11 skills flagged before, 0 after.

## Fix

- Extract the trigger regex to a module-level `_TRIGGER_PATTERN` constant so the anti-pattern detector and `_description_pushiness` heuristic can share it (previously two slightly-divergent copies).
- Expand the pattern to match `(?:should\s+be\s+)?use(?:d)?\s+(?:this\s+skill\s+)?(?:immediately\s+)?(?:when|after|before|whenever)` plus `auto-loads when` and `trigger when`.
- Keep all existing accepted phrasings (`Use when`, `Use this skill when`, `Use proactively`, `Trigger when`).

## Test plan

- [x] 22 tests pass (`uv run --extra dev pytest tests/test_static.py -v`), including:
  - 11 new parametrised positive cases covering the expanded forms
  - 4 parametrised negative cases (descriptions with no trigger phrase still flag)
  - 2 regression tests asserting that the canonical Anthropic phrasings (`This skill should be used when …`, `Use immediately before …`) do **not** produce `MISSING_TRIGGER`
- [x] End-to-end run against plugin-dev confirms 7 false positives → 0
- [x] End-to-end run against an external plugin confirms 6 false positives → 0