### PR TITLE
Add Pensyve external integration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,8 +6,8 @@
     "url": "https://github.com/wshobson"
   },
   "metadata": {
-    "description": "Production-ready workflow orchestration with 80 focused plugins, 185 specialized agents, and 153 skills - optimized for granular installation and minimal token usage",
-    "version": "1.7.0"
+    "description": "Production-ready workflow orchestration with 83 marketplace plugins, 191 local specialized agents, and 155 local skills - optimized for granular installation and minimal token usage",
+    "version": "1.7.1"
   },
   "plugins": [
     {
@@ -1006,6 +1006,24 @@
       "homepage": "https://github.com/cskwork",
       "license": "MIT",
       "category": "security"
+    },
+    {
+      "name": "pensyve",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/major7apps/pensyve.git",
+        "path": "integrations/claude-code"
+      },
+      "description": "Universal memory runtime for Claude Code with cross-session memory, entity-aware recall, lifecycle hooks, skills, commands, and memory-curator agents",
+      "version": "1.3.0",
+      "author": {
+        "name": "Major7 Apps",
+        "email": "seth@major7apps.com",
+        "url": "https://github.com/major7apps/pensyve"
+      },
+      "homepage": "https://github.com/major7apps/pensyve",
+      "license": "Apache-2.0",
+      "category": "memory"
     },
     {
       "name": "qa-orchestra",

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -51,7 +51,8 @@ jobs:
       - name: Validate marketplace entries resolve to plugin dirs
         run: |
           python3 - <<'PY'
-          import json, os, sys
+          import json, os, posixpath, sys
+          from urllib.parse import urlparse
           with open('.claude-plugin/marketplace.json') as f:
               mp = json.load(f)
           errors = []
@@ -63,9 +64,37 @@ jobs:
                       errors.append(f"{p['name']}: source {src} does not exist")
                   elif not os.path.isfile(os.path.join(path, '.claude-plugin', 'plugin.json')):
                       errors.append(f"{p['name']}: missing .claude-plugin/plugin.json in {src}")
-              elif isinstance(src, dict) and src.get('source') == 'git-subdir':
-                  if not src.get('url'):
+              elif isinstance(src, dict):
+                  if src.get('source') != 'git-subdir':
+                      errors.append(f"{p['name']}: unsupported source object {src.get('source')!r}")
+                      continue
+
+                  extra_keys = set(src) - {'source', 'url', 'path'}
+                  if extra_keys:
+                      errors.append(f"{p['name']}: git-subdir entry has unsupported keys: {sorted(extra_keys)}")
+
+                  url = src.get('url')
+                  path = src.get('path')
+
+                  if not url:
                       errors.append(f"{p['name']}: git-subdir entry missing url")
+                  else:
+                      parsed = urlparse(url)
+                      if parsed.scheme != 'https' or parsed.netloc != 'github.com' or not parsed.path.endswith('.git'):
+                          errors.append(f"{p['name']}: git-subdir url must be an https://github.com/*.git URL")
+
+                  if not path:
+                      errors.append(f"{p['name']}: git-subdir entry missing path")
+                  elif path != '.':
+                      normalized = posixpath.normpath(path)
+                      if (
+                          path.startswith('/')
+                          or '\\' in path
+                          or normalized != path
+                          or normalized == '..'
+                          or normalized.startswith('../')
+                      ):
+                          errors.append(f"{p['name']}: git-subdir path must be a normalized relative path")
           if errors:
               for e in errors:
                   print(f"::error::{e}")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # claude-agents — multi-harness agentic plugin marketplace
 
-Production-ready agentic-workflow building blocks: **82 plugins** (81 local + 1 external), **191 agents**, **155 skills**, **102 commands**. Native source-of-truth for Claude Code; also consumed by OpenAI Codex CLI, Cursor, OpenCode, and Gemini CLI from a single Markdown source.
+Production-ready agentic-workflow building blocks: **83 plugins** (81 local + 2 external), **191 agents**, **155 skills**, **102 commands**. Native source-of-truth for Claude Code; also consumed by OpenAI Codex CLI, Cursor, OpenCode, and Gemini CLI from a single Markdown source.
 
 This file is the canonical context file. Codex / Cursor / OpenCode read it directly. Claude Code reads it via `@AGENTS.md` import in `CLAUDE.md`. Gemini CLI reads it via `.gemini/settings.json` (`context.fileName`).
 
@@ -10,7 +10,7 @@ This file is the canonical context file. Codex / Cursor / OpenCode read it direc
 
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — top-level architectural overview (adapter framework, source-of-truth invariant, capability matrix summary)
 - **[docs/architecture.md](docs/architecture.md)** — detailed design principles
-- **[docs/plugins.md](docs/plugins.md)** — full plugin catalog (82 plugins by category)
+- **[docs/plugins.md](docs/plugins.md)** — full plugin catalog (83 plugins by category)
 - **[docs/agents.md](docs/agents.md)** — agent reference (191 agents, model tiers)
 - **[docs/agent-skills.md](docs/agent-skills.md)** — skill reference (progressive disclosure model)
 - **[docs/usage.md](docs/usage.md)** — commands, workflows, examples

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,7 +26,7 @@ claude-agents/
 ├── CONTRIBUTING.md                 # Contributor entry point
 ├── .claude-plugin/marketplace.json # Plugin registry (source of truth)
 ├── .gemini/settings.json           # Gemini CLI → AGENTS.md redirect
-├── plugins/                        # SOURCE OF TRUTH (82 plugins)
+├── plugins/                        # SOURCE OF TRUTH (81 local plugins; 2 externals in marketplace)
 │   └── <name>/
 │       ├── .claude-plugin/plugin.json
 │       ├── agents/*.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -17,6 +17,15 @@ make generate HARNESS=gemini
 - **191 subagents** at `agents/<plugin>__<agent>.md` — invoke with `@<agent>`.
 - **102 slash commands** at `/<plugin>:<command>` — use `/help` to list.
 
+## Companion Memory Extension
+
+Pensyve is maintained upstream as a separate Gemini CLI extension with MCP-backed
+memory and context injection:
+
+```bash
+gemini extensions install https://github.com/major7apps/pensyve
+```
+
 ## Gemini-specific differences
 
 | Capability | Claude Code | Gemini CLI |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agentic Plugin Marketplace
 
-> Production-ready agentic workflow building blocks: **82 plugins**, **191 agents**,
+> Production-ready agentic workflow building blocks: **83 plugins**, **191 agents**,
 > **155 skills**, **102 commands** — built for Claude Code and consumed natively by
 > OpenAI Codex CLI, Cursor, OpenCode, and Gemini CLI from a single Markdown source.
 
@@ -19,7 +19,7 @@ Pick your harness:
 
 ```bash
 /plugin marketplace add wshobson/agents
-/plugin install python-development          # or any of 82 plugins
+/plugin install python-development          # or any of 83 plugins
 ```
 
 [→ Full Claude Code setup, troubleshooting, and plugin catalog](docs/usage.md)
@@ -38,7 +38,7 @@ Setup details and per-harness gotchas: [docs/harnesses.md](docs/harnesses.md). G
 
 | | Count | What it is |
 |---|---:|---|
-| **Plugins** | 82 | Granular, single-purpose installable units (81 local + 1 external via git-subdir) |
+| **Plugins** | 83 | Granular, single-purpose installable units (81 local + 2 external via git-subdir) |
 | **Agents** | 191 | Domain experts (architecture, languages, infra, security, data, ML, docs, business, SEO) |
 | **Skills** | 155 | Modular knowledge packages with progressive disclosure (load when activated) |
 | **Commands** | 102 | Slash commands: scaffolding, security scans, test gen, infrastructure setup |
@@ -112,7 +112,7 @@ uv run plugin-eval certify path/to/skill
 
 Detail lives in `docs/`. Read in this order:
 
-- **[docs/plugins.md](docs/plugins.md)** — full catalog of all 82 plugins
+- **[docs/plugins.md](docs/plugins.md)** — full catalog of all 83 plugins
 - **[docs/agents.md](docs/agents.md)** — all 191 agents by category
 - **[docs/agent-skills.md](docs/agent-skills.md)** — 155 skills with progressive disclosure
 - **[docs/usage.md](docs/usage.md)** — commands, workflows, examples
@@ -126,15 +126,19 @@ Gemini-specific setup: [GEMINI.md](GEMINI.md). All other harness setup, capabili
 
 Contributing: [CONTRIBUTING.md](CONTRIBUTING.md) · Authoring: [docs/authoring.md](docs/authoring.md)
 
-## Related plugins (external sources)
+## External Memory Integration
 
-- **[Pensyve](https://github.com/major7apps/pensyve)** — universal memory runtime with
-  cross-session cognitive memory for Claude Code.
+[Pensyve](https://github.com/major7apps/pensyve) is included as an external
+`git-subdir` entry for Claude Code. Pensyve also maintains direct upstream
+integrations for this marketplace's other supported harnesses.
 
-  ```bash
-  /plugin marketplace add major7apps/pensyve
-  /plugin install pensyve@major7apps-pensyve
-  ```
+| Harness | Pensyve integration |
+|---|---|
+| Claude Code | `/plugin install pensyve` from this marketplace (`integrations/claude-code`) |
+| Codex CLI | [integrations/codex-plugin](https://github.com/major7apps/pensyve/tree/main/integrations/codex-plugin) |
+| Cursor | [integrations/cursor](https://github.com/major7apps/pensyve/tree/main/integrations/cursor) |
+| OpenCode | [integrations/opencode-plugin](https://github.com/major7apps/pensyve/tree/main/integrations/opencode-plugin) |
+| Gemini CLI | `gemini extensions install https://github.com/major7apps/pensyve` |
 
 ## License
 

--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -1,6 +1,6 @@
 # Agent Skills
 
-Agent Skills are modular packages that extend Claude's capabilities with specialized domain knowledge, following Anthropic's [Agent Skills Specification](https://github.com/anthropics/skills/blob/main/agent_skills_spec.md). This plugin ecosystem includes **155 local specialized skills** across 40 plugins, enabling progressive disclosure and efficient token usage.
+Agent Skills are modular packages that extend Claude's capabilities with specialized domain knowledge, following Anthropic's [Agent Skills Specification](https://github.com/anthropics/skills/blob/main/agent_skills_spec.md). This plugin ecosystem includes **155 local specialized skills** across 41 plugins, enabling progressive disclosure and efficient token usage.
 
 ## Overview
 

--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -1,6 +1,6 @@
 # Agent Skills
 
-Agent Skills are modular packages that extend Claude's capabilities with specialized domain knowledge, following Anthropic's [Agent Skills Specification](https://github.com/anthropics/skills/blob/main/agent_skills_spec.md). This plugin ecosystem includes **153 specialized skills** across 40 plugins, enabling progressive disclosure and efficient token usage.
+Agent Skills are modular packages that extend Claude's capabilities with specialized domain knowledge, following Anthropic's [Agent Skills Specification](https://github.com/anthropics/skills/blob/main/agent_skills_spec.md). This plugin ecosystem includes **155 local specialized skills** across 40 plugins, enabling progressive disclosure and efficient token usage.
 
 ## Overview
 
@@ -380,7 +380,7 @@ fastapi-templates skill → Supplies production-ready templates
 
 ## Specification Compliance
 
-All 153 skills follow the [Agent Skills Specification](https://agentskills.io/specification):
+All 155 skills follow the [Agent Skills Specification](https://agentskills.io/specification):
 
 - ✓ Required `name` field (hyphen-case)
 - ✓ Required `description` field with "Use when" clause

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,6 +1,6 @@
 # Agent Reference
 
-Complete reference for all **185 specialized AI agents** organized by category with model assignments.
+Complete reference for all **191 local specialized AI agents** organized by category with model assignments.
 
 ## Agent Categories
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,31 +36,31 @@ This marketplace follows industry best practices with a focus on granularity, co
 
 ### Plugin Distribution
 
-- **82 focused plugins** (81 local + 1 external via git-subdir) optimized for specific use cases
-- **25 clear categories** with 1-10 plugins each for easy discovery
+- **83 marketplace plugins** (81 local + 2 external via git-subdir) optimized for specific use cases
+- **26 clear categories** with 1-10 plugins each for easy discovery
 - Organized by domain:
-  - **Development**: 4 plugins (debugging, backend, frontend, multi-platform)
-  - **Security**: 4 plugins (scanning, compliance, backend-api, frontend-mobile)
+  - **Development**: 6 plugins (debugging, backend, frontend, UI, multi-platform, essentials)
+  - **Security**: 6 plugins (scanning, compliance, API, frontend/mobile, reverse engineering, hook policy)
   - **Operations**: 4 plugins (incident, diagnostics, distributed, observability)
-  - **Languages**: 7 plugins (Python, JS/TS, systems, JVM, scripting, functional, embedded)
+  - **Languages**: 10 plugins (Python, JS/TS, systems, JVM, scripting, functional, embedded, and more)
   - **Infrastructure**: 5 plugins (deployment, validation, K8s, cloud, CI/CD)
-  - And 18 more specialized categories
+  - And 21 more specialized categories
 
 ### Component Breakdown
 
-**185 Specialized Agents**
+**191 Local Specialized Agents**
 
 - Domain experts with deep knowledge
 - Organized across architecture, languages, infrastructure, quality, data/AI, documentation, business, and SEO
 - Model-optimized with three-tier strategy (Opus, Sonnet, Haiku) for performance and cost
 
-**15 Workflow Orchestrators**
+**16 Workflow Orchestrators**
 
 - Multi-agent coordination systems
 - Complex operations like full-stack development, security hardening, ML pipelines, incident response
 - Pre-configured agent workflows
 
-**71 Development Tools**
+**102 Local Commands**
 
 - Optimized utilities including:
   - Project scaffolding (Python, TypeScript, Rust)
@@ -69,11 +69,11 @@ This marketplace follows industry best practices with a focus on granularity, co
   - Component scaffolding (React, React Native)
   - Infrastructure setup (Terraform, Kubernetes)
 
-**107 Agent Skills**
+**155 Local Agent Skills**
 
 - Modular knowledge packages
 - Progressive disclosure architecture
-- Domain-specific expertise across 18 plugins
+- Domain-specific expertise across 40 plugins
 - Spec-compliant (Anthropic Agent Skills Specification)
 
 ## Repository Structure
@@ -81,7 +81,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 ```
 claude-agents/
 ├── .claude-plugin/
-│   └── marketplace.json          # Marketplace catalog (77 plugins)
+│   └── marketplace.json          # Marketplace catalog (83 plugins)
 ├── plugins/                       # Isolated plugin directories
 │   ├── python-development/
 │   │   ├── agents/               # Python language agents
@@ -124,7 +124,7 @@ claude-agents/
 │   │   │   └── c4-context.md
 │   │   └── commands/
 │   │       └── c4-architecture.md
-│   └── ... (62 more isolated plugins)
+│   └── ... (77 more isolated plugins)
 ├── docs/                          # Documentation
 │   ├── agent-skills.md           # Agent Skills guide
 │   ├── agents.md                 # Agent reference
@@ -194,7 +194,7 @@ description: What the skill does. Use when [trigger]. # Required: < 1024 chars
 - **Composability**: Mix and match skills across workflows
 - **Maintainability**: Isolated updates don't affect other skills
 
-See [Agent Skills](./agent-skills.md) for complete details on the 153 skills.
+See [Agent Skills](./agent-skills.md) for complete details on the 155 skills.
 
 ## Model Configuration Strategy
 
@@ -262,13 +262,13 @@ code-reviewer (Sonnet) validates architecture
 ### Component Coverage
 
 - **100% agent coverage** - all plugins include at least one agent
-- **100% component availability** - all 185 agents accessible across plugins
+- **100% component availability** - all 191 local agents accessible across plugins
 - **Efficient distribution** - 5.5 components per plugin average
 
 ### Discoverability
 
 - **Clear plugin names** convey purpose immediately
-- **Logical categorization** with 23 well-defined categories
+- **Logical categorization** with 26 well-defined categories
 - **Searchable documentation** with cross-references
 - **Easy to find** the right tool for the job
 
@@ -392,5 +392,5 @@ Feature Development Workflow:
 
 - [Agent Skills](./agent-skills.md) - Modular knowledge packages
 - [Agent Reference](./agents.md) - Complete agent catalog
-- [Plugin Reference](./plugins.md) - All 77 plugins
+- [Plugin Reference](./plugins.md) - All 83 marketplace plugins
 - [Usage Guide](./usage.md) - Commands and workflows

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,7 +73,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 
 - Modular knowledge packages
 - Progressive disclosure architecture
-- Domain-specific expertise across 40 plugins
+- Domain-specific expertise across 41 plugins
 - Spec-compliant (Anthropic Agent Skills Specification)
 
 ## Repository Structure

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -74,6 +74,19 @@ make generate HARNESS=gemini
 make generate-all
 ```
 
+## External Pensyve integrations
+
+The Claude Code marketplace includes Pensyve as an external `git-subdir` plugin.
+For generated harnesses, use Pensyve's upstream harness-native integration:
+
+| Harness | Upstream integration |
+|---|---|
+| Claude Code | `https://github.com/major7apps/pensyve.git`, path `integrations/claude-code` |
+| Codex CLI | `integrations/codex-plugin` |
+| Cursor | `integrations/cursor` |
+| OpenCode | `integrations/opencode-plugin` |
+| Gemini CLI | `gemini extensions install https://github.com/major7apps/pensyve` |
+
 ## See also
 
 - [`authoring.md`](authoring.md) — portable-content style guide for plugin authors

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,8 +1,6 @@
 # Complete Plugin Reference
 
-Browse all **81 focused, single-purpose plugins** organized by category, plus 1 externally-hosted plugin (`qa-orchestra`) distributed via a `git-subdir` marketplace entry — **82 plugins total**.
-
-> 💡 **Also recommended:** [Pensyve](https://github.com/major7apps/pensyve) — universal memory runtime for Claude Code. Distributed from its own marketplace (`major7apps/pensyve`) so updates ship directly from the source. Install with `/plugin marketplace add major7apps/pensyve` then `/plugin install pensyve@major7apps-pensyve`.
+Browse all **83 marketplace plugins** organized by category: 81 local plugins plus 2 externally hosted `git-subdir` entries (`pensyve`, `qa-orchestra`).
 
 ## Quick Start - Essential Plugins
 
@@ -119,16 +117,18 @@ Next.js, React + Vite, and Node.js project setup with pnpm and TypeScript best p
 | **frontend-mobile-development** | Frontend UI and mobile development                           | `/plugin install frontend-mobile-development` |
 | **ui-design**                   | UI/UX design for mobile (iOS, Android, React Native) and web | `/plugin install ui-design`                   |
 | **multi-platform-apps**         | Cross-platform app coordination (web/iOS/Android)            | `/plugin install multi-platform-apps`         |
+| **developer-essentials**        | Essential Git, SQL, code review, auth, debugging, and monorepo skills | `/plugin install developer-essentials`        |
 
 ### 📚 Documentation (4 plugins)
 
 | Plugin                       | Description                                                                                                                                     | Install                                    |
 | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| **documentation-standards**  | HADS semantic tagging conventions for human- and AI-friendly documentation                                                                       | `/plugin install documentation-standards`  |
 | **code-documentation**       | Documentation generation and code explanation                                                                                                   | `/plugin install code-documentation`       |
 | **documentation-generation** | OpenAPI specs, Mermaid diagrams, tutorials                                                                                                      | `/plugin install documentation-generation` |
 | **c4-architecture**          | Comprehensive C4 architecture documentation workflow with bottom-up code analysis, component synthesis, container mapping, and context diagrams | `/plugin install c4-architecture`          |
 
-### 🔄 Workflows (5 plugins)
+### 🔄 Workflows (6 plugins)
 
 | Plugin                       | Description                                                                    | Install                                    |
 | ---------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------ |
@@ -136,6 +136,8 @@ Next.js, React + Vite, and Node.js project setup with pnpm and TypeScript best p
 | **git-pr-workflows**         | Git automation and PR enhancement                                              | `/plugin install git-pr-workflows`         |
 | **full-stack-orchestration** | End-to-end feature orchestration                                               | `/plugin install full-stack-orchestration` |
 | **tdd-workflows**            | Test-driven development methodology                                            | `/plugin install tdd-workflows`            |
+| **agent-teams**              | Parallel code review, debugging, feature, and research teams                   | `/plugin install agent-teams`              |
+| **ship-mate**                | Story-file to reviewed, tested PR workflow orchestration                       | `/plugin install ship-mate`                |
 
 ### ✅ Testing (2 plugins)
 
@@ -150,6 +152,7 @@ Next.js, React + Vite, and Node.js project setup with pnpm and TypeScript best p
 | ------------------------------ | --------------------------------------------- | -------------------------------------------- |
 | **comprehensive-review**       | Multi-perspective code analysis               | `/plugin install comprehensive-review`       |
 | **performance-testing-review** | Performance analysis and test coverage review | `/plugin install performance-testing-review` |
+| **plugin-eval**                | Three-layer quality evaluation framework for Claude Code plugins | `/plugin install plugin-eval`                |
 
 ### 🛠️ Utilities (4 plugins)
 
@@ -168,6 +171,12 @@ Next.js, React + Vite, and Node.js project setup with pnpm and TypeScript best p
 | **agent-orchestration**  | Multi-agent system optimization     | `/plugin install agent-orchestration`  |
 | **context-management**   | Context persistence and restoration | `/plugin install context-management`   |
 | **machine-learning-ops** | ML training pipelines and MLOps     | `/plugin install machine-learning-ops` |
+
+### 🧠 Memory (1 external plugin)
+
+| Plugin      | Description                                                                                  | Install                   |
+| ----------- | -------------------------------------------------------------------------------------------- | ------------------------- |
+| **pensyve** | Cross-session memory runtime with MCP-backed recall, skills, commands, agents, and hooks     | `/plugin install pensyve` |
 
 ### 📊 Data (2 plugins)
 
@@ -220,11 +229,13 @@ Next.js, React + Vite, and Node.js project setup with pnpm and TypeScript best p
 | **reverse-engineering**      | Binary analysis, malware triage, firmware security (authorized) | `/plugin install reverse-engineering`      |
 | **block-no-verify**          | PreToolUse hook blocking `--no-verify` and hook-bypass flags    | `/plugin install block-no-verify`          |
 
-### 🛡️ Governance (1 plugin)
+### 🛡️ Governance (3 plugins)
 
-| Plugin           | Description                                                                                                             | Install                        |
-| ---------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
-| **protect-mcp**  | Cedar policy enforcement + Ed25519 signed receipts for every tool call; offline-verifiable audit trail via hash chaining | `/plugin install protect-mcp`  |
+| Plugin                      | Description                                                                                                             | Install                                   |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| **protect-mcp**             | Cedar policy enforcement + Ed25519 signed receipts for every tool call; offline-verifiable audit trail via hash chaining | `/plugin install protect-mcp`             |
+| **signed-audit-trails**     | Cookbook-style signed audit trail patterns for Claude Code tool calls                                                   | `/plugin install signed-audit-trails`     |
+| **review-agent-governance** | Human approval governance before AI agents post reviews, comments, merges, or CI writes                                 | `/plugin install review-agent-governance` |
 
 ### 🔄 Modernization (2 plugins)
 
@@ -254,6 +265,7 @@ Next.js, React + Vite, and Node.js project setup with pnpm and TypeScript best p
 | Plugin                        | Description                          | Install                                     |
 | ----------------------------- | ------------------------------------ | ------------------------------------------- |
 | **business-analytics**        | KPI tracking and financial reporting | `/plugin install business-analytics`        |
+| **startup-business-analyst**  | Market sizing, financial modeling, team planning, and strategic research for startups | `/plugin install startup-business-analyst`  |
 | **hr-legal-compliance**       | HR policies and legal templates      | `/plugin install hr-legal-compliance`       |
 | **customer-sales-automation** | Support and sales automation         | `/plugin install customer-sales-automation` |
 
@@ -267,7 +279,10 @@ Next.js, React + Vite, and Node.js project setup with pnpm and TypeScript best p
 | **jvm-languages**               | Java, Scala, C# with enterprise patterns | `/plugin install jvm-languages`               |
 | **web-scripting**               | PHP and Ruby for web applications        | `/plugin install web-scripting`               |
 | **functional-programming**      | Elixir with OTP and Phoenix              | `/plugin install functional-programming`      |
+| **julia-development**           | Julia scientific computing and high-performance numerical code | `/plugin install julia-development`           |
 | **arm-cortex-microcontrollers** | ARM Cortex-M firmware and drivers        | `/plugin install arm-cortex-microcontrollers` |
+| **shell-scripting**             | Production-grade Bash and POSIX shell scripting | `/plugin install shell-scripting`             |
+| **dotnet-contribution**         | C#/.NET backend development with ASP.NET Core, EF Core, and Dapper | `/plugin install dotnet-contribution`         |
 
 ### 🔗 Blockchain (1 plugin)
 
@@ -299,11 +314,12 @@ Next.js, React + Vite, and Node.js project setup with pnpm and TypeScript best p
 | ---------------------------- | ---------------------------------- | ------------------------------------------ |
 | **accessibility-compliance** | WCAG auditing and inclusive design | `/plugin install accessibility-compliance` |
 
-### 🎨 Creative (1 plugin)
+### 🎨 Creative (2 plugins)
 
 | Plugin               | Description                                                              | Install                            |
 | -------------------- | ------------------------------------------------------------------------ | ---------------------------------- |
 | **meigen-ai-design** | AI image generation with creative workflow orchestration and prompt MCPs | `/plugin install meigen-ai-design` |
+| **brand-landingpage** | Brand discovery through deployment-ready landing page HTML              | `/plugin install brand-landingpage` |
 
 ## Plugin Structure
 
@@ -339,7 +355,7 @@ plugins/python-development/
 /plugin marketplace add wshobson/agents
 ```
 
-This makes all 77 plugins available for installation, but **does not load any agents or tools** into your context.
+This makes all 83 marketplace plugins available for installation, but **does not load any agents or tools** into your context.
 
 ### Step 2: Install Specific Plugins
 
@@ -382,7 +398,7 @@ Each installed plugin loads **only its specific agents and commands** into Claud
 
 ## See Also
 
-- [Agent Skills](./agent-skills.md) - 153 specialized skills across plugins
+- [Agent Skills](./agent-skills.md) - 155 specialized skills across plugins
 - [Agent Reference](./agents.md) - Complete agent catalog
 - [Usage Guide](./usage.md) - Commands and workflows
 - [Architecture](./architecture.md) - Design principles

--- a/docs/round-trip-results.md
+++ b/docs/round-trip-results.md
@@ -94,7 +94,7 @@ make generate HARNESS=cursor
 # 1. Open Cursor 2.5+
 # 2. Settings → Plugins → Add Local Plugin Source
 # 3. Point at /path/to/claude-agents/
-# 4. Verify the marketplace browser lists all 82 plugins
+# 4. Verify the marketplace browser lists all 81 local plugins
 # 5. Verify .cursor/rules/*.mdc files activate per their `globs`
 # 6. Skills under .claude/skills/ should auto-trigger from descriptions
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -385,11 +385,11 @@ User: "Implement Kubernetes deployment with Helm"
 → Result: Production-grade K8s manifests with Helm charts
 ```
 
-See [Agent Skills](./agent-skills.md) for details on the 153 specialized skills.
+See [Agent Skills](./agent-skills.md) for details on the 155 specialized skills.
 
 ## See Also
 
 - [Agent Skills](./agent-skills.md) - Specialized knowledge packages
 - [Agent Reference](./agents.md) - Complete agent catalog
-- [Plugin Reference](./plugins.md) - All 80 plugins
+- [Plugin Reference](./plugins.md) - All 83 marketplace plugins
 - [Architecture](./architecture.md) - Design principles

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-workflows",
-  "version": "1.7.0",
-  "description": "Multi-harness agentic plugin marketplace — 82 plugins, 191 agents, 155 skills, 102 commands across architecture, infrastructure, languages, security, testing, ML, and full-stack development. Native to Claude Code; also consumable by Codex CLI, Cursor, OpenCode, and Gemini CLI.",
+  "version": "1.7.1",
+  "description": "Multi-harness agentic plugin marketplace — 83 plugins, 191 agents, 155 skills, 102 commands across architecture, infrastructure, languages, security, testing, ML, and full-stack development. Native to Claude Code; also consumable by Codex CLI, Cursor, OpenCode, and Gemini CLI.",
   "contextFileName": "AGENTS.md"
 }


### PR DESCRIPTION
## Summary
- Adds Pensyve as an externally hosted Claude Code marketplace plugin via git-subdir from major7apps/pensyve integrations/claude-code.
- Documents the supported-harness split: Claude Code installs through this marketplace, Gemini users install Pensyve's upstream extension as an opt-in companion.
- Refreshes visible catalog counts and tightens git-subdir validation for URL/path shape.

## Research Notes
- Upstream Pensyve integrations checked at 8366b9c64a85f609da5620175cd0715c35c5c714.
- This repo directly supports Claude Code marketplace and Gemini CLI extension harnesses; it does not directly host Codex, OpenCode, or OpenClaw plugin harnesses.

## Validation
- python3 -m json.tool .claude-plugin/marketplace.json >/dev/null && python3 -m json.tool gemini-extension.json >/dev/null
- Marketplace validation snippet: OK: 83 marketplace entries validated
- All local plugin.json and hooks.json files validated with python3 -m json.tool
- python3 tools/check_agent_name_collisions.py --max-duplicate-names 30 --max-colliding-files 95
- git diff --check
- Code review subagent re-review: no blocking findings