### PR TITLE
fix: agent teams coordination guardrails

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -68,6 +68,9 @@ jobs:
           print(f"OK: {len(mp.get('plugins', []))} marketplace entries validated")
           PY
 
+      - name: Check agent name collision baseline
+        run: python3 tools/check_agent_name_collisions.py --max-duplicate-names 30 --max-colliding-files 95
+
   plugin-eval-tests:
     name: plugin-eval pytest
     runs-on: ubuntu-latest

--- a/plugins/agent-teams/agents/team-debugger.md
+++ b/plugins/agent-teams/agents/team-debugger.md
@@ -1,7 +1,7 @@
 ---
 name: team-debugger
 description: Hypothesis-driven debugging investigator that investigates one assigned hypothesis, gathering evidence to confirm or falsify it with file:line citations and confidence levels. Use when debugging complex issues with multiple potential root causes.
-tools: Read, Glob, Grep, Bash
+tools: Read, Glob, Grep, Bash, TaskList, TaskGet, TaskUpdate, SendMessage
 model: opus
 color: red
 ---

--- a/plugins/agent-teams/agents/team-implementer.md
+++ b/plugins/agent-teams/agents/team-implementer.md
@@ -1,7 +1,7 @@
 ---
 name: team-implementer
 description: Parallel feature builder that implements components within strict file ownership boundaries, coordinating at integration points via messaging. Use when building features in parallel across multiple agents with file ownership coordination.
-tools: Read, Write, Edit, Glob, Grep, Bash
+tools: Read, Write, Edit, Glob, Grep, Bash, TaskList, TaskGet, TaskUpdate, SendMessage
 model: opus
 color: yellow
 ---

--- a/plugins/agent-teams/agents/team-lead.md
+++ b/plugins/agent-teams/agents/team-lead.md
@@ -1,7 +1,7 @@
 ---
 name: team-lead
 description: Team orchestrator that decomposes work into parallel tasks with file ownership boundaries, manages team lifecycle, and synthesizes results. Use when coordinating multi-agent teams, decomposing complex tasks, or managing parallel workstreams.
-tools: Read, Glob, Grep, Bash
+tools: Read, Glob, Grep, Bash, Agent, TeamCreate, TeamDelete, TaskCreate, TaskList, TaskGet, TaskUpdate, SendMessage
 model: opus
 color: blue
 ---
@@ -65,11 +65,12 @@ Lead multi-agent teams through structured workflows: analyze requirements, decom
 
 ## Communication Protocols
 
-1. Use `message` for direct teammate communication (default)
+1. Use `SendMessage` with `message` for direct teammate communication (default)
 2. Use `broadcast` only for critical team-wide announcements
 3. Never send structured JSON status messages — use TaskUpdate instead
 4. Read team config from `~/.claude/teams/{team-name}/config.json` for teammate discovery
-5. Refer to teammates by NAME, never by UUID
+5. Refer to teammates by their actual spawned NAME, never by UUID or role alias
+6. If a spawned name is suffixed to avoid a collision, use the suffixed name from config/Agent output for all messages and tasks
 
 ## Team Lifecycle Protocol
 

--- a/plugins/agent-teams/agents/team-reviewer.md
+++ b/plugins/agent-teams/agents/team-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: team-reviewer
 description: Multi-dimensional code reviewer that operates on one assigned review dimension (security, performance, architecture, testing, or accessibility) with structured finding format. Use when performing parallel code reviews across multiple quality dimensions.
-tools: Read, Glob, Grep, Bash
+tools: Read, Glob, Grep, Bash, TaskList, TaskGet, TaskUpdate, SendMessage
 model: opus
 color: green
 ---

--- a/plugins/agent-teams/commands/team-spawn.md
+++ b/plugins/agent-teams/commands/team-spawn.md
@@ -74,9 +74,10 @@ If "custom" is specified:
 1. Use the `TeamCreate` tool to create the team with `team_name` and `description`
 2. For each team member, use the `Agent` tool with:
    - `team_name`: the team name
-   - `name`: descriptive member name (e.g., "security-reviewer", "hypothesis-1")
-   - `subagent_type`: "general-purpose" (teammates need full tool access)
+   - `name`: unique descriptive member name (e.g., "fullstack-lead", "frontend-impl", "security-reviewer")
+   - `subagent_type`: the selected role (for example, `agent-teams:team-lead`, `agent-teams:team-implementer`, `agent-teams:team-reviewer`, `agent-teams:team-debugger`, or `general-purpose` for research)
    - `prompt`: Role-specific instructions referencing the appropriate agent definition
+3. Do not use the role name `team-lead` as the spawned member name. Team creation can reserve role-like names, so use a unique member name and address the teammate by the actual name returned by `Agent` or listed in `~/.claude/teams/{team-name}/config.json`.
 
 ## Phase 3: Initial Setup
 

