### PR TITLE
meigen-ai-design: bump to 1.0.8, pin npm to meigen@1.3.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -963,7 +963,7 @@
       "name": "meigen-ai-design",
       "source": "./plugins/meigen-ai-design",
       "description": "AI image generation with creative workflow orchestration, prompt engineering, and curated inspiration library via MCP server",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "author": {
         "name": "MeiGen",
         "url": "https://github.com/jau123"

--- a/plugins/meigen-ai-design/.claude-plugin/plugin.json
+++ b/plugins/meigen-ai-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "meigen-ai-design",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "AI image generation with creative workflow orchestration, parallel multi-direction output, prompt engineering, and a 1,300+ curated inspiration library. Requires MeiGen MCP server (supports MeiGen Cloud, local ComfyUI, and OpenAI-compatible APIs).",
   "author": {
     "name": "MeiGen",

--- a/plugins/meigen-ai-design/README.md
+++ b/plugins/meigen-ai-design/README.md
@@ -11,7 +11,7 @@ This plugin requires the **meigen** MCP server. Install it by adding to your pro
   "mcpServers": {
     "meigen": {
       "command": "npx",
-      "args": ["-y", "meigen@1.3.1"]
+      "args": ["-y", "meigen@1.3.2"]
     }
   }
 }


### PR DESCRIPTION
Bumps `meigen-ai-design` plugin to 1.0.8 and pins the MCP server to `meigen@1.3.2`.

## What's in meigen@1.3.2

- **Windows reference-image path fix** — paths like `C:/Users/.../photo.jpg` (forward-slash, the form most LLM clients emit on Windows) are now correctly detected as local files and auto-uploaded. Previously they fell through to the URL branch and produced opaque vendor errors. Backslash form unchanged.
- **Reference-URL handling robustness updates** — small internal refinements; no schema or behavior changes for valid public URLs.

No schema or breaking changes. Full release notes: https://github.com/jau123/MeiGen-AI-Design-MCP/releases/tag/v1.3.2

## Files changed
- `plugins/meigen-ai-design/.claude-plugin/plugin.json` — version 1.0.7 → 1.0.8
- `plugins/meigen-ai-design/README.md` — pinned `meigen@1.3.1` → `meigen@1.3.2`
- `.claude-plugin/marketplace.json` — meigen-ai-design entry version 1.0.7 → 1.0.8