### PR TITLE
fix(plugin-eval): exempt slash-only and path-triggered skills from MISSING_TRIGGER

### DIFF
--- a/plugins/plugin-eval/src/plugin_eval/layers/static.py
+++ b/plugins/plugin-eval/src/plugin_eval/layers/static.py
@@ -32,6 +32,23 @@ def anti_pattern_penalty(count: int) -> float:
     return max(0.5, 1.0 - 0.05 * count)
 
 
+def _skill_uses_description_trigger(skill: ParsedSkill) -> bool:
+    """Return True if the skill relies on its description to be auto-invoked.
+
+    Skills that opt out of model-driven invocation (`disable-model-invocation:
+    true`) or that auto-load on a path glob (`paths:` frontmatter) use a
+    different trigger mechanism and should not be checked for a "Use when …"
+    phrase in the description.
+    """
+    fm = skill.frontmatter
+    if fm.get("disable-model-invocation") is True:
+        return False
+    paths = fm.get("paths")
+    if paths is not None and paths != "":
+        return False
+    return True
+
+
 # Line count threshold for BLOATED_SKILL (no references/ dir)
 _BLOATED_LINE_THRESHOLD = 800
 
@@ -160,19 +177,25 @@ class StaticAnalyzer:
         # MISSING_TRIGGER: no recognised trigger phrasing in the description.
         # See `_TRIGGER_PATTERN` for the full list of accepted forms (imperative,
         # third-person canonical, prepositional, auto-load, etc.).
-        if not _TRIGGER_PATTERN.search(skill.description):
-            patterns.append(
-                AntiPattern(
-                    flag="MISSING_TRIGGER",
-                    description=(
-                        "Skill description lacks a recognised trigger phrase "
-                        '(e.g. "Use when …", "This skill should be used when …", '
-                        '"Use after …", "Auto-loads when …"). '
-                        "Without one, the model cannot determine when to invoke the skill."
-                    ),
-                    severity=0.15,
+        # Only applies to skills the model is expected to auto-invoke from the
+        # description. Skills that are slash-only (`disable-model-invocation:
+        # true`) or path-triggered (`paths:` frontmatter) use a different
+        # invocation mechanism and should not be penalised for lacking a
+        # description-level trigger phrase.
+        if _skill_uses_description_trigger(skill):
+            if not _TRIGGER_PATTERN.search(skill.description):
+                patterns.append(
+                    AntiPattern(
+                        flag="MISSING_TRIGGER",
+                        description=(
+                            "Skill description lacks a recognised trigger phrase "
+                            '(e.g. "Use when …", "This skill should be used when …", '
+                            '"Use after …", "Auto-loads when …"). '
+                            "Without one, the model cannot determine when to invoke the skill."
+                        ),
+                        severity=0.15,
+                    )
                 )
-            )
 
         # BLOATED_SKILL: >800 lines without a references/ directory
         if skill.line_count > _BLOATED_LINE_THRESHOLD and not skill.has_references:

--- a/plugins/plugin-eval/src/plugin_eval/layers/static.py
+++ b/plugins/plugin-eval/src/plugin_eval/layers/static.py
@@ -44,9 +44,7 @@ def _skill_uses_description_trigger(skill: ParsedSkill) -> bool:
     if fm.get("disable-model-invocation") is True:
         return False
     paths = fm.get("paths")
-    if paths is not None and paths != "":
-        return False
-    return True
+    return not (isinstance(paths, str) and paths != "")
 
 
 # Line count threshold for BLOATED_SKILL (no references/ dir)
@@ -182,20 +180,21 @@ class StaticAnalyzer:
         # true`) or path-triggered (`paths:` frontmatter) use a different
         # invocation mechanism and should not be penalised for lacking a
         # description-level trigger phrase.
-        if _skill_uses_description_trigger(skill):
-            if not _TRIGGER_PATTERN.search(skill.description):
-                patterns.append(
-                    AntiPattern(
-                        flag="MISSING_TRIGGER",
-                        description=(
-                            "Skill description lacks a recognised trigger phrase "
-                            '(e.g. "Use when …", "This skill should be used when …", '
-                            '"Use after …", "Auto-loads when …"). '
-                            "Without one, the model cannot determine when to invoke the skill."
-                        ),
-                        severity=0.15,
-                    )
+        if _skill_uses_description_trigger(skill) and not _TRIGGER_PATTERN.search(
+            skill.description
+        ):
+            patterns.append(
+                AntiPattern(
+                    flag="MISSING_TRIGGER",
+                    description=(
+                        "Skill description lacks a recognised trigger phrase "
+                        '(e.g. "Use when …", "This skill should be used when …", '
+                        '"Use after …", "Auto-loads when …"). '
+                        "Without one, the model cannot determine when to invoke the skill."
+                    ),
+                    severity=0.15,
                 )
+            )
 
         # BLOATED_SKILL: >800 lines without a references/ directory
         if skill.line_count > _BLOATED_LINE_THRESHOLD and not skill.has_references:

--- a/plugins/plugin-eval/src/plugin_eval/layers/static.py
+++ b/plugins/plugin-eval/src/plugin_eval/layers/static.py
@@ -27,6 +27,23 @@ def anti_pattern_penalty(count: int) -> float:
     return max(0.5, 1.0 - 0.05 * count)
 
 
+def _skill_uses_description_trigger(skill: ParsedSkill) -> bool:
+    """Return True if the skill relies on its description to be auto-invoked.
+
+    Skills that opt out of model-driven invocation (`disable-model-invocation:
+    true`) or that auto-load on a path glob (`paths:` frontmatter) use a
+    different trigger mechanism and should not be checked for a "Use when …"
+    phrase in the description.
+    """
+    fm = skill.frontmatter
+    if fm.get("disable-model-invocation") is True:
+        return False
+    paths = fm.get("paths")
+    if paths is not None and paths != "":
+        return False
+    return True
+
+
 # Line count threshold for BLOATED_SKILL (no references/ dir)
 _BLOATED_LINE_THRESHOLD = 800
 
@@ -129,21 +146,27 @@ class StaticAnalyzer:
                 )
             )
 