--- a/plugins/agent-teams/skills/team-communication-protocols/SKILL.md
+++ b/plugins/agent-teams/skills/team-communication-protocols/SKILL.md
@@ -152,12 +152,15 @@ Find team members by reading the config file:
 }
 ```
 
-**Always use `name`** for messaging and task assignment. Never use `agentId` directly.
+**Always use `name`** for messaging and task assignment. Never use `agentId`, role names, or unsuffixed aliases directly. If a teammate was spawned as `team-lead-2`, send to `team-lead-2`, not `team-lead`.
 
 ## Troubleshooting
 
 **A teammate is not responding to messages.**
 Check the teammate's task status. If it is idle, it may have completed its task and is waiting to be assigned new work or shut down. If it is still active, it may be mid-execution and will process messages once the current operation finishes.
+
+**A teammate says it cannot see SendMessage.**
+Check the teammate agent's `tools:` frontmatter. Agent Teams communication tools such as `SendMessage`, `TaskList`, `TaskGet`, and `TaskUpdate` must be listed explicitly when an agent uses a restricted tool allowlist.
 
 **The lead is sending broadcasts for every status update.**
 This is a common anti-pattern. Broadcasts are expensive — each one sends N messages. Use direct messages (`type: "message"`) for point-to-point updates. Reserve broadcasts for critical shared-resource changes like an updated interface contract.

--- a/plugins/agent-teams/skills/team-composition-patterns/SKILL.md
+++ b/plugins/agent-teams/skills/team-composition-patterns/SKILL.md
@@ -80,15 +80,15 @@ Best practices for composing multi-agent teams, selecting team sizes, choosing a
 
 When spawning teammates with the `Agent` tool, choose `subagent_type` based on what tools the teammate needs:
 
-| Agent Type                     | Tools Available                           | Use For                                                    |
-| ------------------------------ | ----------------------------------------- | ---------------------------------------------------------- |
-| `general-purpose`              | All tools (Read, Write, Edit, Bash, etc.) | Implementation, debugging, any task requiring file changes |
-| `Explore`                      | Read-only tools (Read, Grep, Glob)        | Research, code exploration, analysis                       |
-| `Plan`                         | Read-only tools                           | Architecture planning, task decomposition                  |
-| `agent-teams:team-reviewer`    | All tools                                 | Code review with structured findings                       |
-| `agent-teams:team-debugger`    | All tools                                 | Hypothesis-driven investigation                            |
-| `agent-teams:team-implementer` | All tools                                 | Building features within file ownership boundaries         |
-| `agent-teams:team-lead`        | All tools                                 | Team orchestration and coordination                        |
+| Agent Type                     | Tools Available                                      | Use For                                                    |
+| ------------------------------ | ---------------------------------------------------- | ---------------------------------------------------------- |
+| `general-purpose`              | All tools (Read, Write, Edit, Bash, etc.)            | Implementation, debugging, any task requiring file changes |
+| `Explore`                      | Read-only tools (Read, Grep, Glob)                   | Research, code exploration, analysis                       |
+| `Plan`                         | Read-only tools                                      | Architecture planning, task decomposition                  |
+| `agent-teams:team-reviewer`    | Read/search/Bash plus TaskUpdate and SendMessage     | Code review with structured findings                       |
+| `agent-teams:team-debugger`    | Read/search/Bash plus TaskUpdate and SendMessage     | Hypothesis-driven investigation                            |
+| `agent-teams:team-implementer` | Read/Write/Edit/search/Bash plus task/message tools  | Building features within file ownership boundaries         |
+| `agent-teams:team-lead`        | Read/search/Bash plus Agent Teams coordination tools | Team orchestration and coordination                        |
 
 **Key distinction**: Read-only agents (Explore, Plan) cannot modify files. Never assign implementation tasks to read-only agents.
 

--- a/plugins/agent-teams/skills/team-composition-patterns/SKILL.md
+++ b/plugins/agent-teams/skills/team-composition-patterns/SKILL.md
@@ -85,9 +85,9 @@ When spawning teammates with the `Agent` tool, choose `subagent_type` based on w
 | `general-purpose`              | All tools (Read, Write, Edit, Bash, etc.)            | Implementation, debugging, any task requiring file changes |
 | `Explore`                      | Read-only tools (Read, Grep, Glob)                   | Research, code exploration, analysis                       |
 | `Plan`                         | Read-only tools                                      | Architecture planning, task decomposition                  |
-| `agent-teams:team-reviewer`    | Read/search/Bash plus TaskUpdate and SendMessage     | Code review with structured findings                       |
-| `agent-teams:team-debugger`    | Read/search/Bash plus TaskUpdate and SendMessage     | Hypothesis-driven investigation                            |
-| `agent-teams:team-implementer` | Read/Write/Edit/search/Bash plus task/message tools  | Building features within file ownership boundaries         |
+| `agent-teams:team-reviewer`    | Read/search/Bash plus TaskList/TaskGet/TaskUpdate/SendMessage | Code review with structured findings               |
+| `agent-teams:team-debugger`    | Read/search/Bash plus TaskList/TaskGet/TaskUpdate/SendMessage | Hypothesis-driven investigation                    |
+| `agent-teams:team-implementer` | Read/Write/Edit/search/Bash plus TaskList/TaskGet/TaskUpdate/SendMessage | Building features within file ownership boundaries |
 | `agent-teams:team-lead`        | Read/search/Bash plus Agent Teams coordination tools | Team orchestration and coordination                        |
 
 **Key distinction**: Read-only agents (Explore, Plan) cannot modify files. Never assign implementation tasks to read-only agents.

--- a/plugins/agent-teams/skills/team-composition-patterns/references/agent-type-selection.md
+++ b/plugins/agent-teams/skills/team-composition-patterns/references/agent-type-selection.md
@@ -5,30 +5,30 @@ Decision matrix for choosing the right `subagent_type` when spawning teammates.
 ## Decision Matrix
 
 ```
