### PR TITLE
feat: add pluginpool plugin (10 productivity commands)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
     {
       "name": "documentation-standards",
       "source": "./plugins/documentation-standards",
-      "description": "HADS (Human-AI Document Standard) — semantic tagging convention for writing docs that work efficiently for both humans and AI models. Reduces token consumption by separating machine-critical facts from human context.",
+      "description": "HADS (Human-AI Document Standard) \u2014 semantic tagging convention for writing docs that work efficiently for both humans and AI models. Reduces token consumption by separating machine-critical facts from human context.",
       "version": "1.0.0",
       "author": {
         "name": "Niksa Barlovic",
@@ -900,7 +900,7 @@
       "description": "Binary reverse engineering, malware analysis, firmware security, and software protection research for authorized security research, CTF competitions, and defensive security",
       "version": "1.0.0",
       "author": {
-        "name": "Dávid Balatoni",
+        "name": "D\u00e1vid Balatoni",
         "url": "https://github.com/balcsida"
       },
       "homepage": "https://github.com/wshobson/agents",
@@ -909,7 +909,7 @@
     },
     {
       "name": "conductor",
-      "description": "Context-Driven Development plugin that transforms Claude Code into a project management tool with structured workflow: Context → Spec & Plan → Implement",
+      "description": "Context-Driven Development plugin that transforms Claude Code into a project management tool with structured workflow: Context \u2192 Spec & Plan \u2192 Implement",
       "version": "1.2.1",
       "author": {
         "name": "Seth Hobson",
@@ -1014,7 +1014,7 @@
         "url": "https://github.com/Anasss/qa-orchestra.git",
         "path": "."
       },
-      "description": "Multi-agent QA toolkit with 10 specialized agents covering the full QA lifecycle — orchestrator, environment-manager, functional-reviewer, test-scenario-designer, browser-validator, automation-writer, manual-validator, bug-reporter, release-analyzer, and smart-test-selector. Stack-agnostic, output-chained, designed around live validation via Chrome MCP.",
+      "description": "Multi-agent QA toolkit with 10 specialized agents covering the full QA lifecycle \u2014 orchestrator, environment-manager, functional-reviewer, test-scenario-designer, browser-validator, automation-writer, manual-validator, bug-reporter, release-analyzer, and smart-test-selector. Stack-agnostic, output-chained, designed around live validation via Chrome MCP.",
       "version": "1.0.0",
       "author": {
         "name": "Anass Rach",
@@ -1027,7 +1027,7 @@
     {
       "name": "protect-mcp",
       "source": "./plugins/protect-mcp",
-      "description": "Cedar policy enforcement + Ed25519 signed receipts for every Claude Code tool call. First cryptographic governance plugin — decisions are policy-gated before they run and every decision produces a tamper-evident receipt verifiable offline.",
+      "description": "Cedar policy enforcement + Ed25519 signed receipts for every Claude Code tool call. First cryptographic governance plugin \u2014 decisions are policy-gated before they run and every decision produces a tamper-evident receipt verifiable offline.",
       "version": "0.1.0",
       "author": {
         "name": "Tom Farley",
@@ -1037,7 +1037,15 @@
       "homepage": "https://veritasacta.com",
       "license": "MIT",
       "category": "governance",
-      "keywords": ["cedar", "receipts", "ed25519", "policy", "governance", "audit", "compliance"]
+      "keywords": [
+        "cedar",
+        "receipts",
+        "ed25519",
+        "policy",
+        "governance",
+        "audit",
+        "compliance"
+      ]
     },
     {
       "name": "signed-audit-trails",
@@ -1052,7 +1060,16 @@
       "homepage": "https://veritasacta.com",
       "license": "MIT",
       "category": "governance",
-      "keywords": ["tutorial", "skill", "recipe", "audit", "governance", "cedar", "receipts", "ed25519"]
+      "keywords": [
+        "tutorial",
+        "skill",
+        "recipe",
+        "audit",
+        "governance",
+        "cedar",
+        "receipts",
+        "ed25519"
+      ]
     },
     {
       "name": "review-agent-governance",
@@ -1067,12 +1084,20 @@
       "homepage": "https://veritasacta.com",
       "license": "MIT",
       "category": "governance",
-      "keywords": ["review", "governance", "cedar", "receipts", "human-approval", "pr-review", "ci-guard"]
+      "keywords": [
+        "review",
+        "governance",
+        "cedar",
+        "receipts",
+        "human-approval",
+        "pr-review",
+        "ci-guard"
+      ]
     },
     {
       "name": "ship-mate",
       "source": "./plugins/ship-mate",
-      "description": "Your AI development teammate. Turns a story file into a shipped, reviewed, and tested feature via orchestrator → architect → developer → PR reviewer → QA → Playwright.",
+      "description": "Your AI development teammate. Turns a story file into a shipped, reviewed, and tested feature via orchestrator \u2192 architect \u2192 developer \u2192 PR reviewer \u2192 QA \u2192 Playwright.",
       "version": "1.0.0",
       "author": {
         "name": "Pranay Yadav",
@@ -1081,7 +1106,29 @@
       },
       "license": "MIT",
       "category": "workflows",
-      "keywords": ["pipeline", "automation", "orchestration", "code-review", "qa", "playwright", "multi-agent", "dev-workflow"]
+      "keywords": [
+        "pipeline",
+        "automation",
+        "orchestration",
+        "code-review",
+        "qa",
+        "playwright",
+        "multi-agent",
+        "dev-workflow"
+      ]
+    },
+    {
+      "name": "pluginpool",
+      "source": "./plugins/pluginpool",
+      "description": "Ten focused developer productivity commands: commit-narrator, pr-storyteller, test-gap, deps-doctor, env-lint, secret-guard, standup-gen, todo-harvest, flaky-detector, changelog-forge. Each command's core is a deterministic Python helper (stdlib only at runtime) wrapped as a Claude Code slash command. 89 hermetic tests across the suite.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Mehmet Turac",
+        "url": "https://github.com/mturac"
+      },
+      "homepage": "https://github.com/mturac/pluginpool",
+      "license": "MIT",
+      "category": "productivity"
     }
   ]
 }

--- a/plugins/pluginpool/.claude-plugin/plugin.json
+++ b/plugins/pluginpool/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "pluginpool",
+  "version": "0.1.0",
+  "description": "Ten focused developer productivity commands wrapped as Claude Code slash commands — semantic commits, PR stories, test coverage gaps, dependency audits, env-key parity, secret scanning, standup notes, TODO harvest, flakiness detection, and changelog forging. Each command's core is a deterministic Python helper (stdlib only at runtime).",
+  "author": {
+    "name": "Mehmet Turac",
+    "email": "noreply@github.com"
+  },
+  "license": "MIT"
+}