-        # MISSING_TRIGGER: no "Use when..." or "Use this skill when..." phrasing
-        trigger_pattern = (
-            r"\buse\s+(?:this\s+skill\s+)?when\b|\buse\s+proactively\b|\btrigger\s+when\b"
-        )
-        if not re.search(trigger_pattern, skill.description, re.IGNORECASE):
-            patterns.append(
-                AntiPattern(
-                    flag="MISSING_TRIGGER",
-                    description=(
-                        'Skill description lacks a "Use when..." trigger phrase. '
-                        "Without it, the model cannot determine when to invoke the skill."
-                    ),
-                    severity=0.15,
-                )
+        # MISSING_TRIGGER: no "Use when..." or "Use this skill when..." phrasing.
+        # Only applies to skills the model is expected to auto-invoke from the
+        # description. Skills that are slash-only (`disable-model-invocation:
+        # true`) or path-triggered (`paths:` frontmatter) use a different
+        # invocation mechanism and should not be penalised for lacking a
+        # description-level trigger phrase.
+        if _skill_uses_description_trigger(skill):
+            trigger_pattern = (
+                r"\buse\s+(?:this\s+skill\s+)?when\b|\buse\s+proactively\b|\btrigger\s+when\b"
             )
+            if not re.search(trigger_pattern, skill.description, re.IGNORECASE):
+                patterns.append(
+                    AntiPattern(
+                        flag="MISSING_TRIGGER",
+                        description=(
+                            'Skill description lacks a "Use when..." trigger phrase. '
+                            "Without it, the model cannot determine when to invoke the skill."
+                        ),
+                        severity=0.15,
+                    )
+                )
 
         # BLOATED_SKILL: >800 lines without a references/ directory
         if skill.line_count > _BLOATED_LINE_THRESHOLD and not skill.has_references:

--- a/plugins/plugin-eval/tests/test_static.py
+++ b/plugins/plugin-eval/tests/test_static.py
@@ -122,3 +122,86 @@ class TestTriggerPattern:
         result = analyzer.analyze_skill(skill_dir)
         flags = [ap.flag for ap in result.anti_patterns]
         assert "MISSING_TRIGGER" not in flags
+
+
+def _make_skill_with_frontmatter(
+    tmp_path: Path, frontmatter_lines: list[str], name: str = "test-skill"
+) -> Path:
+    skill_dir = tmp_path / name
+    skill_dir.mkdir()
+    frontmatter = "\n".join(frontmatter_lines)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\n{frontmatter}\n---\n\n# Skill\n\n## Overview\n\nBody.\n"
+    )
+    return skill_dir
+
+
+class TestTriggerExemptions:
+    """`disable-model-invocation: true` and `paths:` frontmatter should exempt
+    a skill from the MISSING_TRIGGER check, because those skills are not
+    auto-invoked from the description.
+    """
+
+    def test_disable_model_invocation_exempts_skill(self, tmp_path: Path) -> None:
+        skill_dir = _make_skill_with_frontmatter(
+            tmp_path,
+            [
+                "name: setup",
+                "description: One-time setup that adds .claude/state/ to the project's .gitignore.",
+                "disable-model-invocation: true",
+            ],
+        )
+        analyzer = StaticAnalyzer()
+        result = analyzer.analyze_skill(skill_dir)
+        flags = [ap.flag for ap in result.anti_patterns]
+        assert "MISSING_TRIGGER" not in flags, (
+            "Slash-only skills should not be flagged for missing description trigger"
+        )
+
+    def test_paths_auto_load_exempts_skill(self, tmp_path: Path) -> None:
+        skill_dir = _make_skill_with_frontmatter(
+            tmp_path,
+            [
+                "name: self-evaluate",
+                "description: Self-critical evaluation guard for test/spec files.",
+                'paths: "**/*test*,**/*spec*"',
+            ],
+        )
+        analyzer = StaticAnalyzer()
+        result = analyzer.analyze_skill(skill_dir)
+        flags = [ap.flag for ap in result.anti_patterns]
+        assert "MISSING_TRIGGER" not in flags, (
+            "Path-triggered skills should not be flagged for missing description trigger"
+        )
+
+    def test_disable_model_invocation_false_still_checks_trigger(
+        self, tmp_path: Path
+    ) -> None:
+        skill_dir = _make_skill_with_frontmatter(
+            tmp_path,
+            [
+                "name: model-invocable",
+                "description: A description without a trigger phrase whatsoever.",
+                "disable-model-invocation: false",
+            ],
+        )
+        analyzer = StaticAnalyzer()
+        result = analyzer.analyze_skill(skill_dir)
+        flags = [ap.flag for ap in result.anti_patterns]
+        assert "MISSING_TRIGGER" in flags, (
+            "Model-invocable skills without a trigger phrase must still be flagged"
+        )
+
+    def test_empty_paths_value_still_checks_trigger(self, tmp_path: Path) -> None:
+        skill_dir = _make_skill_with_frontmatter(
+            tmp_path,
+            [
+                "name: bad-paths",
+                "description: Some skill description that lacks the trigger phrase.",
+                'paths: ""',
+            ],
+        )
+        analyzer = StaticAnalyzer()
+        result = analyzer.analyze_skill(skill_dir)
+        flags = [ap.flag for ap in result.anti_patterns]
+        assert "MISSING_TRIGGER" in flags