-Does the teammate need to modify files?
-├── YES → Does it need a specialized role?
-│         ├── YES → Which role?
-│         │         ├── Code review → agent-teams:team-reviewer
-│         │         ├── Bug investigation → agent-teams:team-debugger
-│         │         ├── Feature building → agent-teams:team-implementer
-│         │         └── Team coordination → agent-teams:team-lead
-│         └── NO → general-purpose
-└── NO → Does it need deep codebase exploration?
-          ├── YES → Explore
-          └── NO → Plan (for architecture/design tasks)
+Does the teammate need a specialized Agent Teams role?
+├── YES → Which role?
+│         ├── Team coordination → agent-teams:team-lead
+│         ├── Feature building → agent-teams:team-implementer
+│         ├── Code review → agent-teams:team-reviewer
+│         └── Bug investigation → agent-teams:team-debugger
+└── NO → Does it need to modify files?
+          ├── YES → general-purpose
+          └── NO → Does it need deep codebase exploration?
+                    ├── YES → Explore
+                    └── NO → Plan (for architecture/design tasks)
 ```
 
 ## Agent Type Comparison
 
-| Agent Type                   | Can Read | Can Write | Can Edit | Can Bash | Specialized        |
-| ---------------------------- | -------- | --------- | -------- | -------- | ------------------ |
-| general-purpose              | Yes      | Yes       | Yes      | Yes      | No                 |
-| Explore                      | Yes      | No        | No       | No       | Search/explore     |
-| Plan                         | Yes      | No        | No       | No       | Architecture       |
-| agent-teams:team-lead        | Yes      | Yes       | Yes      | Yes      | Team orchestration |
-| agent-teams:team-reviewer    | Yes      | Yes       | Yes      | Yes      | Code review        |
-| agent-teams:team-debugger    | Yes      | Yes       | Yes      | Yes      | Bug investigation  |
-| agent-teams:team-implementer | Yes      | Yes       | Yes      | Yes      | Feature building   |
+| Agent Type                   | Can Read | Can Write | Can Edit | Can Bash | Team Tools | Specialized        |
+| ---------------------------- | -------- | --------- | -------- | -------- | ---------- | ------------------ |
+| general-purpose              | Yes      | Yes       | Yes      | Yes      | No         | No                 |
+| Explore                      | Yes      | No        | No       | No       | No         | Search/explore     |
+| Plan                         | Yes      | No        | No       | No       | No         | Architecture       |
+| agent-teams:team-lead        | Yes      | No        | No       | Yes      | Yes        | Team orchestration |
+| agent-teams:team-reviewer    | Yes      | No        | No       | Yes      | Yes        | Code review        |
+| agent-teams:team-debugger    | Yes      | No        | No       | Yes      | Yes        | Bug investigation  |
+| agent-teams:team-implementer | Yes      | Yes       | Yes      | Yes      | Yes        | Feature building   |
 
 ## Common Mistakes
 

--- a/tools/check_agent_name_collisions.py
+++ b/tools/check_agent_name_collisions.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Report duplicate Claude Code agent names across plugin agent files."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+FRONTMATTER_RE = re.compile(r"\A---\n(?P<frontmatter>.*?)\n---", re.DOTALL)
+NAME_RE = re.compile(r"^name:\s*(?P<name>.+?)\s*$", re.MULTILINE)
+
+
+def _read_agent_name(path: Path) -> str | None:
+    """Extract the top-level frontmatter name from an agent file."""
+    content = path.read_text(encoding="utf-8")
+    frontmatter_match = FRONTMATTER_RE.search(content)
+    if not frontmatter_match:
+        return None
+
+    name_match = NAME_RE.search(frontmatter_match.group("frontmatter"))
+    if not name_match:
+        return None
+
+    raw_name = name_match.group("name").split("#", 1)[0].strip()
+    return raw_name.strip("\"'")
+
+
+def find_agent_names(root: Path) -> dict[str, list[Path]]:
+    """Return agent names mapped to the files that declare them."""
+    by_name: dict[str, list[Path]] = defaultdict(list)
+    for agent_path in sorted((root / "plugins").glob("*/agents/*.md")):
+        name = _read_agent_name(agent_path)
+        if name:
+            by_name[name].append(agent_path)
+    return by_name
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Report duplicate agent frontmatter names across plugins."
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path("."),
+        help="Repository root to scan. Defaults to the current directory.",
+    )
+    parser.add_argument(
+        "--max-duplicate-names",
+        type=int,
+        default=None,
+        help="Fail if the number of duplicated names exceeds this baseline.",
+    )
+    parser.add_argument(
+        "--max-colliding-files",
+        type=int,
+        default=None,
+        help="Fail if the number of files involved in collisions exceeds this baseline.",
+    )
+    parser.add_argument(
+        "--fail-on-duplicates",
+        action="store_true",
+        help="Fail whenever any duplicate agent names are found.",
+    )
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+    by_name = find_agent_names(root)
+    duplicates = {
+        name: paths
+        for name, paths in sorted(by_name.items(), key=lambda item: (-len(item[1]), item[0]))
+        if len(paths) > 1
+    }
+
+    duplicate_name_count = len(duplicates)
+    colliding_file_count = sum(len(paths) for paths in duplicates.values())
+
+    if not duplicates:
+        print("OK: no duplicate agent names found")
+        return 0
+
+    print(
+        f"Found {duplicate_name_count} duplicate agent names across "
+        f"{colliding_file_count} files:"
+    )
+    for name, paths in duplicates.items():
+        print(f"\n{name} ({len(paths)} files)")
+        for path in paths:
+            print(f"  - {path.relative_to(root)}")
+
+    failed = args.fail_on_duplicates
+    if (
+        args.max_duplicate_names is not None
+        and duplicate_name_count > args.max_duplicate_names
+    ):
+        print(
+            f"\nERROR: duplicate name count {duplicate_name_count} exceeds "
+            f"baseline {args.max_duplicate_names}",
+            file=sys.stderr,
+        )
+        failed = True
+    if (
+        args.max_colliding_files is not None
+        and colliding_file_count > args.max_colliding_files
+    ):
+        print(
+            f"\nERROR: colliding file count {colliding_file_count} exceeds "
+            f"baseline {args.max_colliding_files}",
+            file=sys.stderr,
+        )
+        failed = True
+
+    if failed:
+        return 1
+
+    print("\nOK: duplicate agent-name collisions are within the configured baseline")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_agent_name_collisions.py
+++ b/tools/check_agent_name_collisions.py
@@ -16,7 +16,7 @@ NAME_RE = re.compile(r"^name:\s*(?P<name>.+?)\s*$", re.MULTILINE)
 
 def _read_agent_name(path: Path) -> str | None:
     """Extract the top-level frontmatter name from an agent file."""
-    content = path.read_text(encoding="utf-8")
+    content = path.read_text(encoding="utf-8").replace("\r\n", "\n").replace("\r", "\n")
     frontmatter_match = FRONTMATTER_RE.search(content)
     if not frontmatter_match:
         return None
@@ -40,6 +40,7 @@ def find_agent_names(root: Path) -> dict[str, list[Path]]:
 
 
 def main() -> int:
+    """Run the duplicate agent-name checker CLI."""
     parser = argparse.ArgumentParser(
         description="Report duplicate agent frontmatter names across plugins."
     )


### PR DESCRIPTION
## Summary

- Add Agent Teams communication/task tools to restricted team agent allowlists so teammates can send messages and update tasks.
- Clarify team-spawn and communication docs to use actual spawned teammate names instead of role aliases when names are suffixed.
- Add a duplicate agent-name collision checker and wire it into validation as a baseline guardrail so the known collision count cannot regress.

## Why

Open issue triage found two valid maintenance problems:

- Agent Teams agents referenced `SendMessage` / task coordination behavior but their explicit `tools:` allowlists omitted the required tools.
- Duplicate agent names are a real repo-wide issue, but a broad rename would be disruptive. The new check makes the current baseline visible and prevents new collisions while the long-term namespacing strategy is revisited.

## Validation

- `git diff --check`
- Agent Teams frontmatter parse check for `SendMessage` and `TaskUpdate`
- `python3 tools/check_agent_name_collisions.py --max-duplicate-names 30 --max-colliding-files 95`