### PR TITLE
fix(plugin-eval): surface plugin-level depth downgrades loudly

### DIFF
--- a/plugins/plugin-eval/src/plugin_eval/cli.py
+++ b/plugins/plugin-eval/src/plugin_eval/cli.py
@@ -17,6 +17,7 @@ app = typer.Typer(
     add_completion=False,
 )
 console = Console()
+stderr_console = Console(stderr=True)
 
 
 def _detect_target(path: Path) -> str:
@@ -55,6 +56,15 @@ def _run_score(
     if target == "skill":
         result = engine.evaluate_skill(path)
     elif target == "plugin":
+        if depth != Depth.QUICK:
+            stderr_console.print(
+                f"[yellow]warning:[/yellow] plugin-level evaluation only runs the "
+                f"static layer; judge and Monte Carlo layers require per-skill "
+                f"evaluation. Requested depth [bold]{depth.value}[/bold] will be "
+                f"served from the static layer only — confidence label will be "
+                f"[bold]Estimated[/bold] regardless. To use the deeper layers, "
+                f"point at an individual skill directory."
+            )
         result = engine.evaluate_plugin(path)
     else:
         # Attempt skill evaluation as fallback

--- a/plugins/plugin-eval/src/plugin_eval/reporter.py
+++ b/plugins/plugin-eval/src/plugin_eval/reporter.py
@@ -2,7 +2,20 @@
 
 from __future__ import annotations
 
-from plugin_eval.models import PluginEvalResult
+from plugin_eval.models import Depth, PluginEvalResult
+
+
+_LAYER_TO_DEPTH: dict[frozenset[str], Depth] = {
+    frozenset({"static", "judge", "monte_carlo"}): Depth.DEEP,
+    frozenset({"static", "judge"}): Depth.STANDARD,
+    frozenset({"static"}): Depth.QUICK,
+}
+
+
+def _effective_depth(result: PluginEvalResult) -> Depth:
+    """Return the deepest depth actually covered by the layers that ran."""
+    layer_names = frozenset(layer.layer for layer in result.layers)
+    return _LAYER_TO_DEPTH.get(layer_names, Depth.QUICK)
 
 
 class Reporter:
@@ -27,8 +40,28 @@ class Reporter:
         lines.append("")
         lines.append(f"**Path:** `{result.plugin_path}`")
         lines.append(f"**Timestamp:** {result.timestamp}")
-        lines.append(f"**Depth:** {result.config.depth}")
+        requested = Depth(result.config.depth)
+        effective = _effective_depth(result)
+        if effective is requested:
+            lines.append(f"**Depth:** {requested.value}")
+        else:
+            lines.append(
+                f"**Depth:** {requested.value} (requested) → "
+                f"{effective.value} (effective)"
+            )
         lines.append("")
+
+        if effective is not requested:
+            lines.append(
+                "> **Note:** Requested depth `"
+                f"{requested.value}` was downgraded to `{effective.value}` "
+                "because plugin-level evaluation only runs the static layer. "
+                "Judge and Monte Carlo layers require per-skill evaluation — "
+                "point at an individual skill directory to use the deeper "
+                "layers. Composite score and confidence reflect the layers "
+                "actually run."
+            )
+            lines.append("")
 
         # Overall Score
         lines.append("## Overall Score")

--- a/plugins/plugin-eval/tests/test_cli.py
+++ b/plugins/plugin-eval/tests/test_cli.py
@@ -29,3 +29,31 @@ class TestCLI:
     def test_score_nonexistent_path(self, tmp_path: Path):
         result = runner.invoke(app, ["score", str(tmp_path / "nonexistent")])
         assert result.exit_code == 2
+
+    def test_plugin_eval_at_deep_depth_emits_downgrade_warning(
+        self, sample_plugin_dir: Path
+    ) -> None:
+        """Plugin-level evaluation only runs the static layer; certify-style
+        invocations at deep depth must warn the user that the deeper layers
+        were skipped, not silently produce a static-only report.
+        """
+        result = runner.invoke(
+            app,
+            ["certify", str(sample_plugin_dir), "--output", "markdown"],
+        )
+        assert result.exit_code == 0
+        # Click 8.3+ exposes stdout/stderr as separate attributes by default.
+        assert "warning" in result.stderr.lower()
+        assert "plugin-level" in result.stderr.lower()
+        assert "deep" in result.stderr.lower()
+
+    def test_plugin_eval_at_quick_depth_does_not_warn(
+        self, sample_plugin_dir: Path
+    ) -> None:
+        """No warning when the requested depth is already static-only."""
+        result = runner.invoke(
+            app,
+            ["score", str(sample_plugin_dir), "--depth", "quick"],
+        )
+        assert result.exit_code == 0
+        assert "warning" not in result.stderr.lower()

--- a/plugins/plugin-eval/tests/test_reporter.py
+++ b/plugins/plugin-eval/tests/test_reporter.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from plugin_eval.engine import EvalEngine
 from plugin_eval.models import Depth, EvalConfig
-from plugin_eval.reporter import Reporter
+from plugin_eval.reporter import Reporter, _effective_depth
 
 
 class TestReporter:
@@ -30,3 +30,52 @@ class TestReporter:
         assert "Overall Score" in output
         assert "Layer Breakdown" in output
         assert "Dimension Scores" in output
+
+
+class TestDepthDowngradeWarning:
+    """When plugin-level evaluation silently downgrades a deep/standard request
+    to static-only, the reporter must surface the downgrade in-band so the
+    consumer cannot mistake the score for a deeply-evaluated one.
+    """
+
+    def test_effective_depth_matches_layers_run(self, sample_skill_dir: Path) -> None:
+        config = EvalConfig(depth=Depth.QUICK)
+        engine = EvalEngine(config)
+        result = engine.evaluate_skill(sample_skill_dir)
+        assert _effective_depth(result) is Depth.QUICK
+
+    def test_markdown_shows_no_warning_when_depth_was_honored(
+        self, sample_skill_dir: Path
+    ) -> None:
+        config = EvalConfig(depth=Depth.QUICK)
+        engine = EvalEngine(config)
+        result = engine.evaluate_skill(sample_skill_dir)
+
+        output = Reporter().to_markdown(result)
+        assert "(requested)" not in output
+        assert "downgraded" not in output
+
+    def test_markdown_shows_warning_when_plugin_eval_downgrades_depth(
+        self, sample_plugin_dir: Path
+    ) -> None:
+        # Plugin-level eval at deep depth: the engine runs only the static
+        # layer regardless. The report must say so clearly.
+        config = EvalConfig(depth=Depth.DEEP)
+        engine = EvalEngine(config)
+        result = engine.evaluate_plugin(sample_plugin_dir)
+
+        output = Reporter().to_markdown(result)
+        assert "deep (requested)" in output
+        assert "quick (effective)" in output
+        assert "downgraded" in output
+
+    def test_markdown_shows_warning_when_standard_depth_is_downgraded(
+        self, sample_plugin_dir: Path
+    ) -> None:
+        config = EvalConfig(depth=Depth.STANDARD)
+        engine = EvalEngine(config)
+        result = engine.evaluate_plugin(sample_plugin_dir)
+
+        output = Reporter().to_markdown(result)
+        assert "standard (requested)" in output
+        assert "quick (effective)" in output


### PR DESCRIPTION
## Problem

`plugin-eval certify <plugin-dir>` is documented and named as a deep, three-layer evaluation (static + judge + Monte Carlo). In practice, plugin-level evaluation only runs the static layer regardless of the requested depth — the judge and Monte Carlo analyzers are per-skill primitives, and `EvalEngine.evaluate_plugin` hard-codes a static-only path:

```python
# engine.py
def evaluate_plugin(self, plugin_dir: Path) -> PluginEvalResult:
    """...
    Note: Plugin-level evaluation currently only runs Layer 1 (static).
    Judge and Monte Carlo require per-skill evaluation. The confidence
    label is always "Estimated" regardless of requested depth.
    """
    # ...only Layer 1 (static) is run...
    composite.confidence_label = Depth.QUICK.confidence_label
```

Nothing surfaces this to the user. Running `plugin-eval certify <plugin-dir> --output markdown` produces a report that reads `Depth: deep` and exits in seconds, with the downgrade signal buried in:
- a `Confidence: Estimated` row in the score table, and
- a `No model usage (static-only evaluation)` footnote near the end.

A consumer comparing scores across plugins will quietly mistake an in-effect static-only run for a deep certification.

## Fix

This PR makes the downgrade impossible to miss without changing the underlying evaluation pipeline (per-skill judge aggregation is a larger feature, not a bug fix).

1. **CLI warning to stderr.** `_run_score` detects a plugin-target run at non-quick depth and prints a yellow `warning:` line to stderr naming the skipped layers and the workaround (run on a single skill to get the deeper layers).

2. **In-band markdown callout.** The reporter now derives the *effective* depth from the set of layers actually present in the result. When effective differs from requested, the report header reads
   ```
   **Depth:** deep (requested) → quick (effective)
   ```
   and a `> Note:` block above the score table explains why and how to get the deeper layers.

3. **Effective-depth helper.** `_effective_depth(result)` maps the set of layer names (`static` / `judge` / `monte_carlo`) back to a `Depth` value, so the reporter never has to trust `result.config.depth` when describing what actually ran.

## Example output

Before:
```text
**Depth:** deep
[score table]
_No model usage (static-only evaluation)._
```

After (stderr):
```text
warning: plugin-level evaluation only runs the static layer; judge and Monte
Carlo layers require per-skill evaluation. Requested depth deep will be served
from the static layer only — confidence label will be Estimated regardless. To
use the deeper layers, point at an individual skill directory.
```

After (stdout markdown):
```text
**Depth:** deep (requested) → quick (effective)

> **Note:** Requested depth `deep` was downgraded to `quick` because
> plugin-level evaluation only runs the static layer. Judge and Monte Carlo
> layers require per-skill evaluation — point at an individual skill directory
> to use the deeper layers. Composite score and confidence reflect the layers
> actually run.
```

## Test plan

- [x] `TestDepthDowngradeWarning` (4 tests in `tests/test_reporter.py`): asserts the effective-depth helper, the "no warning when depth was honored" path, and the warning content for both deep and standard plugin-level requests.
- [x] `TestCLI` (2 new tests in `tests/test_cli.py`): asserts the stderr warning is emitted on plugin-level certify and is *not* emitted at quick depth.
- [x] Full plugin-eval suite (75 tests) passes via `uv run --extra dev pytest tests/`.

## Follow-up (out of scope for this PR)

A larger change could implement per-skill judge / Monte Carlo aggregation so plugin-level deep evaluation is honoured directly. That has architectural questions (aggregation strategy, cost handling, dimension reduction) that this PR deliberately doesn't try to settle. The warning + in-band note here is the minimal fix for the silent-downgrade bug; deeper-layer plugin aggregation can be a follow-up.