--- a/plugins/plugin-eval/tests/test_static.py
+++ b/plugins/plugin-eval/tests/test_static.py
@@ -43,3 +43,90 @@ class TestStaticAnalyzer:
         good = "Test skill for evaluation. Use when testing plugin-eval. Use PROACTIVELY for quality checks."
         weak = "A skill."
         assert analyzer._description_pushiness(good) > analyzer._description_pushiness(weak)
+
+
+def _make_skill_with_frontmatter(
+    tmp_path: Path, frontmatter_lines: list[str], name: str = "test-skill"
+) -> Path:
+    skill_dir = tmp_path / name
+    skill_dir.mkdir()
+    frontmatter = "\n".join(frontmatter_lines)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\n{frontmatter}\n---\n\n# Skill\n\n## Overview\n\nBody.\n"
+    )
+    return skill_dir
+
+
+class TestTriggerExemptions:
+    """`disable-model-invocation: true` and `paths:` frontmatter should exempt
+    a skill from the MISSING_TRIGGER check, because those skills are not
+    auto-invoked from the description.
+    """
+
+    def test_disable_model_invocation_exempts_skill(self, tmp_path: Path) -> None:
+        # No "Use when…" phrase, but the skill is explicitly slash-only.
+        skill_dir = _make_skill_with_frontmatter(
+            tmp_path,
+            [
+                "name: setup",
+                "description: One-time setup that adds .claude/state/ to the project's .gitignore.",
+                "disable-model-invocation: true",
+            ],
+        )
+        analyzer = StaticAnalyzer()
+        result = analyzer.analyze_skill(skill_dir)
+        flags = [ap.flag for ap in result.anti_patterns]
+        assert "MISSING_TRIGGER" not in flags, (
+            "Slash-only skills should not be flagged for missing description trigger"
+        )
+
+    def test_paths_auto_load_exempts_skill(self, tmp_path: Path) -> None:
+        # Path-triggered skill: invocation is driven by `paths:` glob, not the description.
+        skill_dir = _make_skill_with_frontmatter(
+            tmp_path,
+            [
+                "name: self-evaluate",
+                "description: Self-critical evaluation guard for test/spec files.",
+                'paths: "**/*test*,**/*spec*"',
+            ],
+        )
+        analyzer = StaticAnalyzer()
+        result = analyzer.analyze_skill(skill_dir)
+        flags = [ap.flag for ap in result.anti_patterns]
+        assert "MISSING_TRIGGER" not in flags, (
+            "Path-triggered skills should not be flagged for missing description trigger"
+        )
+
+    def test_disable_model_invocation_false_still_checks_trigger(
+        self, tmp_path: Path
+    ) -> None:
+        # Explicitly model-invocable, no trigger phrase → should still flag.
+        skill_dir = _make_skill_with_frontmatter(
+            tmp_path,
+            [
+                "name: model-invocable",
+                "description: A description without a trigger phrase whatsoever.",
+                "disable-model-invocation: false",
+            ],
+        )
+        analyzer = StaticAnalyzer()
+        result = analyzer.analyze_skill(skill_dir)
+        flags = [ap.flag for ap in result.anti_patterns]
+        assert "MISSING_TRIGGER" in flags, (
+            "Model-invocable skills without a trigger phrase must still be flagged"
+        )
+
+    def test_empty_paths_value_still_checks_trigger(self, tmp_path: Path) -> None:
+        # `paths:` with no value is not a valid auto-load configuration.
+        skill_dir = _make_skill_with_frontmatter(
+            tmp_path,
+            [
+                "name: bad-paths",
+                "description: Some skill description that lacks the trigger phrase.",
+                'paths: ""',
+            ],
+        )
+        analyzer = StaticAnalyzer()
+        result = analyzer.analyze_skill(skill_dir)
+        flags = [ap.flag for ap in result.anti_patterns]
+        assert "MISSING_TRIGGER" in flags


