### PR TITLE
ci: add dependabot for uv-managed Python projects

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,6 @@ updates:
       - "dependencies"
     commit-message:
       prefix: "deps(yt-design-extractor)"
-      include: "scope"
     groups:
       python-minor-and-patch:
         update-types:
@@ -36,7 +35,6 @@ updates:
       - "dependencies"
     commit-message:
       prefix: "deps(plugin-eval)"
-      include: "scope"
     groups:
       python-minor-and-patch:
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+# Dependabot config for the uv-managed Python projects in this repo.
+# See AGENTS.md for the canonical toolchain (uv + ruff + ty).
+#
+# Native uv support landed in GitHub Dependabot in 2024; the ecosystem
+# key is "uv" and Dependabot will update both pyproject.toml and uv.lock
+# in lock-step.
+
+version: 2
+updates:
+  # tools/yt-design-extractor — internal tooling
+  - package-ecosystem: "uv"
+    directory: "/tools/yt-design-extractor"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps(yt-design-extractor)"
+      include: "scope"
+    groups:
+      python-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # plugins/plugin-eval — plugin quality evaluation framework
+  - package-ecosystem: "uv"
+    directory: "/plugins/plugin-eval"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps(plugin-eval)"
+      include: "scope"
+    groups:
+      python-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` configuring weekly dependency updates for the two uv-managed projects: `tools/yt-design-extractor` and `plugins/plugin-eval`.
- Minor/patch bumps are grouped into a single rollup PR per project per week; majors arrive as individual PRs.
- Dependabot's native `uv` ecosystem support (added 2024) updates `pyproject.toml` and `uv.lock` in lock-step.

## Test plan

- [ ] PR validation passes (markdownlint, YAML lint).
- [ ] After merge, confirm the Dependabot tab in repo settings shows two active update jobs.
- [ ] Wait for the first scheduled run (next Monday) and verify PRs land with the `dependencies` label and the `deps(<scope>)` prefix.