--- a/plugins/pluginpool/README.md
+++ b/plugins/pluginpool/README.md
@@ -1,0 +1,44 @@
+# pluginpool
+
+Ten focused developer productivity commands wrapped as Claude Code slash commands. Each command's core is a deterministic Python helper (Python standard library only at runtime — no `pip install` to use any of them).
+
+## Commands
+
+| Command | Purpose |
+|---|---|
+| `/commit-narrator` | Generate semantic commit message from `git diff --cached`, including the *why* behind changes |
+| `/pr-storyteller` | Generate PR title, body, and test plan from commits and diff vs base branch |
+| `/test-gap` | Identify lines in your diff lacking test coverage (Cobertura / lcov / coverage.json) |
+| `/deps-doctor` | Multi-ecosystem dependency audit (npm, pip, cargo, go) — one unified report |
+| `/env-lint` | Compare `.env` vs `.env.example` key parity — never prints values |
+| `/secret-guard` | Pre-commit secret scanner using pattern and entropy detection, redacted output |
+| `/standup-gen` | Generate daily standup notes from git activity across one or many repos |
+| `/todo-harvest` | Scan for TODO/FIXME/HACK comments with git blame author + age |
+| `/flaky-detector` | Run a test command N times and report per-test flakiness percentage |
+| `/changelog-forge` | Convert conventional commits into a CHANGELOG section + semver bump |
+
+**89 hermetic tests across the suite** (in upstream repos), all green. Each helper has a plain CLI for use without Claude Code:
+
+```sh
+git diff --staged | python3 plugins/pluginpool/scripts/narrate.py --diff - --format json
+```
+
+## Upstream
+
+Each command also lives as its own standalone repo with a full test suite, examples, and Makefile-based development workflow:
+
+- [mturac/pluginpool](https://github.com/mturac/pluginpool) (index)
+- [pluginpool-commit-narrator](https://github.com/mturac/pluginpool-commit-narrator)
+- [pluginpool-pr-storyteller](https://github.com/mturac/pluginpool-pr-storyteller)
+- [pluginpool-test-gap](https://github.com/mturac/pluginpool-test-gap)
+- [pluginpool-deps-doctor](https://github.com/mturac/pluginpool-deps-doctor)
+- [pluginpool-env-lint](https://github.com/mturac/pluginpool-env-lint)
+- [pluginpool-secret-guard](https://github.com/mturac/pluginpool-secret-guard)
+- [pluginpool-standup-gen](https://github.com/mturac/pluginpool-standup-gen)
+- [pluginpool-todo-harvest](https://github.com/mturac/pluginpool-todo-harvest)
+- [pluginpool-flaky-detector](https://github.com/mturac/pluginpool-flaky-detector)
+- [pluginpool-changelog-forge](https://github.com/mturac/pluginpool-changelog-forge)
+
+## License
+
+MIT.

--- a/plugins/pluginpool/commands/changelog-forge.md
+++ b/plugins/pluginpool/commands/changelog-forge.md
@@ -1,0 +1,16 @@
+---
+description: Group conventional commits since last tag into a CHANGELOG entry
+allowed-tools: Bash
+---
+
+Role: act as a release scribe. Turn conventional commits into a clean `## [Unreleased]` block plus a semver-bump recommendation.
+
+Run the helper:
+
+```bash
+python3 scripts/forge.py --format md
+```
+
+Useful flags: `--from v1.2.0`, `--to HEAD`, `--write` (prepend to `CHANGELOG.md`, idempotent), `--format json`.
+
+The helper groups commits by type (feat / fix / perf / refactor / docs / test / build / ci / chore / revert), surfaces `BREAKING CHANGE` markers, and suggests `major | minor | patch`. Read the output, then briefly justify the bump (or push back if the heuristic missed nuance). Only run `--write` when the user explicitly asks for it.

--- a/plugins/pluginpool/commands/commit-narrator.md
+++ b/plugins/pluginpool/commands/commit-narrator.md
@@ -1,0 +1,16 @@
+---
+description: Generate a conventional commit message from the staged diff
+allowed-tools: Bash
+---
+
+Role: act as the commit-message author responsible only for producing one conventional commit message for the current repository.
+
+Run the local helper with Bash:
+
+```bash
+git diff --staged --binary | python3 scripts/narrate.py --diff -
+```
+
+The helper accepts an empty diff and returns no text. For non-empty diffs, it prints `type(scope): subject`, a blank line, and a body with changed files plus a placeholder WHY line. Valid types are `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, and `perf`.
+
+Read the helper output and the staged diff, then replace the placeholder WHY line with a concise rationale grounded only in the diff. Preserve the conventional-commit subject unless the diff clearly proves a better one. Print only the final commit message.

--- a/plugins/pluginpool/commands/deps-doctor.md
+++ b/plugins/pluginpool/commands/deps-doctor.md
@@ -1,0 +1,16 @@
+---
+description: Run dependency health audits across supported ecosystems
+allowed-tools: Bash
+---
+
+Run `python3 scripts/doctor.py "$@"` from the deps-doctor plugin root.
+
+Purpose: detect supported dependency ecosystems, run available local audit tools, and summarize advisories without failing when tools are missing.
+
+Inputs: optional `--format`, `--severity`, and `--ecosystem` arguments supplied by the user.
+
+Boundaries: do not edit files, do not install packages, do not use the network directly, and do not hide skipped tools.
+
+Output contract: return either the helper output or a concise failure summary with command, exit status, and next step.
+
+Verification contract: accept success only when the helper exits 0 and prints JSON or markdown matching the requested format.

--- a/plugins/pluginpool/commands/env-lint.md
+++ b/plugins/pluginpool/commands/env-lint.md
@@ -1,0 +1,18 @@
+---
+description: Validate .env files against .env.example without printing values
+allowed-tools: Bash
+---
+
+Role: act as an env-var auditor. Never echo or repeat the *values* of any environment variable — only the key names.
+
+Run the helper:
+
+```sh
+python3 scripts/envlint.py --format md
+```
+
+Useful flags: `--example .env.example --env .env.local`, `--format json`.
+
+The helper auto-detects common pairs (`.env` vs `.env.example`, `.env.local` vs `.env.example`, `.env.production` vs `.env.example`) or accepts an explicit pair. It reports missing keys, extra keys, and keys with empty values. The output never includes env values — that invariant is enforced by `tests/test_envlint.py::test_never_emits_values_in_json_or_markdown`.
+
+Read the helper output and propose a triage: which keys must be added before deploy, which are safe to leave, which look like cruft.

--- a/plugins/pluginpool/commands/flaky-detector.md
+++ b/plugins/pluginpool/commands/flaky-detector.md
@@ -1,0 +1,16 @@
+---
+description: Detect flaky tests by running a test command N times
+allowed-tools: Bash
+---
+
+Role: act as a flake hunter. Identify tests that don't always agree with themselves.
+
+Run the helper:
+
+```bash
+python3 scripts/flaky.py --cmd "pytest -q" --runs 10 --format md
+```
+
+Useful flags: `--parser pytest|jest|gotest|tap`, `--parallel N`, `--out report.json`.
+
+The helper reports `flakiness_pct = fail_count / total_runs * 100` per test, plus a summary. Exit codes: `0` clean, `1` flaky tests found, `2` always-failing tests found. Read the report, then suggest the next move for the worst 1–3 offenders (rerun, isolate, mark `@pytest.mark.flaky`, or root-cause). Don't speculate beyond what the output supports.

--- a/plugins/pluginpool/commands/pr-storyteller.md
+++ b/plugins/pluginpool/commands/pr-storyteller.md
@@ -1,0 +1,20 @@
+---
+description: Generate a PR title, body, and test plan from commits and diff
+allowed-tools: Bash
+---
+
+Role: act as the PR description author responsible only for producing a PR title and markdown body for the current repository.
+
+Run the local helper with Bash:
+
+```bash
+python3 scripts/story.py --base main
+```
+
+If the result has no commits and no changed files, rerun with:
+
+```bash
+python3 scripts/story.py --base master
+```
+
+The helper returns JSON with `commits`, `files_changed`, and `suggested_title`. Use only that JSON plus local diff evidence. Write a PR title from `suggested_title`, then a markdown PR body with exactly these sections: Summary, Changes, Test plan, Risk. Print only the PR title and markdown body.

--- a/plugins/pluginpool/commands/secret-guard.md
+++ b/plugins/pluginpool/commands/secret-guard.md
@@ -1,0 +1,24 @@
+---
+description: Scan staged diff (or specified files) for leaked secrets with redacted output
+allowed-tools: Bash
+---
+
+Role: act as a pre-merge security gate. Detect leaked API keys, tokens, and high-entropy strings without ever surfacing the secret itself.
+
+Run the helper:
+
+```sh
+python3 scripts/guard.py --format md
+```
+
+Useful flags: `--files app.py config.txt` (scan explicit files instead of staged diff), `--allowlist .secret-allowlist` (suppress known false positives).
+
+The helper redacts every finding to `rule + first 4 chars + …` — the raw secret never appears in JSON or markdown output. This invariant is enforced by `tests/test_guard.py::test_redaction_contains_only_rule_and_first_four`.
+
+For pre-commit integration:
+
+```sh
+cp hooks/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+```
+
+Exit codes: `0` clean, `1` finding present. Read the report and recommend: rotate, allowlist, or fix.

--- a/plugins/pluginpool/commands/standup-gen.md
+++ b/plugins/pluginpool/commands/standup-gen.md
@@ -1,0 +1,16 @@
+---
+description: Generate daily standup notes from git activity
+allowed-tools: Bash
+---
+
+Role: act as a standup-note author. Produce Yesterday / Today / Blockers sections grounded only in the user's git activity.
+
+Run the helper:
+
+```bash
+python3 scripts/standup.py --format md
+```
+
+Useful flags: `--since 2026-05-15`, `--since yesterday`, `--repos /path/repoA,/path/repoB`, `--author all`, `--format json`.
+
+The helper fills "Yesterday" from commit subjects and leaves "Today (planned)" and "Blockers" as placeholders. Read the commit list, then propose 1–3 candidate "Today" items derived from in-flight files (e.g. files with WIP or follow-up commits). Mark blockers only if the diffs or commit messages clearly evidence one. Print the final markdown.

--- a/plugins/pluginpool/commands/test-gap.md
+++ b/plugins/pluginpool/commands/test-gap.md
@@ -1,0 +1,16 @@
+---
+description: Surface changed git diff lines that are not covered by tests
+allowed-tools: Bash
+---
+
+Run `python3 scripts/gap.py "$@"` from the test-gap plugin root.
+
+Purpose: compare the current git diff against the selected base branch, parse the selected or auto-detected coverage report, and report changed lines that are not covered by tests.
+
+Inputs: optional `--base`, `--report`, and `--format` arguments supplied by the user.
+
+Boundaries: do not edit files, do not install packages, do not use the network, and do not hide failures.
+
+Output contract: return either the helper output or a concise failure summary with command, exit status, and next step.
+
+Verification contract: accept success only when the helper exits 0 and prints JSON or markdown matching the requested format.

--- a/plugins/pluginpool/commands/todo-harvest.md
+++ b/plugins/pluginpool/commands/todo-harvest.md
@@ -1,0 +1,16 @@
+---
+description: List TODO/FIXME/HACK comments with author + age in days
+allowed-tools: Bash
+---
+
+Role: act as a debt-triage assistant. Surface the oldest, highest-cost TODOs first.
+
+Run the helper:
+
+```bash
+python3 scripts/harvest.py --format md
+```
+
+Useful flags: `--markers TODO,FIXME,HACK`, `--min-age 90`, `--format json`.
+
+The helper uses `git ls-files` (respecting .gitignore) and runs `git blame` per match for author + age. Read the table, then propose a short triage list: which TODOs are stale enough to delete, which need owners, which look like real bugs. Be specific — quote the file and line.

--- a/plugins/pluginpool/scripts/doctor.py
+++ b/plugins/pluginpool/scripts/doctor.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Run dependency health audits across supported ecosystems."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SEVERITY_ORDER = {"low": 0, "moderate": 1, "medium": 1, "high": 2, "critical": 3}
+COMMANDS = {
+    "npm": ["npm", "audit", "--json"],
+    "pip": ["pip-audit", "--format=json"],
+    "cargo": ["cargo", "audit", "--json"],
+    "go": ["govulncheck", "-json", "./..."],
+}
+
+
+def detect_ecosystems(root: Path = Path(".")) -> list[str]:
+    ecosystems: list[str] = []
+    if (root / "package.json").exists():
+        ecosystems.append("npm")
+    if (root / "requirements.txt").exists() or (root / "pyproject.toml").exists():
+        ecosystems.append("pip")
+    if (root / "Cargo.toml").exists():
+        ecosystems.append("cargo")
+    if (root / "go.mod").exists():
+        ecosystems.append("go")
+    return ecosystems
+
+
+def run_audit(name: str) -> tuple[str | None, str | None]:
+    command = COMMANDS[name]
+    if shutil.which(command[0]) is None:
+        return None, "skipped: tool not installed"
+    result = subprocess.run(command, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if result.stdout:
+        return result.stdout, None
+    if result.returncode != 0:
+        return None, result.stderr.strip() or f"{name} audit failed"
+    return "{}", None
+
+
+def normalize_severity(value: Any) -> str:
+    text = str(value or "unknown").lower()
+    return "moderate" if text == "medium" else text
+
+
+def fixed_in(value: Any) -> list[str]:
+    if value in (None, False):
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    if isinstance(value, dict):
+        version = value.get("version")
+        if version:
+            return [str(version)]
+    return []
+
+
+def npm_advisories(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    advisories: list[dict[str, Any]] = []
+    for package, vuln in payload.get("vulnerabilities", {}).items():
+        via = vuln.get("via", [])
+        source = next((item for item in via if isinstance(item, dict)), {})
+        advisories.append({
+            "id": str(source.get("source") or source.get("url") or vuln.get("name") or package),
+            "severity": normalize_severity(vuln.get("severity") or source.get("severity")),
+            "package": package,
+            "version": ",".join(vuln.get("nodes", [])) or "",
+            "fixed_in": fixed_in(vuln.get("fixAvailable")),
+        })
+    for advisory in payload.get("advisories", {}).values():
+        advisories.append({
+            "id": str(advisory.get("id") or advisory.get("url") or advisory.get("module_name")),
+            "severity": normalize_severity(advisory.get("severity")),
+            "package": advisory.get("module_name", ""),
+            "version": advisory.get("vulnerable_versions", ""),
+            "fixed_in": fixed_in(advisory.get("patched_versions")),
+        })
+    return advisories
+
+
+def pip_advisories(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    advisories: list[dict[str, Any]] = []
+    for dep in payload.get("dependencies", []):
+        for vuln in dep.get("vulns", []):
+            advisories.append({
+                "id": str(vuln.get("id") or vuln.get("aliases", [""])[0]),
+                "severity": normalize_severity(vuln.get("severity")),
+                "package": dep.get("name", ""),
+                "version": dep.get("version", ""),
+                "fixed_in": fixed_in(vuln.get("fix_versions")),
+            })
+    return advisories
+
+
+def cargo_advisories(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    advisories: list[dict[str, Any]] = []
+    for item in payload.get("vulnerabilities", {}).get("list", []):
+        advisory = item.get("advisory", {})
+        package = item.get("package", {})
+        versions = item.get("versions", {})
+        advisories.append({
+            "id": str(advisory.get("id", "")),
+            "severity": normalize_severity(advisory.get("severity")),
+            "package": package.get("name", ""),
+            "version": package.get("version", ""),
+            "fixed_in": fixed_in(versions.get("patched")),
+        })
+    return advisories
+
+
+def go_advisories(output: str) -> list[dict[str, Any]]:
+    advisories: list[dict[str, Any]] = []
+    for line in output.splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        finding = event.get("finding") or event.get("vulnerability") or {}
+        osv = finding.get("osv") or finding
+        if not osv:
+            continue
+        advisories.append({
+            "id": str(osv.get("id", "")),
+            "severity": normalize_severity(osv.get("database_specific", {}).get("severity")),
+            "package": finding.get("package", ""),
+            "version": "",
+            "fixed_in": fixed_in(osv.get("affected", [])),
+        })
+    return advisories
+
+
+def parse_advisories(name: str, output: str) -> list[dict[str, Any]]:
+    # govulncheck emits NDJSON (one JSON object per line); pass raw text through
+    # so the go parser can handle line-by-line. Other tools emit a single JSON document.
+    if name == "go":
+        return go_advisories(output)
+    try:
+        payload = json.loads(output or "{}")
+    except json.JSONDecodeError:
+        return []
+    if name == "npm":
+        return npm_advisories(payload)
+    if name == "pip":
+        return pip_advisories(payload)
+    if name == "cargo":
+        return cargo_advisories(payload)
+    return []
+
+
+def severity_allowed(advisory: dict[str, Any], minimum: str) -> bool:
+    return SEVERITY_ORDER.get(advisory.get("severity", "unknown"), -1) >= SEVERITY_ORDER[minimum]
+
+
+def audit(ecosystems: list[str], minimum: str = "low") -> dict[str, list[dict[str, Any]]]:
+    results: list[dict[str, Any]] = []
+    for name in ecosystems:
+        output, skipped = run_audit(name)
+        advisories = [] if output is None else [item for item in parse_advisories(name, output) if severity_allowed(item, minimum)]
+        results.append({
+            "name": name,
+            "advisories": advisories,
+            "outdated_count": 0,
+            "license_warnings": [],
+            **({"skipped": skipped} if skipped else {}),
+        })
+    return {"ecosystems": results}
+
+
+def markdown(result: dict[str, list[dict[str, Any]]]) -> str:
+    grouped: dict[str, list[tuple[str, dict[str, Any]]]] = {key: [] for key in ("critical", "high", "moderate", "low", "unknown")}
+    skipped: list[str] = []
+    for eco in result["ecosystems"]:
+        if eco.get("skipped"):
+            skipped.append(f"- {eco['name']}: {eco['skipped']}")
+        for advisory in eco["advisories"]:
+            grouped.setdefault(advisory.get("severity", "unknown"), []).append((eco["name"], advisory))
+
+    lines = ["# Dependency Doctor"]
+    for severity in ("critical", "high", "moderate", "low", "unknown"):
+        items = grouped.get(severity, [])
+        if not items:
+            continue
+        lines.extend([f"## {severity.title()}", "| Ecosystem | ID | Package | Version | Fixed In |", "| --- | --- | --- | --- | --- |"])
+        for ecosystem, advisory in items:
+            lines.append(
+                f"| {ecosystem} | {advisory['id']} | {advisory['package']} | "
+                f"{advisory['version']} | {','.join(advisory['fixed_in']) or '-'} |"
+            )
+    if skipped:
+        lines.append("## Skipped")
+        lines.extend(skipped)
+    if len(lines) == 1:
+        lines.append("No advisories found.")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run dependency health audits across ecosystems.")
+    parser.add_argument("--format", choices=("json", "md"), default="json")
+    parser.add_argument("--severity", choices=("low", "moderate", "high", "critical"), default="low")
+    parser.add_argument("--ecosystem", help="Comma-separated ecosystem filter, e.g. npm,pip.")
+    args = parser.parse_args(argv)
+
+    detected = detect_ecosystems()
+    if args.ecosystem:
+        allowed = {item.strip() for item in args.ecosystem.split(",") if item.strip()}
+        detected = [item for item in detected if item in allowed]
+    result = audit(detected, args.severity)
+    print(markdown(result) if args.format == "md" else json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/pluginpool/scripts/envlint.py
+++ b/plugins/pluginpool/scripts/envlint.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Validate .env files against .env.example without emitting values."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+
+KEY_RE = re.compile(r"^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=")
+DEFAULT_PAIRS = (
+    (".env.example", ".env"),
+    (".env.example", ".env.local"),
+    (".env.example", ".env.production"),
+)
+
+
+def parse_env(path: str) -> Tuple[List[str], Dict[str, bool]]:
+    keys: List[str] = []
+    empty: Dict[str, bool] = {}
+    seen = set()
+    with open(path, "r", encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            match = KEY_RE.match(line)
+            if not match:
+                continue
+            key = match.group(1)
+            if key not in seen:
+                keys.append(key)
+                seen.add(key)
+            value = line.split("=", 1)[1].strip()
+            empty[key] = value in {"", '""', "''"}
+    return keys, empty
+
+
+def existing_pairs() -> List[Tuple[str, str]]:
+    return [(example, env) for example, env in DEFAULT_PAIRS if os.path.exists(example) and os.path.exists(env)]
+
+
+def compare_pair(example: str, env: str) -> dict:
+    example_keys, _ = parse_env(example)
+    env_keys, env_empty = parse_env(env)
+    example_set = set(example_keys)
+    env_set = set(env_keys)
+    return {
+        "example": example,
+        "env": env,
+        "missing_in_env": [key for key in example_keys if key not in env_set],
+        "extra_in_env": [key for key in env_keys if key not in example_set],
+        "empty_values": [key for key in env_keys if env_empty.get(key, False)],
+    }
+
+
+def to_markdown(results: Sequence[dict]) -> str:
+    lines = ["# env-lint report", ""]
+    if not results:
+        lines.append("No existing .env pairs found.")
+        return "\n".join(lines) + "\n"
+    for item in results:
+        lines.extend(
+            [
+                f"## {item['env']} vs {item['example']}",
+                "",
+                f"- Missing in env: {', '.join(item['missing_in_env']) or 'none'}",
+                f"- Extra in env: {', '.join(item['extra_in_env']) or 'none'}",
+                f"- Empty values: {', '.join(item['empty_values']) or 'none'}",
+                "",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Validate .env files against .env.example without printing values.")
+    parser.add_argument("--example", help="Example env file path")
+    parser.add_argument("--env", help="Environment file path")
+    parser.add_argument("--format", choices=("json", "md"), default="json", help="Output format")
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if bool(args.example) != bool(args.env):
+        raise SystemExit("--example and --env must be provided together")
+
+    pairs = [(args.example, args.env)] if args.example else existing_pairs()
+    results = [compare_pair(example, env) for example, env in pairs]
+    payload = {"pairs": results}
+    if args.format == "md":
+        sys.stdout.write(to_markdown(results))
+    else:
+        sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    return 1 if any(pair["missing_in_env"] for pair in results) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/pluginpool/scripts/flaky.py
+++ b/plugins/pluginpool/scripts/flaky.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Run a test command N times and report per-test flakiness."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import re
+import shlex
+import subprocess
+import sys
+from collections import defaultdict
+from typing import Callable
+
+
+# ---------- parsers ----------
+
+_PYTEST_LINE = re.compile(
+    r"^(?P<path>\S+::\S+(?:::\S+)?)\s+(?P<status>PASSED|FAILED|ERROR|SKIPPED|XFAIL|XPASS)"
+)
+# Short-form `pytest -q` only prints `FAILED path::test - reason` / `ERROR path::test` in the
+# tail summary, plus a final tally line. We pick those up to avoid a false-green report when
+# the user runs the default short reporter.
+_PYTEST_TAIL = re.compile(r"^(?P<status>FAILED|ERROR|PASSED)\s+(?P<path>\S+::\S+(?:::\S+)?)")
+_PYTEST_TALLY = re.compile(r"=+\s*(?:(\d+) failed[, ]*)?(?:(\d+) passed[, ]*)?")
+
+
+def parse_pytest(stdout: str) -> dict[str, str]:
+    """Parse pytest -v and pytest -q output. Returns {test_id: 'pass'|'fail'|'skip'}."""
+    results: dict[str, str] = {}
+    for line in stdout.splitlines():
+        m = _PYTEST_LINE.search(line)
+        if m:
+            status = m.group("status")
+            test_id = m.group("path")
+            if status in ("PASSED", "XPASS"):
+                results[test_id] = "pass"
+            elif status in ("FAILED", "ERROR", "XFAIL"):
+                results[test_id] = "fail"
+            elif status == "SKIPPED":
+                results[test_id] = "skip"
+            continue
+        m2 = _PYTEST_TAIL.match(line)
+        if m2:
+            status, tid = m2.group("status"), m2.group("path")
+            if status == "PASSED":
+                results.setdefault(tid, "pass")
+            else:
+                results[tid] = "fail"
+    return results
+
+
+def _pytest_tally(stdout: str) -> tuple[int, int]:
+    """Return (failed, passed) from the pytest tail tally line, or (0, 0) if absent."""
+    failed = passed = 0
+    for line in reversed(stdout.splitlines()):
+        m = _PYTEST_TALLY.search(line)
+        if m and (m.group(1) or m.group(2)):
+            failed = int(m.group(1) or 0)
+            passed = int(m.group(2) or 0)
+            break
+    return failed, passed
+
+
+_JEST_LINE = re.compile(r"^\s*(✓|✗|×|PASS|FAIL)\s+(.+?)(?:\s+\(\d+\s*m?s\))?\s*$")
+
+
+def parse_jest(stdout: str) -> dict[str, str]:
+    results: dict[str, str] = {}
+    for line in stdout.splitlines():
+        m = _JEST_LINE.match(line)
+        if not m:
+            continue
+        token, name = m.group(1), m.group(2).strip()
+        if token in ("✓", "PASS"):
+            results[name] = "pass"
+        elif token in ("✗", "×", "FAIL"):
+            results[name] = "fail"
+    return results
+
+
+_GOTEST_LINE = re.compile(r"^---\s+(PASS|FAIL|SKIP):\s+(\S+)")
+
+
+def parse_gotest(stdout: str) -> dict[str, str]:
+    results: dict[str, str] = {}
+    for line in stdout.splitlines():
+        m = _GOTEST_LINE.match(line)
+        if m:
+            status, name = m.group(1), m.group(2)
+            results[name] = {"PASS": "pass", "FAIL": "fail", "SKIP": "skip"}[status]
+    return results
+
+
+_TAP_LINE = re.compile(r"^(ok|not ok)\s+\d+\s*-?\s*(.*?)\s*$")
+
+
+def parse_tap(stdout: str) -> dict[str, str]:
+    results: dict[str, str] = {}
+    for line in stdout.splitlines():
+        m = _TAP_LINE.match(line)
+        if m:
+            ok, name = m.group(1), m.group(2)
+            name = name or f"<test-{len(results) + 1}>"
+            results[name] = "pass" if ok == "ok" else "fail"
+    return results
+
+
+PARSERS: dict[str, Callable[[str], dict[str, str]]] = {
+    "pytest": parse_pytest,
+    "jest": parse_jest,
+    "gotest": parse_gotest,
+    "tap": parse_tap,
+}
+
+
+def auto_parser(cmd: str) -> str:
+    c = cmd.lower()
+    if "jest" in c or "vitest" in c:
+        return "jest"
+    if "go test" in c:
+        return "gotest"
+    if "tap" in c:
+        return "tap"
+    return "pytest"
+
+
+# ---------- runner ----------
+
+def _run_once(cmd: str) -> str:
+    res = subprocess.run(shlex.split(cmd), capture_output=True, text=True, check=False)
+    return (res.stdout or "") + "\n" + (res.stderr or "")
+
+
+def run_many(cmd: str, runs: int, parallel: int) -> list[str]:
+    if parallel <= 1 or runs == 1:
+        return [_run_once(cmd) for _ in range(runs)]
+    outputs: list[str] = [""] * runs
+    with concurrent.futures.ThreadPoolExecutor(max_workers=parallel) as ex:
+        futures = {ex.submit(_run_once, cmd): i for i in range(runs)}
+        for fut in concurrent.futures.as_completed(futures):
+            i = futures[fut]
+            outputs[i] = fut.result()
+    return outputs
+
+
+# ---------- aggregator ----------
+
+def aggregate(per_run: list[dict[str, str]]) -> dict:
+    total = len(per_run)
+    counts: dict[str, dict[str, int]] = defaultdict(lambda: {"pass": 0, "fail": 0, "skip": 0})
+    for run in per_run:
+        for tid, status in run.items():
+            counts[tid][status] += 1
+
+    tests = []
+    for tid, c in counts.items():
+        runs_seen = c["pass"] + c["fail"]
+        pct = (c["fail"] / runs_seen * 100.0) if runs_seen else 0.0
+        tests.append(
+            {
+                "id": tid,
+                "pass_count": c["pass"],
+                "fail_count": c["fail"],
+                "skip_count": c["skip"],
+                "flakiness_pct": round(pct, 2),
+            }
+        )
+
+    flaky = [t for t in tests if 0 < t["flakiness_pct"] < 100]
+    always_failing = [t for t in tests if t["pass_count"] == 0 and t["fail_count"] > 0]
+    always_passing = [t for t in tests if t["fail_count"] == 0 and t["pass_count"] > 0]
+
+    tests.sort(key=lambda t: (-t["flakiness_pct"], t["id"]))
+    return {
+        "tests": tests,
+        "summary": {
+            "total_runs": total,
+            "flaky_tests": len(flaky),
+            "always_failing": len(always_failing),
+            "always_passing": len(always_passing),
+        },
+    }
+
+
+def render_markdown(report: dict) -> str:
+    s = report["summary"]
+    lines = [
+        f"# Flaky-detector report ({s['total_runs']} runs)",
+        "",
+        f"- flaky: **{s['flaky_tests']}**  |  always-failing: **{s['always_failing']}**  |  always-passing: {s['always_passing']}",
+        "",
+        "| test | pass | fail | flakiness % |",
+        "|---|---|---|---|",
+    ]
+    for t in report["tests"]:
+        if t["fail_count"] == 0:
+            continue
+        lines.append(f"| {t['id']} | {t['pass_count']} | {t['fail_count']} | {t['flakiness_pct']} |")
+    return "\n".join(lines) + "\n"
+
+
+# ---------- main ----------
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Detect flaky tests by running a command N times.")
+    p.add_argument("--cmd", required=True)
+    p.add_argument("--runs", type=int, default=10)
+    p.add_argument("--parallel", type=int, default=1)
+    p.add_argument("--parser", choices=list(PARSERS.keys()) + ["auto"], default="auto")
+    p.add_argument("--out", default=None)
+    p.add_argument("--format", choices=["json", "md"], default="json")
+    args = p.parse_args(argv)
+
+    parser_name = auto_parser(args.cmd) if args.parser == "auto" else args.parser
+    parse = PARSERS[parser_name]
+
+    outputs = run_many(args.cmd, args.runs, args.parallel)
+    per_run = [parse(o) for o in outputs]
+    report = aggregate(per_run)
+    report["parser"] = parser_name
+
+    # Guard against silent false-green: if zero tests parsed yet the tally suggests
+    # tests actually ran, surface a warning + non-zero exit.
+    warnings: list[str] = []
+    if parser_name == "pytest" and not any(per_run) and outputs:
+        for o in outputs:
+            failed, passed = _pytest_tally(o)
+            if failed + passed > 0:
+                warnings.append(
+                    f"pytest reported {failed} failed / {passed} passed but no per-test "
+                    "lines parsed — re-run with `-v` so flaky-detector can attribute results."
+                )
+                break
+    report["warnings"] = warnings
+
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2)
+
+    if args.format == "md":
+        sys.stdout.write(render_markdown(report))
+    else:
+        json.dump(report, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+
+    if report["summary"]["always_failing"] > 0:
+        return 2
+    if report["summary"]["flaky_tests"] > 0:
+        return 1
+    if warnings:
+        sys.stderr.write("\n".join(warnings) + "\n")
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/pluginpool/scripts/forge.py
+++ b/plugins/pluginpool/scripts/forge.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Group conventional commits since last tag into a CHANGELOG section."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import subprocess
+import sys
+from typing import Iterable
+
+
+CONVENTIONAL_TYPES = (
+    "feat",
+    "fix",
+    "perf",
+    "refactor",
+    "docs",
+    "test",
+    "build",
+    "ci",
+    "chore",
+    "revert",
+)
+
+_HEADER = re.compile(
+    r"^(?P<type>[a-z]+)(?:\((?P<scope>[^)]+)\))?(?P<bang>!?):\s*(?P<subject>.+)$"
+)
+
+# Use RS (0x1e) record separator and US (0x1f) field separator
+_FMT = "%H%x1f%s%x1f%b%x1e"
+
+
+def _run(args: list[str], cwd: str) -> str:
+    res = subprocess.run(args, cwd=cwd, capture_output=True, text=True, check=False)
+    return res.stdout
+
+
+def _last_tag(cwd: str) -> str | None:
+    out = _run(["git", "describe", "--tags", "--abbrev=0"], cwd).strip()
+    return out or None
+
+
+def _git_log(cwd: str, frm: str | None, to: str) -> str:
+    rng = f"{frm}..{to}" if frm else to
+    return _run(["git", "log", rng, f"--pretty=format:{_FMT}"], cwd)
+
+
+def _split_log(raw: str) -> list[tuple[str, str, str]]:
+    items: list[tuple[str, str, str]] = []
+    for record in raw.split("\x1e"):
+        record = record.strip("\n\r")
+        if not record:
+            continue
+        parts = record.split("\x1f")
+        if len(parts) < 3:
+            parts += [""] * (3 - len(parts))
+        h, subj, body = parts[0].strip(), parts[1], parts[2]
+        if h:
+            items.append((h, subj, body))
+    return items
+
+
+def parse_commit(hash_: str, subject: str, body: str) -> dict:
+    m = _HEADER.match(subject)
+    if not m:
+        return {"hash": hash_, "type": "other", "scope": None, "breaking": False,
+                "subject": subject, "body": body}
+    typ = m.group("type")
+    scope = m.group("scope")
+    breaking = bool(m.group("bang")) or ("BREAKING CHANGE" in body)
+    return {
+        "hash": hash_,
+        "type": typ if typ in CONVENTIONAL_TYPES else "other",
+        "scope": scope,
+        "breaking": breaking,
+        "subject": m.group("subject").strip(),
+        "body": body,
+    }
+
+
+def group_commits(commits: Iterable[dict]) -> dict[str, list[dict]]:
+    sections: dict[str, list[dict]] = {t: [] for t in CONVENTIONAL_TYPES}
+    sections["other"] = []
+    for c in commits:
+        sections.setdefault(c["type"], []).append(c)
+    return sections
+
+
+def suggested_bump(commits: list[dict]) -> str:
+    if any(c["breaking"] for c in commits):
+        return "major"
+    if any(c["type"] == "feat" for c in commits):
+        return "minor"
+    if any(c["type"] in ("fix", "perf") for c in commits):
+        return "patch"
+    return "patch"
+
+
+def bump_version(version: str, bump: str) -> str:
+    v = version.lstrip("v")
+    parts = v.split(".")
+    while len(parts) < 3:
+        parts.append("0")
+    try:
+        major, minor, patch = (int(parts[0]), int(parts[1]), int(parts[2]))
+    except ValueError:
+        return v
+    if bump == "major":
+        return f"{major + 1}.0.0"
+    if bump == "minor":
+        return f"{major}.{minor + 1}.0"
+    return f"{major}.{minor}.{patch + 1}"
+
+
+_PRETTY_TITLES = {
+    "feat": "Features",
+    "fix": "Bug Fixes",
+    "perf": "Performance",
+    "refactor": "Refactor",
+    "docs": "Docs",
+    "test": "Tests",
+    "build": "Build",
+    "ci": "CI",
+    "chore": "Chores",
+    "revert": "Reverts",
+    "other": "Other",
+}
+
+_ORDER = ("feat", "fix", "perf", "refactor", "docs", "test", "build", "ci", "chore", "revert", "other")
+
+
+def render_markdown(report: dict, today: dt.date | None = None) -> str:
+    today = today or dt.date.today()
+    out = [f"## [Unreleased] - {today.isoformat()}", ""]
+    for typ in _ORDER:
+        entries = report["sections"].get(typ, [])
+        if not entries:
+            continue
+        out.append(f"### {_PRETTY_TITLES[typ]}")
+        for c in entries:
+            scope = f"**{c['scope']}**: " if c["scope"] else ""
+            bang = " ⚠ BREAKING" if c["breaking"] else ""
+            out.append(f"- {scope}{c['subject']}{bang} ({c['hash'][:7]})")
+        out.append("")
+    out.append(f"_Suggested bump: **{report['suggested_bump']}**_")
+    if report.get("suggested_version"):
+        out.append(f"_Suggested version: **{report['suggested_version']}**_")
+    out.append("")
+    return "\n".join(out)
+
+
+_UNRELEASED_BLOCK = re.compile(
+    r"(?ms)^## \[Unreleased\][^\n]*\n.*?(?=^## \[|\Z)"
+)
+
+
+def write_changelog(path: str, section_md: str) -> None:
+    section = section_md.rstrip() + "\n\n"
+    if os.path.exists(path):
+        with open(path, "r", encoding="utf-8") as f:
+            existing = f.read()
+        if _UNRELEASED_BLOCK.search(existing):
+            new = _UNRELEASED_BLOCK.sub(section, existing, count=1)
+        else:
+            # Insert the new section AFTER any leading `# Title` block, not before it.
+            stripped = existing.lstrip("\n")
+            if stripped.startswith("# "):
+                head_end = stripped.find("\n\n")
+                if head_end == -1:
+                    head_end = len(stripped)
+                head = stripped[: head_end + 2] if head_end < len(stripped) else stripped + "\n\n"
+                tail = stripped[head_end + 2 :] if head_end < len(stripped) else ""
+                new = head + section + tail
+            else:
+                new = section + existing
+    else:
+        new = "# Changelog\n\n" + section
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(new)
+
+
+def build_report(cwd: str, frm: str | None, to: str) -> dict:
+    raw = _git_log(cwd, frm, to)
+    parsed = [parse_commit(*c) for c in _split_log(raw)]
+    sections = group_commits(parsed)
+    bump = suggested_bump(parsed)
+    suggested_version = None
+    base_tag = frm or _last_tag(cwd)
+    if base_tag:
+        suggested_version = bump_version(base_tag, bump)
+    return {
+        "from": frm or base_tag,
+        "to": to,
+        "commits": parsed,
+        "sections": sections,
+        "breaking_changes": [
+            {"commit": c["hash"], "note": c["subject"]} for c in parsed if c["breaking"]
+        ],
+        "suggested_bump": bump,
+        "suggested_version": suggested_version,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Generate a CHANGELOG section from conventional commits.")
+    p.add_argument("--cwd", default=os.getcwd())
+    p.add_argument("--from", dest="frm", default=None, help="Base ref or tag (default: last tag).")
+    p.add_argument("--to", default="HEAD")
+    p.add_argument("--format", choices=["json", "md"], default="md")
+    p.add_argument("--write", action="store_true", help="Prepend (idempotently) to CHANGELOG.md.")
+    p.add_argument("--changelog", default="CHANGELOG.md")
+    args = p.parse_args(argv)
+
+    frm = args.frm or _last_tag(args.cwd)
+    report = build_report(args.cwd, frm, args.to)
+    md = render_markdown(report)
+
+    if args.write:
+        write_changelog(os.path.join(args.cwd, args.changelog), md)
+
+    if args.format == "md":
+        sys.stdout.write(md)
+    else:
+        json.dump(report, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/pluginpool/scripts/gap.py
+++ b/plugins/pluginpool/scripts/gap.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Find changed git diff lines that coverage reports mark as uncovered."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class CoverageFile:
+    covered: set[int]
+    uncovered: set[int]
+    pct: float
+
+
+HUNK_RE = re.compile(r"@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+
+def run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def default_base() -> str:
+    for branch in ("main", "master"):
+        result = run(["git", "rev-parse", "--verify", branch])
+        if result.returncode == 0:
+            return branch
+    return "main"
+
+
+def git_diff(base: str) -> str:
+    result = run(["git", "diff", "--unified=0", f"{base}..HEAD"])
+    if result.returncode != 0:
+        return ""
+    return result.stdout
+
+
+def parse_diff(diff_text: str) -> dict[str, list[int]]:
+    changed: dict[str, set[int]] = {}
+    current_file: str | None = None
+    current_line: int | None = None
+
+    for line in diff_text.splitlines():
+        if line.startswith("+++ "):
+            path = line[4:].strip()
+            current_file = None if path == "/dev/null" else path.removeprefix("b/")
+            if current_file:
+                changed.setdefault(current_file, set())
+            continue
+
+        match = HUNK_RE.match(line)
+        if match:
+            current_line = int(match.group(1))
+            continue
+
+        if current_file is None or current_line is None:
+            continue
+        if line.startswith("+") and not line.startswith("+++"):
+            changed[current_file].add(current_line)
+            current_line += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            continue
+        elif line.startswith(" "):
+            current_line += 1
+
+    return {path: sorted(lines) for path, lines in changed.items()}
+
+
+def pct(covered: set[int], uncovered: set[int]) -> float:
+    total = len(covered | uncovered)
+    return round((len(covered) / total) * 100, 2) if total else 100.0
+
+
+def parse_lcov(path: Path) -> dict[str, CoverageFile]:
+    files: dict[str, CoverageFile] = {}
+    current: str | None = None
+    covered: set[int] = set()
+    uncovered: set[int] = set()
+
+    def flush() -> None:
+        if current is not None:
+            files[normalize(current)] = CoverageFile(set(covered), set(uncovered), pct(covered, uncovered))
+
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        if raw.startswith("SF:"):
+            flush()
+            current = raw[3:]
+            covered.clear()
+            uncovered.clear()
+        elif raw.startswith("DA:") and current is not None:
+            line_no, hits, *_ = raw[3:].split(",")
+            target = covered if int(float(hits)) > 0 else uncovered
+            target.add(int(line_no))
+        elif raw == "end_of_record":
+            flush()
+            current = None
+            covered.clear()
+            uncovered.clear()
+    flush()
+    return files
+
+
+def parse_cobertura(path: Path) -> dict[str, CoverageFile]:
+    root = ET.parse(path).getroot()
+    files: dict[str, CoverageFile] = {}
+    for class_node in root.findall(".//class"):
+        filename = class_node.get("filename")
+        if not filename:
+            continue
+        covered: set[int] = set()
+        uncovered: set[int] = set()
+        for line in class_node.findall(".//line"):
+            number = line.get("number")
+            hits = line.get("hits", "0")
+            if number is None:
+                continue
+            target = covered if int(float(hits)) > 0 else uncovered
+            target.add(int(number))
+        files[normalize(filename)] = CoverageFile(covered, uncovered, pct(covered, uncovered))
+    return files
+
+
+def parse_coverage_json(path: Path) -> dict[str, CoverageFile]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    files: dict[str, CoverageFile] = {}
+    for filename, data in payload.get("files", {}).items():
+        covered = set(map(int, data.get("executed_lines", [])))
+        uncovered = set(map(int, data.get("missing_lines", [])))
+        summary = data.get("summary", {})
+        percent = summary.get("percent_covered")
+        files[normalize(filename)] = CoverageFile(covered, uncovered, round(float(percent), 2) if percent is not None else pct(covered, uncovered))
+    return files
+
+
+def normalize(path: str) -> str:
+    return os.path.normpath(path).replace("\\", "/")
+
+
+def detect_report(explicit: str | None) -> Path | None:
+    if explicit:
+        candidate = Path(explicit)
+        return candidate if candidate.exists() else None
+    for name in ("coverage.xml", "lcov.info", "coverage.json"):
+        candidate = Path(name)
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def parse_report(path: Path | None) -> dict[str, CoverageFile]:
+    if path is None:
+        return {}
+    if path.name == "lcov.info":
+        return parse_lcov(path)
+    if path.suffix == ".xml":
+        return parse_cobertura(path)
+    if path.suffix == ".json":
+        return parse_coverage_json(path)
+    raise SystemExit(f"Unsupported coverage report: {path}")
+
+
+_UNKNOWN_PCT = -1.0  # sentinel: no coverage info for this file
+
+
+def coverage_for(path: str, coverage: dict[str, CoverageFile]) -> CoverageFile:
+    norm = normalize(path)
+    if norm in coverage:
+        return coverage[norm]
+    for candidate, data in coverage.items():
+        if candidate.endswith("/" + norm) or norm.endswith("/" + candidate):
+            return data
+    return CoverageFile(set(), set(), _UNKNOWN_PCT)
+
+
+def build_result(changed: dict[str, list[int]], coverage: dict[str, CoverageFile]) -> dict[str, list[dict[str, object]]]:
+    have_coverage = bool(coverage)
+    files: list[dict[str, object]] = []
+    for path in sorted(changed):
+        data = coverage_for(path, coverage)
+        if data.pct == _UNKNOWN_PCT:
+            uncovered = list(changed[path])  # unknown → treat every changed line as a gap
+            cov_pct: object = None
+        else:
+            uncovered = [line for line in changed[path] if line in data.uncovered]
+            cov_pct = data.pct
+        files.append({
+            "path": path,
+            "changed_lines": changed[path],
+            "uncovered_lines": uncovered,
+            "coverage_pct": cov_pct,
+        })
+    return {"files": files, "coverage_loaded": have_coverage}
+
+
+def markdown(result: dict[str, list[dict[str, object]]]) -> str:
+    files = sorted(result["files"], key=lambda item: len(item["uncovered_lines"]), reverse=True)
+    if not files:
+        return "No changed lines found."
+    rows = ["| File | Changed | Uncovered | Coverage |", "| --- | ---: | ---: | ---: |"]
+    for item in files:
+        cov = item["coverage_pct"]
+        cov_cell = "unknown" if cov is None else f"{cov:.2f}%"
+        rows.append(
+            f"| {item['path']} | {len(item['changed_lines'])} | "
+            f"{','.join(map(str, item['uncovered_lines'])) or '-'} | {cov_cell} |"
+        )
+    if not result.get("coverage_loaded", True):
+        rows.append("")
+        rows.append("> **No coverage report found** — every changed line is reported as a gap. "
+                    "Run your test suite with coverage (e.g. `pytest --cov --cov-report=xml`) first.")
+    return "\n".join(rows)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Report changed diff lines not covered by tests.")
+    parser.add_argument("--base", help="Base branch for git diff; defaults to main, then master.")
+    parser.add_argument("--report", help="Coverage report path.")
+    parser.add_argument("--format", choices=("json", "md"), default="json")
+    args = parser.parse_args(argv)
+
+    base = args.base or default_base()
+    if args.report and not Path(args.report).exists():
+        sys.stderr.write(f"error: coverage report not found at {args.report}\n")
+        return 2
+    changed = parse_diff(git_diff(base))
+    result = build_result(changed, parse_report(detect_report(args.report)))
+    if not result.get("coverage_loaded") and changed:
+        sys.stderr.write(
+            "warning: no coverage report detected (looked for coverage.xml, lcov.info, "
+            "coverage.json) — treating every changed line as a gap.\n"
+        )
+    print(markdown(result) if args.format == "md" else json.dumps(result, indent=2, sort_keys=True))
+    return 1 if changed and not result.get("coverage_loaded") else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/pluginpool/scripts/guard.py
+++ b/plugins/pluginpool/scripts/guard.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Scan staged diffs or files for secrets with redacted output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import subprocess
+import sys
+from typing import Iterable, Iterator, List, Pattern, Sequence, Tuple
+
+
+NAMED_PATTERNS: Sequence[Tuple[str, Pattern[str]]] = (
+    ("AWS Access Key", re.compile(r"AKIA[0-9A-Z]{16}")),
+    ("GitHub PAT", re.compile(r"gh[pousr]_[A-Za-z0-9]{36,}")),
+    ("Slack token", re.compile(r"xox[abpr]-[A-Za-z0-9-]{10,}")),
+    ("Stripe", re.compile(r"sk_(live|test)_[A-Za-z0-9]{24,}")),
+    ("Google API", re.compile(r"AIza[0-9A-Za-z_-]{35}")),
+    ("JWT", re.compile(r"eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+")),
+    ("Private key", re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----")),
+)
+ENTROPY_RE = re.compile(r"[A-Za-z0-9+/=_-]{32,}")
+
+
+def shannon_entropy(value: str) -> float:
+    if not value:
+        return 0.0
+    total = len(value)
+    return -sum((value.count(char) / total) * math.log2(value.count(char) / total) for char in set(value))
+
+
+def load_allowlist(path: str | None) -> List[Pattern[str]]:
+    if not path:
+        return []
+    rules = []
+    with open(path, "r", encoding="utf-8") as handle:
+        for raw in handle:
+            line = raw.strip()
+            if line and not line.startswith("#"):
+                rules.append(re.compile(line))
+    return rules
+
+
+def is_allowed(rules: Sequence[Pattern[str]], line: str, secret: str) -> bool:
+    return any(rule.search(line) or rule.search(secret) for rule in rules)
+
+
+def redact(rule: str, secret: str) -> str:
+    return f"{rule}: {secret[:4]}\u2026"
+
+
+def scan_line(file_name: str, line_no: int, line: str, allowlist: Sequence[Pattern[str]]) -> List[dict]:
+    findings = []
+    for rule, pattern in NAMED_PATTERNS:
+        for match in pattern.finditer(line):
+            secret = match.group(0)
+            if not is_allowed(allowlist, line, secret):
+                findings.append({"file": file_name, "line": line_no, "pattern": rule, "snippet_redacted": redact(rule, secret)})
+    if findings:
+        return findings
+    for match in ENTROPY_RE.finditer(line):
+        secret = match.group(0)
+        if shannon_entropy(secret) >= 4.5 and not is_allowed(allowlist, line, secret):
+            findings.append(
+                {"file": file_name, "line": line_no, "pattern": "Generic high-entropy", "snippet_redacted": redact("Generic high-entropy", secret)}
+            )
+    return findings
+
+
+def staged_added_lines() -> Iterator[Tuple[str, int, str]]:
+    proc = subprocess.run(
+        ["git", "diff", "--cached", "--unified=0", "--no-ext-diff"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if proc.returncode not in (0, 1):
+        raise RuntimeError(proc.stderr.strip() or "git diff failed")
+
+    current_file = None
+    next_line = 0
+    for raw in proc.stdout.splitlines():
+        if raw.startswith("+++ b/"):
+            current_file = raw[6:]
+            continue
+        if raw.startswith("@@"):
+            match = re.search(r"\+(\d+)(?:,(\d+))?", raw)
+            next_line = int(match.group(1)) if match else 0
+            continue
+        if raw.startswith("+") and not raw.startswith("+++"):
+            if current_file is not None:
+                yield current_file, next_line, raw[1:]
+            next_line += 1
+
+
+def _looks_binary(path: str) -> bool:
+    try:
+        with open(path, "rb") as handle:
+            chunk = handle.read(1024)
+        return b"\x00" in chunk
+    except OSError:
+        return True
+
+
+def file_lines(paths: Sequence[str]) -> Iterator[Tuple[str, int, str]]:
+    for path in paths:
+        if _looks_binary(path):
+            continue
+        try:
+            with open(path, "r", encoding="utf-8", errors="replace") as handle:
+                for index, line in enumerate(handle, 1):
+                    yield path, index, line.rstrip("\n")
+        except OSError:
+            continue
+
+
+def scan_sources(sources: Iterable[Tuple[str, int, str]], allowlist: Sequence[Pattern[str]]) -> List[dict]:
+    findings = []
+    for file_name, line_no, line in sources:
+        findings.extend(scan_line(file_name, line_no, line, allowlist))
+    return findings
+
+
+def to_markdown(findings: Sequence[dict]) -> str:
+    lines = ["# secret-guard report", ""]
+    if not findings:
+        lines.append("No findings.")
+        return "\n".join(lines) + "\n"
+    lines.append("| File | Line | Pattern | Snippet |")
+    lines.append("| --- | ---: | --- | --- |")
+    for item in findings:
+        lines.append(f"| {item['file']} | {item['line']} | {item['pattern']} | {item['snippet_redacted']} |")
+    return "\n".join(lines) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Scan staged diffs or files for leaked secrets.")
+    parser.add_argument("--files", nargs="+", help="Scan specific files instead of staged diff")
+    parser.add_argument("--format", choices=("json", "md"), default="json", help="Output format")
+    parser.add_argument("--allowlist", help="Regex allowlist file, one pattern per line")
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    allowlist = load_allowlist(args.allowlist)
+    sources = file_lines(args.files) if args.files else staged_added_lines()
+    findings = scan_sources(sources, allowlist)
+    if args.format == "md":
+        sys.stdout.write(to_markdown(findings))
+    else:
+        sys.stdout.write(json.dumps(findings, indent=2, sort_keys=True) + "\n")
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/pluginpool/scripts/harvest.py
+++ b/plugins/pluginpool/scripts/harvest.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Harvest TODO/FIXME/HACK markers from a git repo with author + age."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import subprocess
+import sys
+from typing import Iterable
+
+
+DEFAULT_MARKERS = ("TODO", "FIXME", "HACK", "XXX", "NOTE")
+
+
+def _run(args: list[str], cwd: str) -> str:
+    res = subprocess.run(args, cwd=cwd, capture_output=True, text=True, check=False)
+    return res.stdout
+
+
+def _is_binary(path: str) -> bool:
+    try:
+        with open(path, "rb") as f:
+            chunk = f.read(1024)
+        return b"\x00" in chunk
+    except OSError:
+        return True
+
+
+def _list_files(repo: str) -> list[str]:
+    out = _run(["git", "ls-files"], repo)
+    return [line for line in out.splitlines() if line]
+
+
+def _marker_pattern(markers: Iterable[str]) -> re.Pattern:
+    escaped = [re.escape(m) for m in markers]
+    return re.compile(r"\b(" + "|".join(escaped) + r")\b[:\s](.*)$")
+
+
+def _blame(repo: str, path: str, line: int) -> dict:
+    out = _run(
+        ["git", "blame", "--porcelain", "-L", f"{line},{line}", "--", path],
+        repo,
+    )
+    author = ""
+    epoch = 0
+    commit = ""
+    for ln in out.splitlines():
+        if not commit and re.match(r"^[0-9a-f]{7,40} ", ln):
+            commit = ln.split(" ", 1)[0]
+        if ln.startswith("author "):
+            author = ln[len("author "):].strip()
+        elif ln.startswith("author-time "):
+            try:
+                epoch = int(ln[len("author-time "):].strip())
+            except ValueError:
+                epoch = 0
+    return {"author": author, "commit": commit, "author_time": epoch}
+
+
+def _age_days(epoch: int, now: dt.datetime | None = None) -> int:
+    if epoch <= 0:
+        return -1
+    now = now or dt.datetime.now(tz=dt.timezone.utc)
+    delta = now - dt.datetime.fromtimestamp(epoch, tz=dt.timezone.utc)
+    return max(0, delta.days)
+
+
+def _is_git_repo(repo: str) -> bool:
+    """A directory is a git repo if `.git` is a dir (normal) OR a file (worktree).
+    Fall back to `git rev-parse --is-inside-work-tree` for edge cases like
+    GIT_DIR overrides or bare checkouts."""
+    git_path = os.path.join(repo, ".git")
+    if os.path.exists(git_path):  # file (worktree pointer) or directory
+        return True
+    res = subprocess.run(
+        ["git", "-C", repo, "rev-parse", "--is-inside-work-tree"],
+        capture_output=True, text=True, check=False,
+    )
+    return res.returncode == 0 and res.stdout.strip() == "true"
+
+
+def harvest(repo: str, markers: tuple[str, ...] = DEFAULT_MARKERS, min_age: int = 0) -> list[dict]:
+    if not _is_git_repo(repo):
+        return []
+    pat = _marker_pattern(markers)
+    hits: list[dict] = []
+    for rel in _list_files(repo):
+        abs_path = os.path.join(repo, rel)
+        if not os.path.isfile(abs_path) or _is_binary(abs_path):
+            continue
+        try:
+            with open(abs_path, "r", encoding="utf-8", errors="replace") as f:
+                for n, line in enumerate(f, 1):
+                    m = pat.search(line)
+                    if not m:
+                        continue
+                    marker, text = m.group(1), m.group(2).strip()
+                    blame = _blame(repo, rel, n)
+                    age = _age_days(blame["author_time"])
+                    if age >= 0 and age < min_age:
+                        continue
+                    hits.append(
+                        {
+                            "path": rel,
+                            "line": n,
+                            "marker": marker,
+                            "text": text,
+                            "author": blame["author"],
+                            "age_days": age,
+                            "commit": blame["commit"],
+                        }
+                    )
+        except OSError:
+            continue
+    hits.sort(key=lambda h: (-h["age_days"], h["path"], h["line"]))
+    return hits
+
+
+def _render_markdown(hits: list[dict]) -> str:
+    if not hits:
+        return "_No matching markers._\n"
+    out = ["| age (d) | marker | file:line | author | note |", "|---|---|---|---|---|"]
+    for h in hits:
+        note = h["text"].replace("|", "\\|")
+        out.append(
+            f"| {h['age_days']} | {h['marker']} | {h['path']}:{h['line']} | {h['author']} | {note} |"
+        )
+    return "\n".join(out) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Harvest TODO/FIXME/HACK markers with git blame.")
+    p.add_argument("--repo", default=os.getcwd())
+    p.add_argument("--markers", default=",".join(DEFAULT_MARKERS),
+                   help="Comma-separated marker words.")
+    p.add_argument("--min-age", type=int, default=0)
+    p.add_argument("--format", choices=["json", "md"], default="json")
+    args = p.parse_args(argv)
+
+    markers = tuple(m.strip() for m in args.markers.split(",") if m.strip())
+    hits = harvest(args.repo, markers, args.min_age)
+    if args.format == "md":
+        sys.stdout.write(_render_markdown(hits))
+    else:
+        json.dump(hits, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/pluginpool/scripts/narrate.py
+++ b/plugins/pluginpool/scripts/narrate.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Generate a conventional commit message from a git diff."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+TYPES = ("feat", "fix", "refactor", "docs", "test", "chore", "perf")
+
+
+def run_git_diff() -> str:
+    try:
+        proc = subprocess.run(
+            ["git", "diff", "--staged", "--binary"],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError:
+        return ""
+    return proc.stdout if proc.returncode == 0 else ""
+
+
+def read_diff(source: str | None) -> str:
+    if source == "-":
+        return sys.stdin.read()
+    return run_git_diff()
+
+
+_DIFF_GIT_LINE = re.compile(
+    r'^diff --git (?:"a/(?P<aq>(?:[^"\\]|\\.)*)"|a/(?P<ap>\S+)) (?:"b/(?P<bq>(?:[^"\\]|\\.)*)"|b/(?P<bp>.+))$'
+)
+
+
+def changed_files(diff: str) -> list[str]:
+    """Collect unique paths from a unified diff. Two sources, in order:
+    - `+++ b/<path>` (tab-separated from any trailing timestamp) — preferred, robust to spaces.
+    - `diff --git a/X b/Y` header — supports both unquoted and "quoted/with spaces" forms.
+    """
+    files: list[str] = []
+    seen: set[str] = set()
+
+    def _add(path: str) -> None:
+        if path and path != "/dev/null" and path not in seen:
+            seen.add(path)
+            files.append(path)
+
+    saw_plusplus = False
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            saw_plusplus = True
+            _add(line[len("+++ b/"):].split("\t", 1)[0].rstrip())
+        elif line.startswith("Binary files "):
+            match = re.search(r" b/(.+?) differ$", line)
+            if match:
+                _add(match.group(1))
+
+    if saw_plusplus:
+        return files
+
+    # Fallback for compact diffs that omit the +++/--- headers
+    for line in diff.splitlines():
+        m = _DIFF_GIT_LINE.match(line)
+        if m:
+            _add(m.group("bq") or m.group("bp") or "")
+    return files
+
+
+def classify(files: list[str], diff: str) -> str:
+    lower_files = [path.lower() for path in files]
+    lower_diff = diff.lower()
+    if any("/test" in f or f.startswith("test") or f.endswith("_test.py") or "spec." in f for f in lower_files):
+        return "test"
+    if any(f.startswith(("docs/", "doc/")) or Path(f).name.lower() in {"readme.md", "license"} for f in lower_files):
+        return "docs"
+    if any(word in lower_diff for word in ("performance", "optimize", "optimise", "benchmark", "cache hit")):
+        return "perf"
+    if any(word in lower_diff for word in ("bug", "fix", "error", "exception", "regression", "crash")):
+        return "fix"
+    if any(word in lower_diff for word in ("refactor", "rename", "extract", "cleanup")):
+        return "refactor"
+    if any(line.startswith("new file mode") for line in diff.splitlines()) or any(
+        f.startswith(("src/", "app/", "commands/", "scripts/")) for f in lower_files
+    ):
+        return "feat"
+    return "chore"
+
+
+def infer_scope(files: list[str]) -> str:
+    if not files:
+        return ""
+    first = files[0]
+    parts = first.split("/")
+    if len(parts) > 1:
+        return re.sub(r"[^a-z0-9-]+", "-", parts[0].lower()).strip("-") or "repo"
+    stem = Path(first).stem.lower()
+    return re.sub(r"[^a-z0-9-]+", "-", stem).strip("-") or "repo"
+
+
+def subject_for(change_type: str, scope: str, files: list[str]) -> str:
+    target = scope or "repository"
+    if change_type == "docs":
+        return f"update {target} documentation"
+    if change_type == "test":
+        return f"add {target} coverage"
+    if change_type == "fix":
+        return f"fix {target} behavior"
+    if change_type == "refactor":
+        return f"refactor {target} structure"
+    if change_type == "perf":
+        return f"improve {target} performance"
+    if change_type == "feat":
+        action = "add" if any("new file mode" in line for line in "\n".join(files).splitlines()) else "update"
+        return f"{action} {target} support"
+    return f"update {target} maintenance"
+
+
+def narrate(diff: str) -> dict[str, object]:
+    files = changed_files(diff)
+    if not diff.strip() or not files:
+        return {"type": "", "scope": "", "subject": "", "body": "", "files": []}
+    change_type = classify(files, diff)
+    scope = infer_scope(files)
+    subject = subject_for(change_type, scope, files)
+    listed = "\n".join(f"- {path}" for path in files[:5])
+    body = f"Changed files:\n{listed}\n\nWHY: Explain why this change is needed based on the diff."
+    return {"type": change_type, "scope": scope, "subject": subject, "body": body, "files": files}
+
+
+def render_text(result: dict[str, object]) -> str:
+    if not result["type"]:
+        return ""
+    return f"{result['type']}({result['scope']}): {result['subject']}\n\n{result['body']}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--diff", default=None, help="Diff source. Use '-' to read from stdin; omit to read staged git diff.")
+    parser.add_argument("--format", choices=("text", "json"), default="text", help="Output format.")
+    args = parser.parse_args(argv)
+
+    result = narrate(read_diff(args.diff))
+    if args.format == "json":
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        text = render_text(result)
+        if text:
+            print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/pluginpool/scripts/standup.py
+++ b/plugins/pluginpool/scripts/standup.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Generate daily standup notes from `git log` across one or many repos."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import subprocess
+import sys
+from typing import Iterable
+
+
+def _run(args: list[str], cwd: str) -> str:
+    res = subprocess.run(args, cwd=cwd, capture_output=True, text=True, check=False)
+    return res.stdout
+
+
+def _git_user_email(cwd: str) -> str:
+    return _run(["git", "config", "user.email"], cwd).strip()
+
+
+def _last_business_day(today: dt.date) -> dt.date:
+    if today.weekday() == 0:  # Monday → Friday
+        return today - dt.timedelta(days=3)
+    if today.weekday() == 6:  # Sunday → Friday
+        return today - dt.timedelta(days=2)
+    return today - dt.timedelta(days=1)
+
+
+def _parse_since(value: str | None, today: dt.date | None = None) -> str:
+    today = today or dt.date.today()
+    if not value or value == "yesterday":
+        return _last_business_day(today).isoformat()
+    return value
+
+
+def _collect_commits(
+    repo: str,
+    since_iso: str,
+    author: str | None,
+    until_iso: str | None = None,
+) -> list[dict]:
+    if not os.path.isdir(os.path.join(repo, ".git")):
+        return []
+    args = [
+        "git",
+        "log",
+        f"--since={since_iso} 00:00:00",
+        "--pretty=format:%H%x09%ad%x09%s",
+        "--date=short",
+    ]
+    if until_iso:
+        args.append(f"--until={until_iso} 00:00:00")
+    if author and author != "all":
+        args.append(f"--author={author}")
+    out = _run(args, repo)
+    commits: list[dict] = []
+    for line in out.splitlines():
+        parts = line.split("\t", 2)
+        if len(parts) != 3:
+            continue
+        commits.append({"hash": parts[0], "date": parts[1], "subject": parts[2]})
+    return commits
+
+
+def _render_markdown(report: dict) -> str:
+    lines: list[str] = []
+    lines.append(f"# Standup — {dt.date.today().isoformat()}")
+    lines.append("")
+    lines.append("## Yesterday")
+    any_commit = False
+    for r in report["repos"]:
+        commits = r["commits"]
+        if not commits:
+            continue
+        any_commit = True
+        rname = os.path.basename(r["path"].rstrip("/")) or r["path"]
+        lines.append(f"### {rname}")
+        for c in commits:
+            lines.append(f"- {c['date']} `{c['hash'][:7]}` {c['subject']}")
+    if not any_commit:
+        lines.append("- _no commits in range_")
+    lines.append("")
+    lines.append("## Today (planned)")
+    lines.append("- TODO")
+    lines.append("")
+    lines.append("## Blockers")
+    lines.append("- TODO")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _build_report(
+    repos: Iterable[str],
+    since_iso: str,
+    author: str | None,
+    until_iso: str | None = None,
+) -> dict:
+    repo_reports: list[dict] = []
+    for r in repos:
+        repo_reports.append({
+            "path": r,
+            "commits": _collect_commits(r, since_iso, author, until_iso),
+        })
+    return {
+        "since": since_iso,
+        "until": until_iso,
+        "author": author or "self",
+        "repos": repo_reports,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Generate standup notes from git activity.")
+    p.add_argument("--repos", default=None, help="Comma-separated repo paths (default: cwd).")
+    p.add_argument("--since", default=None, help="ISO date or 'yesterday' (default: last business day).")
+    p.add_argument("--until", default=None,
+                   help="ISO date upper-bound (default: today, exclusive). Use 'none' to drop the bound.")
+    p.add_argument("--author", default=None, help="Email to filter by, or 'all' (default: self).")
+    p.add_argument("--format", choices=["json", "md"], default="json")
+    args = p.parse_args(argv)
+
+    cwd = os.getcwd()
+    if args.repos:
+        repos = [os.path.abspath(r.strip()) for r in args.repos.split(",") if r.strip()]
+    else:
+        repos = [cwd]
+
+    since_iso = _parse_since(args.since)
+    if args.until is None:
+        # default upper bound: today at 00:00, so "yesterday" never bleeds into today
+        until_iso: str | None = dt.date.today().isoformat()
+    elif args.until.lower() == "none":
+        until_iso = None
+    else:
+        until_iso = args.until
+
+    author = args.author or _git_user_email(repos[0]) or None
+    if args.author == "all":
+        author = "all"
+
+    report = _build_report(repos, since_iso, author, until_iso)
+    if args.format == "md":
+        sys.stdout.write(_render_markdown(report))
+    else:
+        json.dump(report, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/pluginpool/scripts/story.py
+++ b/plugins/pluginpool/scripts/story.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Collect PR story data from local git history."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+
+
+def git(args: list[str]) -> tuple[int, str]:
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError:
+        return 1, ""
+    return proc.returncode, proc.stdout
+
+
+def is_repo() -> bool:
+    code, out = git(["rev-parse", "--is-inside-work-tree"])
+    return code == 0 and out.strip() == "true"
+
+
+def ref_exists(ref: str) -> bool:
+    code, _ = git(["rev-parse", "--verify", "--quiet", ref])
+    return code == 0
+
+
+def choose_base(base: str) -> str | None:
+    if ref_exists(base):
+        return base
+    if base == "main" and ref_exists("master"):
+        return "master"
+    return None
+
+
+def commits_since(base: str | None) -> list[dict[str, str]]:
+    if base:
+        code, out = git(["log", "--pretty=format:%h%x00%s", f"{base}..HEAD"])
+    else:
+        code, out = git(["log", "--pretty=format:%h%x00%s", "-n", "20"])
+    if code != 0:
+        return []
+    commits = []
+    for line in out.splitlines():
+        if "\0" in line:
+            short, subject = line.split("\0", 1)
+            commits.append({"hash": short, "subject": subject})
+    return commits
+
+
+def changed_files(base: str | None) -> list[dict[str, int | str]]:
+    args = ["diff", "--numstat", f"{base}...HEAD"] if base else ["diff", "--numstat", "HEAD"]
+    code, out = git(args)
+    if code != 0:
+        code, out = git(["diff", "--numstat"])
+    if code != 0:
+        return []
+    files = []
+    for line in out.splitlines():
+        parts = line.split("\t")
+        if len(parts) < 3:
+            continue
+        additions = 0 if parts[0] == "-" else int(parts[0])
+        deletions = 0 if parts[1] == "-" else int(parts[1])
+        files.append({"path": parts[2], "additions": additions, "deletions": deletions})
+    return files
+
+
+def story(base: str) -> dict[str, object]:
+    if not is_repo():
+        return {"commits": [], "files_changed": [], "suggested_title": ""}
+    selected = choose_base(base)
+    commits = commits_since(selected)
+    files = changed_files(selected)
+    title = commits[0]["subject"] if commits else "Update changes"
+    return {"commits": commits, "files_changed": files, "suggested_title": title}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default="main", help="Base branch or ref. Defaults to main.")
+    args = parser.parse_args(argv)
+    print(json.dumps(story(args.base), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a new **pluginpool** plugin under `plugins/pluginpool/` that bundles ten focused developer productivity commands.

## What's in the bundle

| Command | Purpose | Tests (upstream) |
|---|---|---:|
| `/commit-narrator` | Semantic commit message from `git diff --cached`, with the *why* | 8 |
| `/pr-storyteller` | PR title + body + test plan from commits and diff vs base | 6 |
| `/test-gap` | Lines in diff lacking test coverage (Cobertura / lcov / coverage.json) | 9 |
| `/deps-doctor` | Multi-ecosystem dependency audit (npm, pip, cargo, go) | 8 |
| `/env-lint` | `.env` vs `.env.example` key parity (never prints values) | 7 |
| `/secret-guard` | Pre-commit secret scanner (pattern + entropy, redacted) | 10 |
| `/standup-gen` | Standup notes from git activity across repos | 8 |
| `/todo-harvest` | TODO/FIXME/HACK scan with git blame author + age | 9 |
| `/flaky-detector` | Per-test flakiness % from N runs | 11 |
| `/changelog-forge` | Conventional commits → CHANGELOG + semver bump | 13 |

**89 hermetic tests across the suite (upstream), all green.** Each command's core is a deterministic Python helper using only the standard library — no `pip install` to use any of them. The same helpers can be run as plain CLIs (without Claude Code), making them auditable and CI-friendly.

## PR contents

- Adds `plugins/pluginpool/`:
  - `.claude-plugin/plugin.json`
  - `commands/<10>.md` — each with name + description + allowed-tools frontmatter
  - `scripts/<10>.py` — Python stdlib-only helpers
  - `README.md` — plugin documentation with upstream links
- Adds entry to `.claude-plugin/marketplace.json` under category `productivity`

## Upstream

Each command also lives as its own standalone repo under [mturac/pluginpool-<name>](https://github.com/mturac?tab=repositories&q=pluginpool). The umbrella index is at https://github.com/mturac/pluginpool, which also exposes a Claude Code marketplace manifest at `.claude-plugin/marketplace.json`. MIT.

Happy to split into multiple themed plugins (git-pr-workflows, unit-testing, security-compliance) if you'd prefer the commands distributed rather than bundled.