### PR DESCRIPTION
## Problem

The `MISSING_TRIGGER` anti-pattern check assumes every skill is auto-invoked by the model based on its description. Claude Code actually supports three invocation mechanisms:

1. **Description-driven auto-invocation** — the default. `MISSING_TRIGGER` is the correct gate.
2. **Slash-only invocation** — `disable-model-invocation: true` in the SKILL.md frontmatter. The model cannot auto-invoke these, so a trigger phrase in the description is irrelevant.
3. **Path-triggered auto-load** — `paths:` frontmatter glob. The skill loads when the model opens a matching file. The description is documentation rather than a discovery surface; description-level trigger phrasing is orthogonal.

The current check fires against every skill, producing false-positive flags against operator-only commands (setup, doctor, audit tools) and against path-triggered guards (test-edit primers, etc.).

## Fix

- Add a `_skill_uses_description_trigger(skill)` predicate that inspects `skill.frontmatter` for `disable-model-invocation: true` and a non-empty `paths:` value.
- Run the existing `MISSING_TRIGGER` check only when the predicate returns `True`.
- Behaviour for ordinary model-invocable skills is unchanged.

Note: the parser already reads the full frontmatter dict into `ParsedSkill.frontmatter`, so this change is purely additive — no parsing changes required.

## Test plan

- [x] 4 new tests in `tests/test_static.py::TestTriggerExemptions`:
  - `test_disable_model_invocation_exempts_skill` — slash-only skill without a trigger phrase is not flagged
  - `test_paths_auto_load_exempts_skill` — `paths:` skill without a trigger phrase is not flagged
  - `test_disable_model_invocation_false_still_checks_trigger` — explicit `false` does not exempt
  - `test_empty_paths_value_still_checks_trigger` — empty-string `paths:` is not a valid auto-load configuration
- [x] Full plugin-eval suite (73 tests) passes via `uv run --extra dev pytest tests/ -v`.

## Relation to other PRs

Conceptually independent from #530 (broaden MISSING_TRIGGER regex). The two can land in either order; together they eliminate the remaining classes of false-positive MISSING_TRIGGER flags against real-world plugins.