### PR TITLE
Fix duplicate agent name collisions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -102,8 +102,8 @@ jobs:
           print(f"OK: {len(mp.get('plugins', []))} marketplace entries validated")
           PY
 
-      - name: Check agent name collision baseline
-        run: python3 tools/check_agent_name_collisions.py --max-duplicate-names 30 --max-colliding-files 95
+      - name: Check agent name uniqueness
+        run: python3 tools/check_agent_name_collisions.py --fail-on-duplicates
 
   plugin-eval-tests:
     name: plugin-eval pytest

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -76,8 +76,9 @@ on illustrative examples.
 
 Claude Code keys installed agents by the YAML frontmatter `name`, so two plugins that
 ship the same agent name can silently overwrite each other when installed together. Use
-plugin-scoped names for common roles (`backend-development-test-automator`, not
-`test-automator`) and update any bundled command `subagent_type` references to match.
+plugin-scoped names for common roles using `<plugin-directory>-<agent-file-stem>`
+(`backend-development-test-automator`, not `test-automator`) and update any bundled
+command `subagent_type` references to match.
 CI runs `tools/check_agent_name_collisions.py --fail-on-duplicates` to keep the source
 tree collision-free.
 

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -72,6 +72,15 @@ Link from `SKILL.md` like ``See `references/details.md` for the full algorithm.`
 link target as backticked path text so the gardener's dead-link checker doesn't false-positive
 on illustrative examples.
 
+### Use globally unique agent names
+
+Claude Code keys installed agents by the YAML frontmatter `name`, so two plugins that
+ship the same agent name can silently overwrite each other when installed together. Use
+plugin-scoped names for common roles (`backend-development-test-automator`, not
+`test-automator`) and update any bundled command `subagent_type` references to match.
+CI runs `tools/check_agent_name_collisions.py --fail-on-duplicates` to keep the source
+tree collision-free.
+
 ### Don't collide with Codex built-in agent names
 
 `default`, `worker`, and `explorer` are built-in Codex subagent roles. If you name a custom

--- a/plugins/agent-orchestration/agents/context-manager.md
+++ b/plugins/agent-orchestration/agents/context-manager.md
@@ -1,5 +1,5 @@
 ---
-name: context-manager
+name: agent-orchestration-context-manager
 description: Elite AI context engineering specialist mastering dynamic context management, vector databases, knowledge graphs, and intelligent memory systems. Orchestrates context across multi-agent workflows, enterprise AI systems, and long-running projects with 2024/2025 best practices. Use PROACTIVELY for complex AI orchestration.
 model: inherit
 ---

--- a/plugins/api-scaffolding/agents/backend-architect.md
+++ b/plugins/api-scaffolding/agents/backend-architect.md
@@ -1,5 +1,5 @@
 ---
-name: backend-architect
+name: api-scaffolding-backend-architect
 description: Expert backend architect specializing in scalable API design, microservices architecture, and distributed systems. Masters REST/GraphQL/gRPC APIs, event-driven architectures, service mesh patterns, and modern backend frameworks. Handles service boundary definition, inter-service communication, resilience patterns, and observability. Use PROACTIVELY when creating new backend services or APIs.
 model: inherit
 ---

--- a/plugins/api-scaffolding/agents/django-pro.md
+++ b/plugins/api-scaffolding/agents/django-pro.md
@@ -1,5 +1,5 @@
 ---
-name: django-pro
+name: api-scaffolding-django-pro
 description: Master Django 5.x with async views, DRF, Celery, and Django Channels. Build scalable web applications with proper architecture, testing, and deployment. Use PROACTIVELY for Django development, ORM optimization, or complex Django patterns.
 model: opus
 ---

--- a/plugins/api-scaffolding/agents/fastapi-pro.md
+++ b/plugins/api-scaffolding/agents/fastapi-pro.md
@@ -1,5 +1,5 @@
 ---
-name: fastapi-pro
+name: api-scaffolding-fastapi-pro
 description: Build high-performance async APIs with FastAPI, SQLAlchemy 2.0, and Pydantic V2. Master microservices, WebSockets, and modern Python async patterns. Use PROACTIVELY for FastAPI development, async optimization, or API architecture.
 model: opus
 ---

--- a/plugins/api-scaffolding/agents/graphql-architect.md
+++ b/plugins/api-scaffolding/agents/graphql-architect.md
@@ -1,5 +1,5 @@
 ---
-name: graphql-architect
+name: api-scaffolding-graphql-architect
 description: Master modern GraphQL with federation, performance optimization, and enterprise security. Build scalable schemas, implement advanced caching, and design real-time systems. Use PROACTIVELY for GraphQL architecture or performance optimization.
 model: opus
 ---

--- a/plugins/api-testing-observability/agents/api-documenter.md
+++ b/plugins/api-testing-observability/agents/api-documenter.md
@@ -1,5 +1,5 @@
 ---
-name: api-documenter
+name: api-testing-observability-api-documenter
 description: Master API documentation with OpenAPI 3.1, AI-powered tools, and modern developer experience practices. Create interactive docs, generate SDKs, and build comprehensive developer portals. Use PROACTIVELY for API documentation or developer portal creation.
 model: sonnet
 ---

--- a/plugins/application-performance/agents/frontend-developer.md
+++ b/plugins/application-performance/agents/frontend-developer.md
@@ -1,5 +1,5 @@
 ---
-name: frontend-developer
+name: application-performance-frontend-developer
 description: Build React components, implement responsive layouts, and handle client-side state management. Masters React 19, Next.js 15, and modern frontend architecture. Optimizes performance and ensures accessibility. Use PROACTIVELY when creating UI components or fixing frontend issues.
 model: inherit
 ---

--- a/plugins/application-performance/agents/observability-engineer.md
+++ b/plugins/application-performance/agents/observability-engineer.md
@@ -1,5 +1,5 @@
 ---
-name: observability-engineer
+name: application-performance-observability-engineer
 description: Build production-ready monitoring, logging, and tracing systems. Implements comprehensive observability strategies, SLI/SLO management, and incident response workflows. Use PROACTIVELY for monitoring infrastructure, performance optimization, or production reliability.
 model: inherit
 ---

--- a/plugins/application-performance/agents/performance-engineer.md
+++ b/plugins/application-performance/agents/performance-engineer.md
@@ -1,5 +1,5 @@
 ---
-name: performance-engineer
+name: application-performance-performance-engineer
 description: Expert performance engineer specializing in modern observability, application optimization, and scalable system performance. Masters OpenTelemetry, distributed tracing, load testing, multi-tier caching, Core Web Vitals, and performance monitoring. Handles end-to-end optimization, real user monitoring, and scalability patterns. Use PROACTIVELY for performance optimization, observability, or scalability challenges.
 model: inherit
 ---

--- a/plugins/application-performance/commands/performance-optimization.md
+++ b/plugins/application-performance/commands/performance-optimization.md
@@ -72,7 +72,7 @@ Use the Task tool to launch the performance engineer:
 
 ```
 Task:
-  subagent_type: "performance-engineer"
+  subagent_type: "application-performance-performance-engineer"
   description: "Profile application performance for $TARGET"
   prompt: |
     Profile application performance comprehensively for: $TARGET.
@@ -104,7 +104,7 @@ Use the Task tool:
 
 ```
 Task:
-  subagent_type: "observability-engineer"
+  subagent_type: "application-performance-observability-engineer"
   description: "Assess observability setup for $TARGET"
   prompt: |
     Assess current observability setup for: $TARGET.
@@ -138,7 +138,7 @@ Use the Task tool:
 
 ```
 Task:
-  subagent_type: "performance-engineer"
+  subagent_type: "application-performance-performance-engineer"
   description: "Analyze user experience metrics for $TARGET"
   prompt: |
     Analyze user experience metrics for: $TARGET.
@@ -275,7 +275,7 @@ Use the Task tool:
 
 ```
 Task:
-  subagent_type: "performance-engineer"
+  subagent_type: "application-performance-performance-engineer"
   description: "Optimize distributed system performance for $TARGET"
   prompt: |
     Optimize distributed system performance for: $TARGET.
@@ -335,7 +335,7 @@ Use the Task tool:
 
 ```
 Task:
-  subagent_type: "frontend-developer"
+  subagent_type: "application-performance-frontend-developer"
   description: "Optimize frontend performance for $TARGET"
   prompt: |
     Optimize frontend performance for: $TARGET targeting Core Web Vitals improvements.
@@ -469,7 +469,7 @@ Use the Task tool:
 
 ```
 Task:
-  subagent_type: "performance-engineer"
+  subagent_type: "application-performance-performance-engineer"
   description: "Conduct comprehensive load testing for $TARGET"
   prompt: |
     Conduct comprehensive load testing for: $TARGET using k6/Gatling/Artillery.
@@ -565,7 +565,7 @@ Use the Task tool:
 
 ```
 Task:
-  subagent_type: "observability-engineer"
+  subagent_type: "application-performance-observability-engineer"
   description: "Implement production performance monitoring for $TARGET"
   prompt: |
     Implement production performance monitoring for: $TARGET.
@@ -603,7 +603,7 @@ Use the Task tool:
 
 ```
 Task:
-  subagent_type: "performance-engineer"
+  subagent_type: "application-performance-performance-engineer"
   description: "Establish continuous optimization process for $TARGET"
   prompt: |
     Establish continuous optimization process for: $TARGET.

--- a/plugins/backend-api-security/agents/backend-architect.md
+++ b/plugins/backend-api-security/agents/backend-architect.md
@@ -1,5 +1,5 @@
 ---
-name: backend-architect
+name: backend-api-security-backend-architect
 description: Expert backend architect specializing in scalable API design, microservices architecture, and distributed systems. Masters REST/GraphQL/gRPC APIs, event-driven architectures, service mesh patterns, and modern backend frameworks. Handles service boundary definition, inter-service communication, resilience patterns, and observability. Use PROACTIVELY when creating new backend services or APIs.
 model: inherit
 ---

--- a/plugins/backend-api-security/agents/backend-security-coder.md
+++ b/plugins/backend-api-security/agents/backend-security-coder.md
@@ -1,5 +1,5 @@
 ---
-name: backend-security-coder
+name: backend-api-security-backend-security-coder
 description: Expert in secure backend coding practices specializing in input validation, authentication, and API security. Use PROACTIVELY for backend security implementations or security code reviews.
 model: sonnet
 ---

--- a/plugins/backend-development/agents/backend-architect.md
+++ b/plugins/backend-development/agents/backend-architect.md
@@ -1,5 +1,5 @@
 ---
-name: backend-architect
+name: backend-development-backend-architect
 description: Expert backend architect specializing in scalable API design, microservices architecture, and distributed systems. Masters REST/GraphQL/gRPC APIs, event-driven architectures, service mesh patterns, and modern backend frameworks. Handles service boundary definition, inter-service communication, resilience patterns, and observability. Use PROACTIVELY when creating new backend services or APIs.
 model: inherit
 ---

--- a/plugins/backend-development/agents/graphql-architect.md
+++ b/plugins/backend-development/agents/graphql-architect.md
@@ -1,5 +1,5 @@
 ---
-name: graphql-architect
+name: backend-development-graphql-architect
 description: Master modern GraphQL with federation, performance optimization, and enterprise security. Build scalable schemas, implement advanced caching, and design real-time systems. Use PROACTIVELY for GraphQL architecture or performance optimization.
 model: opus
 ---

--- a/plugins/backend-development/agents/performance-engineer.md
+++ b/plugins/backend-development/agents/performance-engineer.md
@@ -1,5 +1,5 @@
 ---
-name: performance-engineer
+name: backend-development-performance-engineer
 description: Profile and optimize application performance including response times, memory usage, query efficiency, and scalability. Use for performance review during feature development.
 model: sonnet
 ---

--- a/plugins/backend-development/agents/security-auditor.md
+++ b/plugins/backend-development/agents/security-auditor.md
@@ -1,5 +1,5 @@
 ---
-name: security-auditor
+name: backend-development-security-auditor
 description: Review code and architecture for security vulnerabilities, OWASP Top 10, auth flaws, and compliance issues. Use for security review during feature development.
 model: sonnet
 ---

--- a/plugins/backend-development/agents/tdd-orchestrator.md
+++ b/plugins/backend-development/agents/tdd-orchestrator.md
@@ -1,5 +1,5 @@
 ---
-name: tdd-orchestrator
+name: backend-development-tdd-orchestrator
 description: Master TDD orchestrator specializing in red-green-refactor discipline, multi-agent workflow coordination, and comprehensive test-driven development practices. Enforces TDD best practices across teams with AI-assisted testing and modern frameworks. Use PROACTIVELY for TDD implementation and governance.
 model: opus
 ---

--- a/plugins/backend-development/agents/test-automator.md
+++ b/plugins/backend-development/agents/test-automator.md
@@ -1,5 +1,5 @@
 ---
-name: test-automator
+name: backend-development-test-automator
 description: Create comprehensive test suites including unit, integration, and E2E tests. Supports TDD/BDD workflows. Use for test creation during feature development.
 model: sonnet
 ---

--- a/plugins/backend-development/commands/feature-development.md
+++ b/plugins/backend-development/commands/feature-development.md
@@ -126,7 +126,7 @@ Use the Task tool to launch the architecture agent:
 
 ```
 Task:
-  subagent_type: "backend-architect"
+  subagent_type: "backend-development-backend-architect"
   description: "Design architecture for $FEATURE"
   prompt: |
     Design the technical architecture for this feature.
@@ -179,7 +179,7 @@ Use the Task tool to launch the backend architect for implementation:
 
 ```
 Task:
-  subagent_type: "backend-architect"
+  subagent_type: "backend-development-backend-architect"
   description: "Implement backend for $FEATURE"
   prompt: |
     Implement the backend for this feature based on the approved architecture.
@@ -253,7 +253,7 @@ Launch three agents in parallel using multiple Task tool calls in a single respo
 
 ```
 Task:
-  subagent_type: "test-automator"
+  subagent_type: "backend-development-test-automator"
   description: "Create test suite for $FEATURE"
   prompt: |
     Create a comprehensive test suite for this feature.
@@ -280,7 +280,7 @@ Task:
 
 ```
 Task:
-  subagent_type: "security-auditor"
+  subagent_type: "backend-development-security-auditor"
   description: "Security review of $FEATURE"
   prompt: |
     Perform a security review of this feature implementation.
@@ -304,7 +304,7 @@ Task:
 
 ```
 Task:
-  subagent_type: "performance-engineer"
+  subagent_type: "backend-development-performance-engineer"
   description: "Performance review of $FEATURE"
   prompt: |
     Review the performance of this feature implementation.

--- a/plugins/cicd-automation/agents/cloud-architect.md
+++ b/plugins/cicd-automation/agents/cloud-architect.md
@@ -1,5 +1,5 @@
 ---
-name: cloud-architect
+name: cicd-automation-cloud-architect
 description: Expert cloud architect specializing in AWS/Azure/GCP/OCI multi-cloud infrastructure design, advanced IaC (Terraform/OpenTofu/CDK), FinOps cost optimization, and modern architectural patterns. Masters serverless, microservices, security, compliance, and disaster recovery. Use PROACTIVELY for cloud architecture, cost optimization, migration planning, or multi-cloud strategies.
 model: opus
 ---

--- a/plugins/cicd-automation/agents/deployment-engineer.md
+++ b/plugins/cicd-automation/agents/deployment-engineer.md
@@ -1,5 +1,5 @@
 ---
-name: deployment-engineer
+name: cicd-automation-deployment-engineer
 description: Expert deployment engineer specializing in modern CI/CD pipelines, GitOps workflows, and advanced deployment automation. Masters GitHub Actions, ArgoCD/Flux, progressive delivery, container security, and platform engineering. Handles zero-downtime deployments, security scanning, and developer experience optimization. Use PROACTIVELY for CI/CD design, GitOps implementation, or deployment automation.
 model: haiku
 ---

--- a/plugins/cicd-automation/agents/devops-troubleshooter.md
+++ b/plugins/cicd-automation/agents/devops-troubleshooter.md
@@ -1,5 +1,5 @@
 ---
-name: devops-troubleshooter
+name: cicd-automation-devops-troubleshooter
 description: Expert DevOps troubleshooter specializing in rapid incident response, advanced debugging, and modern observability. Masters log analysis, distributed tracing, Kubernetes debugging, performance optimization, and root cause analysis. Handles production outages, system reliability, and preventive monitoring. Use PROACTIVELY for debugging, incident response, or system troubleshooting.
 model: sonnet
 ---

--- a/plugins/cicd-automation/agents/kubernetes-architect.md
+++ b/plugins/cicd-automation/agents/kubernetes-architect.md
@@ -1,5 +1,5 @@
 ---
-name: kubernetes-architect
+name: cicd-automation-kubernetes-architect
 description: Expert Kubernetes architect specializing in cloud-native infrastructure, advanced GitOps workflows (ArgoCD/Flux), and enterprise container orchestration. Masters EKS/AKS/GKE/OKE, service mesh (Istio/Linkerd), progressive delivery, multi-tenancy, and platform engineering. Handles security, observability, cost optimization, and developer experience. Use PROACTIVELY for K8s architecture, GitOps implementation, or cloud-native platform design.
 model: opus
 ---

--- a/plugins/cicd-automation/agents/terraform-specialist.md
+++ b/plugins/cicd-automation/agents/terraform-specialist.md
@@ -1,5 +1,5 @@
 ---
-name: terraform-specialist
+name: cicd-automation-terraform-specialist
 description: Expert Terraform/OpenTofu specialist mastering advanced IaC automation, state management, and enterprise infrastructure patterns. Handles complex module design, multi-cloud deployments, GitOps workflows, policy as code, and CI/CD integration. Covers migration strategies, security best practices, and modern IaC ecosystems. Use PROACTIVELY for advanced IaC, state management, or infrastructure automation.
 model: opus
 ---

--- a/plugins/cloud-infrastructure/agents/cloud-architect.md
+++ b/plugins/cloud-infrastructure/agents/cloud-architect.md
@@ -1,5 +1,5 @@
 ---
-name: cloud-architect
+name: cloud-infrastructure-cloud-architect
 description: Expert cloud architect specializing in AWS/Azure/GCP/OCI multi-cloud infrastructure design, advanced IaC (Terraform/OpenTofu/CDK), FinOps cost optimization, and modern architectural patterns. Masters serverless, microservices, security, compliance, and disaster recovery. Use PROACTIVELY for cloud architecture, cost optimization, migration planning, or multi-cloud strategies.
 model: opus
 ---

--- a/plugins/cloud-infrastructure/agents/deployment-engineer.md
+++ b/plugins/cloud-infrastructure/agents/deployment-engineer.md
@@ -1,5 +1,5 @@
 ---
-name: deployment-engineer
+name: cloud-infrastructure-deployment-engineer
 description: Expert deployment engineer specializing in modern CI/CD pipelines, GitOps workflows, and advanced deployment automation. Masters GitHub Actions, ArgoCD/Flux, progressive delivery, container security, and platform engineering. Handles zero-downtime deployments, security scanning, and developer experience optimization. Use PROACTIVELY for CI/CD design, GitOps implementation, or deployment automation.
 model: haiku
 ---

--- a/plugins/cloud-infrastructure/agents/kubernetes-architect.md
+++ b/plugins/cloud-infrastructure/agents/kubernetes-architect.md
@@ -1,5 +1,5 @@
 ---
-name: kubernetes-architect
+name: cloud-infrastructure-kubernetes-architect
 description: Expert Kubernetes architect specializing in cloud-native infrastructure, advanced GitOps workflows (ArgoCD/Flux), and enterprise container orchestration. Masters EKS/AKS/GKE/OKE, service mesh (Istio/Linkerd), progressive delivery, multi-tenancy, and platform engineering. Handles security, observability, cost optimization, and developer experience. Use PROACTIVELY for K8s architecture, GitOps implementation, or cloud-native platform design.
 model: opus
 ---

--- a/plugins/cloud-infrastructure/agents/network-engineer.md
+++ b/plugins/cloud-infrastructure/agents/network-engineer.md
@@ -1,5 +1,5 @@
 ---
-name: network-engineer
+name: cloud-infrastructure-network-engineer
 description: Expert network engineer specializing in modern cloud networking, security architectures, and performance optimization. Masters multi-cloud connectivity, service mesh, zero-trust networking, SSL/TLS, global load balancing, and advanced troubleshooting. Handles CDN optimization, network automation, and compliance. Use PROACTIVELY for network design, connectivity issues, or performance optimization.
 model: sonnet
 ---

--- a/plugins/cloud-infrastructure/agents/terraform-specialist.md
+++ b/plugins/cloud-infrastructure/agents/terraform-specialist.md
@@ -1,5 +1,5 @@
 ---
-name: terraform-specialist
+name: cloud-infrastructure-terraform-specialist
 description: Expert Terraform/OpenTofu specialist mastering advanced IaC automation, state management, and enterprise infrastructure patterns. Handles complex module design, multi-cloud deployments, GitOps workflows, policy as code, and CI/CD integration. Covers migration strategies, security best practices, and modern IaC ecosystems. Use PROACTIVELY for advanced IaC, state management, or infrastructure automation.
 model: opus
 ---

--- a/plugins/code-documentation/agents/code-reviewer.md
+++ b/plugins/code-documentation/agents/code-reviewer.md
@@ -1,5 +1,5 @@
 ---
-name: code-reviewer
+name: code-documentation-code-reviewer
 description: Elite code review expert specializing in modern AI-powered code analysis, security vulnerabilities, performance optimization, and production reliability. Masters static analysis tools, security scanning, and configuration review with 2024/2025 best practices. Use PROACTIVELY for code quality assurance.
 model: opus
 ---

--- a/plugins/code-documentation/agents/docs-architect.md
+++ b/plugins/code-documentation/agents/docs-architect.md
@@ -1,5 +1,5 @@
 ---
-name: docs-architect
+name: code-documentation-docs-architect
 description: Creates comprehensive technical documentation from existing codebases. Analyzes architecture, design patterns, and implementation details to produce long-form technical manuals and ebooks. Use PROACTIVELY for system documentation, architecture guides, or technical deep-dives.
 model: sonnet
 ---

--- a/plugins/code-documentation/agents/tutorial-engineer.md
+++ b/plugins/code-documentation/agents/tutorial-engineer.md
@@ -1,5 +1,5 @@
 ---
-name: tutorial-engineer
+name: code-documentation-tutorial-engineer
 description: Creates step-by-step tutorials and educational content from code. Transforms complex concepts into progressive learning experiences with hands-on examples. Use PROACTIVELY for onboarding guides, feature tutorials, or concept explanations.
 model: sonnet
 ---

--- a/plugins/code-refactoring/agents/code-reviewer.md
+++ b/plugins/code-refactoring/agents/code-reviewer.md
@@ -1,5 +1,5 @@
 ---
-name: code-reviewer
+name: code-refactoring-code-reviewer
 description: Elite code review expert specializing in modern AI-powered code analysis, security vulnerabilities, performance optimization, and production reliability. Masters static analysis tools, security scanning, and configuration review with 2024/2025 best practices. Use PROACTIVELY for code quality assurance.
 model: opus
 ---

--- a/plugins/code-refactoring/agents/legacy-modernizer.md
+++ b/plugins/code-refactoring/agents/legacy-modernizer.md
@@ -1,5 +1,5 @@
 ---
-name: legacy-modernizer
+name: code-refactoring-legacy-modernizer
 description: Refactor legacy codebases, migrate outdated frameworks, and implement gradual modernization. Handles technical debt, dependency updates, and backward compatibility. Use PROACTIVELY for legacy system updates, framework migrations, or technical debt reduction.
 model: sonnet
 ---

--- a/plugins/codebase-cleanup/agents/code-reviewer.md
+++ b/plugins/codebase-cleanup/agents/code-reviewer.md
@@ -1,5 +1,5 @@
 ---
-name: code-reviewer
+name: codebase-cleanup-code-reviewer
 description: Elite code review expert specializing in modern AI-powered code analysis, security vulnerabilities, performance optimization, and production reliability. Masters static analysis tools, security scanning, and configuration review with 2024/2025 best practices. Use PROACTIVELY for code quality assurance.
 model: opus
 ---

--- a/plugins/codebase-cleanup/agents/test-automator.md
+++ b/plugins/codebase-cleanup/agents/test-automator.md
@@ -1,5 +1,5 @@
 ---
-name: test-automator
+name: codebase-cleanup-test-automator
 description: Master AI-powered test automation with modern frameworks, self-healing tests, and comprehensive quality engineering. Build scalable testing strategies with advanced CI/CD integration. Use PROACTIVELY for testing automation or quality assurance.
 model: sonnet
 ---

--- a/plugins/comprehensive-review/agents/architect-review.md
+++ b/plugins/comprehensive-review/agents/architect-review.md
@@ -1,5 +1,5 @@
 ---
-name: architect-review
+name: comprehensive-review-architect-review
 description: Master software architect specializing in modern architecture patterns, clean architecture, microservices, event-driven systems, and DDD. Reviews system designs and code changes for architectural integrity, scalability, and maintainability. Use PROACTIVELY for architectural decisions.
 model: opus
 ---

--- a/plugins/comprehensive-review/agents/code-reviewer.md
+++ b/plugins/comprehensive-review/agents/code-reviewer.md
@@ -1,5 +1,5 @@
 ---
-name: code-reviewer
+name: comprehensive-review-code-reviewer
 description: Elite code review expert specializing in modern AI-powered code analysis, security vulnerabilities, performance optimization, and production reliability. Masters static analysis tools, security scanning, and configuration review with 2024/2025 best practices. Use PROACTIVELY for code quality assurance.
 model: opus
 ---

--- a/plugins/comprehensive-review/agents/security-auditor.md
+++ b/plugins/comprehensive-review/agents/security-auditor.md
@@ -1,5 +1,5 @@
 ---
-name: security-auditor
+name: comprehensive-review-security-auditor
 description: Expert security auditor specializing in DevSecOps, comprehensive cybersecurity, and compliance frameworks. Masters vulnerability assessment, threat modeling, secure authentication (OAuth2/OIDC), OWASP standards, cloud security, and security automation. Handles DevSecOps integration, compliance (GDPR/HIPAA/SOC2), and incident response. Use PROACTIVELY for security audits, DevSecOps, or compliance implementation.
 model: opus
 ---

--- a/plugins/comprehensive-review/commands/full-review.md
+++ b/plugins/comprehensive-review/commands/full-review.md
@@ -111,7 +111,7 @@ Run both agents in parallel using multiple Task tool calls in a single response.
 
 ```
 Task:
-  subagent_type: "code-reviewer"
+  subagent_type: "comprehensive-review-code-reviewer"
   description: "Code quality analysis for $ARGUMENTS"
   prompt: |
     Perform a comprehensive code quality review.
@@ -141,7 +141,7 @@ Task:
 
 ```
 Task:
-  subagent_type: "architect-review"
+  subagent_type: "comprehensive-review-architect-review"
   description: "Architecture review for $ARGUMENTS"
   prompt: |
     Review the architectural design and structural integrity of the target code.
@@ -198,7 +198,7 @@ Run both agents in parallel using multiple Task tool calls in a single response.
 
 ```
 Task:
-  subagent_type: "security-auditor"
+  subagent_type: "comprehensive-review-security-auditor"
   description: "Security audit for $ARGUMENTS"
   prompt: |
     Execute a comprehensive security audit on the target code.

--- a/plugins/context-management/agents/context-manager.md
+++ b/plugins/context-management/agents/context-manager.md
@@ -1,5 +1,5 @@
 ---
-name: context-manager
+name: context-management-context-manager
 description: Elite AI context engineering specialist mastering dynamic context management, vector databases, knowledge graphs, and intelligent memory systems. Orchestrates context across multi-agent workflows, enterprise AI systems, and long-running projects with 2024/2025 best practices. Use PROACTIVELY for complex AI orchestration.
 model: inherit
 ---

--- a/plugins/data-engineering/agents/backend-architect.md
+++ b/plugins/data-engineering/agents/backend-architect.md
@@ -1,5 +1,5 @@
 ---
-name: backend-architect
+name: data-engineering-backend-architect
 description: Expert backend architect specializing in scalable API design, microservices architecture, and distributed systems. Masters REST/GraphQL/gRPC APIs, event-driven architectures, service mesh patterns, and modern backend frameworks. Handles service boundary definition, inter-service communication, resilience patterns, and observability. Use PROACTIVELY when creating new backend services or APIs.
 model: inherit
 ---

--- a/plugins/data-engineering/commands/data-driven-feature.md
+++ b/plugins/data-engineering/commands/data-driven-feature.md
@@ -187,7 +187,7 @@ Use the Task tool:
 
 ```
 Task:
-  subagent_type: "backend-architect"
+  subagent_type: "data-engineering-backend-architect"
   description: "Design feature architecture for $FEATURE with A/B testing capability"
   prompt: |
     Design the feature architecture for: $FEATURE with A/B testing capability.
@@ -310,7 +310,7 @@ Use the Task tool:
 
 ```
 Task:
-  subagent_type: "backend-architect"
+  subagent_type: "data-engineering-backend-architect"
   description: "Implement backend for $FEATURE with full instrumentation"
   prompt: |
     Implement the backend for feature: $FEATURE with full instrumentation.

--- a/plugins/data-validation-suite/agents/backend-security-coder.md
+++ b/plugins/data-validation-suite/agents/backend-security-coder.md
@@ -1,5 +1,5 @@
 ---
-name: backend-security-coder
+name: data-validation-suite-backend-security-coder
 description: Expert in secure backend coding practices specializing in input validation, authentication, and API security. Use PROACTIVELY for backend security implementations or security code reviews.
 model: sonnet
 ---

--- a/plugins/database-cloud-optimization/agents/backend-architect.md
+++ b/plugins/database-cloud-optimization/agents/backend-architect.md
@@ -1,5 +1,5 @@
 ---
-name: backend-architect
+name: database-cloud-optimization-backend-architect
 description: Expert backend architect specializing in scalable API design, microservices architecture, and distributed systems. Masters REST/GraphQL/gRPC APIs, event-driven architectures, service mesh patterns, and modern backend frameworks. Handles service boundary definition, inter-service communication, resilience patterns, and observability. Use PROACTIVELY when creating new backend services or APIs.
 model: inherit
 ---

--- a/plugins/database-cloud-optimization/agents/cloud-architect.md
+++ b/plugins/database-cloud-optimization/agents/cloud-architect.md
@@ -1,5 +1,5 @@
 ---
-name: cloud-architect
+name: database-cloud-optimization-cloud-architect
 description: Expert cloud architect specializing in AWS/Azure/GCP/OCI multi-cloud infrastructure design, advanced IaC (Terraform/OpenTofu/CDK), FinOps cost optimization, and modern architectural patterns. Masters serverless, microservices, security, compliance, and disaster recovery. Use PROACTIVELY for cloud architecture, cost optimization, migration planning, or multi-cloud strategies.
 model: sonnet
 ---

--- a/plugins/database-cloud-optimization/agents/database-architect.md
+++ b/plugins/database-cloud-optimization/agents/database-architect.md
@@ -1,5 +1,5 @@
 ---
-name: database-architect
+name: database-cloud-optimization-database-architect
 description: Expert database architect specializing in data layer design from scratch, technology selection, schema modeling, and scalable database architectures. Masters SQL/NoSQL/TimeSeries database selection, normalization strategies, migration planning, and performance-first design. Handles both greenfield architectures and re-architecture of existing systems. Use PROACTIVELY for database architecture, technology selection, or data modeling decisions.
 model: inherit
 ---

--- a/plugins/database-cloud-optimization/agents/database-optimizer.md
+++ b/plugins/database-cloud-optimization/agents/database-optimizer.md
@@ -1,5 +1,5 @@
 ---
-name: database-optimizer
+name: database-cloud-optimization-database-optimizer
 description: Expert database optimizer specializing in modern performance tuning, query optimization, and scalable architectures. Masters advanced indexing, N+1 resolution, multi-tier caching, partitioning strategies, and cloud database optimization. Handles complex query analysis, migration strategies, and performance monitoring. Use PROACTIVELY for database optimization, performance issues, or scalability challenges.
 model: inherit
 ---

--- a/plugins/database-design/agents/database-architect.md
+++ b/plugins/database-design/agents/database-architect.md
@@ -1,5 +1,5 @@
 ---
-name: database-architect
+name: database-design-database-architect
 description: Expert database architect specializing in data layer design from scratch, technology selection, schema modeling, and scalable database architectures. Masters SQL/NoSQL/TimeSeries database selection, normalization strategies, migration planning, and performance-first design. Handles both greenfield architectures and re-architecture of existing systems. Use PROACTIVELY for database architecture, technology selection, or data modeling decisions.
 model: opus
 ---

--- a/plugins/database-migrations/agents/database-optimizer.md
+++ b/plugins/database-migrations/agents/database-optimizer.md
@@ -1,5 +1,5 @@
 ---
-name: database-optimizer
+name: database-migrations-database-optimizer
 description: Expert database optimizer specializing in modern performance tuning, query optimization, and scalable architectures. Masters advanced indexing, N+1 resolution, multi-tier caching, partitioning strategies, and cloud database optimization. Handles complex query analysis, migration strategies, and performance monitoring. Use PROACTIVELY for database optimization, performance issues, or scalability challenges.
 model: inherit
 ---

--- a/plugins/debugging-toolkit/agents/debugger.md
+++ b/plugins/debugging-toolkit/agents/debugger.md
@@ -1,5 +1,5 @@
 ---
-name: debugger
+name: debugging-toolkit-debugger
 description: Debugging specialist for errors, test failures, and unexpected behavior. Use proactively when encountering any issues.
 model: sonnet
 ---

--- a/plugins/debugging-toolkit/agents/dx-optimizer.md
+++ b/plugins/debugging-toolkit/agents/dx-optimizer.md
@@ -1,5 +1,5 @@
 ---
-name: dx-optimizer
+name: debugging-toolkit-dx-optimizer
 description: Developer Experience specialist. Improves tooling, setup, and workflows. Use PROACTIVELY when setting up new projects, after team feedback, or when development friction is noticed.
 model: sonnet
 ---

--- a/plugins/debugging-toolkit/commands/smart-debug.md
+++ b/plugins/debugging-toolkit/commands/smart-debug.md
@@ -17,7 +17,7 @@ Parse for:
 
 ### 1. Initial Triage
 
-Use Task tool (subagent_type="debugger") for AI-powered analysis:
+Use Task tool (subagent_type="debugging-toolkit-debugger") for AI-powered analysis:
 
 - Error pattern recognition
 - Stack trace analysis with probable causes

--- a/plugins/dependency-management/agents/legacy-modernizer.md
+++ b/plugins/dependency-management/agents/legacy-modernizer.md
@@ -1,5 +1,5 @@
 ---
-name: legacy-modernizer
+name: dependency-management-legacy-modernizer
 description: Refactor legacy codebases, migrate outdated frameworks, and implement gradual modernization. Handles technical debt, dependency updates, and backward compatibility. Use PROACTIVELY for legacy system updates, framework migrations, or technical debt reduction.
 model: sonnet
 ---

--- a/plugins/deployment-strategies/agents/deployment-engineer.md
+++ b/plugins/deployment-strategies/agents/deployment-engineer.md
@@ -1,5 +1,5 @@
 ---
-name: deployment-engineer
+name: deployment-strategies-deployment-engineer
 description: Expert deployment engineer specializing in modern CI/CD pipelines, GitOps workflows, and advanced deployment automation. Masters GitHub Actions, ArgoCD/Flux, progressive delivery, container security, and platform engineering. Handles zero-downtime deployments, security scanning, and developer experience optimization. Use PROACTIVELY for CI/CD design, GitOps implementation, or deployment automation.
 model: haiku
 ---

--- a/plugins/deployment-strategies/agents/terraform-specialist.md
+++ b/plugins/deployment-strategies/agents/terraform-specialist.md
@@ -1,5 +1,5 @@
 ---
-name: terraform-specialist
+name: deployment-strategies-terraform-specialist
 description: Expert Terraform/OpenTofu specialist mastering advanced IaC automation, state management, and enterprise infrastructure patterns. Handles complex module design, multi-cloud deployments, GitOps workflows, policy as code, and CI/CD integration. Covers migration strategies, security best practices, and modern IaC ecosystems. Use PROACTIVELY for advanced IaC, state management, or infrastructure automation.
 model: opus
 ---

--- a/plugins/deployment-validation/agents/cloud-architect.md
+++ b/plugins/deployment-validation/agents/cloud-architect.md
@@ -1,5 +1,5 @@
 ---
-name: cloud-architect
+name: deployment-validation-cloud-architect
 description: Expert cloud architect specializing in AWS/Azure/GCP/OCI multi-cloud infrastructure design, advanced IaC (Terraform/OpenTofu/CDK), FinOps cost optimization, and modern architectural patterns. Masters serverless, microservices, security, compliance, and disaster recovery. Use PROACTIVELY for cloud architecture, cost optimization, migration planning, or multi-cloud strategies.
 model: sonnet
 ---

--- a/plugins/distributed-debugging/agents/devops-troubleshooter.md
+++ b/plugins/distributed-debugging/agents/devops-troubleshooter.md
@@ -1,5 +1,5 @@
 ---
-name: devops-troubleshooter
+name: distributed-debugging-devops-troubleshooter
 description: Expert DevOps troubleshooter specializing in rapid incident response, advanced debugging, and modern observability. Masters log analysis, distributed tracing, Kubernetes debugging, performance optimization, and root cause analysis. Handles production outages, system reliability, and preventive monitoring. Use PROACTIVELY for debugging, incident response, or system troubleshooting.
 model: sonnet
 ---

--- a/plugins/distributed-debugging/agents/error-detective.md
+++ b/plugins/distributed-debugging/agents/error-detective.md
@@ -1,5 +1,5 @@
 ---
-name: error-detective
+name: distributed-debugging-error-detective
 description: Search logs and codebases for error patterns, stack traces, and anomalies. Correlates errors across systems and identifies root causes. Use PROACTIVELY when debugging issues, analyzing logs, or investigating production errors.
 model: sonnet
 ---

--- a/plugins/documentation-generation/agents/api-documenter.md
+++ b/plugins/documentation-generation/agents/api-documenter.md
@@ -1,5 +1,5 @@
 ---
-name: api-documenter
+name: documentation-generation-api-documenter
 description: Master API documentation with OpenAPI 3.1, AI-powered tools, and modern developer experience practices. Create interactive docs, generate SDKs, and build comprehensive developer portals. Use PROACTIVELY for API documentation or developer portal creation.
 model: sonnet
 ---

--- a/plugins/documentation-generation/agents/docs-architect.md
+++ b/plugins/documentation-generation/agents/docs-architect.md
@@ -1,5 +1,5 @@
 ---
-name: docs-architect
+name: documentation-generation-docs-architect
 description: Creates comprehensive technical documentation from existing codebases. Analyzes architecture, design patterns, and implementation details to produce long-form technical manuals and ebooks. Use PROACTIVELY for system documentation, architecture guides, or technical deep-dives.
 model: sonnet
 ---

--- a/plugins/documentation-generation/agents/tutorial-engineer.md
+++ b/plugins/documentation-generation/agents/tutorial-engineer.md
@@ -1,5 +1,5 @@
 ---
-name: tutorial-engineer
+name: documentation-generation-tutorial-engineer
 description: Creates step-by-step tutorials and educational content from code. Transforms complex concepts into progressive learning experiences with hands-on examples. Use PROACTIVELY for onboarding guides, feature tutorials, or concept explanations.
 model: sonnet
 ---

--- a/plugins/error-debugging/agents/debugger.md
+++ b/plugins/error-debugging/agents/debugger.md
@@ -1,5 +1,5 @@
 ---
-name: debugger
+name: error-debugging-debugger
 description: Debugging specialist for errors, test failures, and unexpected behavior. Use proactively when encountering any issues.
 model: sonnet
 ---

--- a/plugins/error-debugging/agents/error-detective.md
+++ b/plugins/error-debugging/agents/error-detective.md
@@ -1,5 +1,5 @@
 ---
-name: error-detective
+name: error-debugging-error-detective
 description: Search logs and codebases for error patterns, stack traces, and anomalies. Correlates errors across systems and identifies root causes. Use PROACTIVELY when debugging issues, analyzing logs, or investigating production errors.
 model: sonnet
 ---

--- a/plugins/error-diagnostics/agents/debugger.md
+++ b/plugins/error-diagnostics/agents/debugger.md
@@ -1,5 +1,5 @@
 ---
-name: debugger
+name: error-diagnostics-debugger
 description: Debugging specialist for errors, test failures, and unexpected behavior. Use proactively when encountering any issues.
 model: sonnet
 ---

--- a/plugins/error-diagnostics/agents/error-detective.md
+++ b/plugins/error-diagnostics/agents/error-detective.md
@@ -1,5 +1,5 @@
 ---
-name: error-detective
+name: error-diagnostics-error-detective
 description: Search logs and codebases for error patterns, stack traces, and anomalies. Correlates errors across systems and identifies root causes. Use PROACTIVELY when debugging issues, analyzing logs, or investigating production errors.
 model: sonnet
 ---

--- a/plugins/error-diagnostics/commands/smart-debug.md
+++ b/plugins/error-diagnostics/commands/smart-debug.md
@@ -21,7 +21,7 @@ Parse for:
 
 ### 1. Initial Triage
 
-Use Task tool (subagent_type="debugger") for AI-powered analysis:
+Use Task tool (subagent_type="error-diagnostics-debugger") for AI-powered analysis:
 
 - Error pattern recognition
 - Stack trace analysis with probable causes

--- a/plugins/framework-migration/agents/architect-review.md
+++ b/plugins/framework-migration/agents/architect-review.md
@@ -1,5 +1,5 @@
 ---
-name: architect-review
+name: framework-migration-architect-review
 description: Master software architect specializing in modern architecture patterns, clean architecture, microservices, event-driven systems, and DDD. Reviews system designs and code changes for architectural integrity, scalability, and maintainability. Use PROACTIVELY for architectural decisions.
 model: opus
 ---

--- a/plugins/framework-migration/agents/legacy-modernizer.md
+++ b/plugins/framework-migration/agents/legacy-modernizer.md
@@ -1,5 +1,5 @@
 ---
-name: legacy-modernizer
+name: framework-migration-legacy-modernizer
 description: Refactor legacy codebases, migrate outdated frameworks, and implement gradual modernization. Handles technical debt, dependency updates, and backward compatibility. Use PROACTIVELY for legacy system updates, framework migrations, or technical debt reduction.
 model: sonnet
 ---

--- a/plugins/framework-migration/commands/legacy-modernize.md
+++ b/plugins/framework-migration/commands/legacy-modernize.md
@@ -67,11 +67,11 @@ Extract the target description from `$ARGUMENTS` (everything before the flags). 
 
 ### Step 1: Comprehensive Legacy System Analysis
 
-Use the Task tool with subagent_type="legacy-modernizer":
+Use the Task tool with subagent_type="framework-migration-legacy-modernizer":
 
 ```
 Task:
-  subagent_type: "legacy-modernizer"
+  subagent_type: "framework-migration-legacy-modernizer"
   description: "Analyze legacy codebase for modernization readiness"
   prompt: |
     Analyze the legacy codebase at $TARGET. Document a technical debt inventory including:
@@ -96,11 +96,11 @@ Update `state.json`: set `current_step` to 2, add `"01-legacy-assessment.md"` to
 
 Read `.legacy-modernize/01-legacy-assessment.md` to load assessment context.
 
-Use the Task tool with subagent_type="architect-review":
+Use the Task tool with subagent_type="framework-migration-architect-review":
 
 ```
 Task:
-  subagent_type: "architect-review"
+  subagent_type: "framework-migration-architect-review"
   description: "Create dependency graph and integration point catalog"
   prompt: |
     Based on the legacy assessment report below, create a comprehensive dependency graph.
@@ -548,11 +548,11 @@ Do NOT proceed to Phase 5 until the user approves.
 
 Read `.legacy-modernize/01-legacy-assessment.md`, `.legacy-modernize/08-first-wave.md`, and `.legacy-modernize/11-rollout.md`.
 
-Use the Task tool with subagent_type="legacy-modernizer":
+Use the Task tool with subagent_type="framework-migration-legacy-modernizer":
 
 ```
 Task:
-  subagent_type: "legacy-modernizer"
+  subagent_type: "framework-migration-legacy-modernizer"
   description: "Plan safe decommissioning of replaced legacy components"
   prompt: |
     Plan safe decommissioning of replaced legacy components.

--- a/plugins/frontend-mobile-development/agents/frontend-developer.md
+++ b/plugins/frontend-mobile-development/agents/frontend-developer.md
@@ -1,5 +1,5 @@
 ---
-name: frontend-developer
+name: frontend-mobile-development-frontend-developer
 description: Build React components, implement responsive layouts, and handle client-side state management. Masters React 19, Next.js 15, and modern frontend architecture. Optimizes performance and ensures accessibility. Use PROACTIVELY when creating UI components or fixing frontend issues.
 model: inherit
 ---

--- a/plugins/frontend-mobile-development/agents/mobile-developer.md
+++ b/plugins/frontend-mobile-development/agents/mobile-developer.md
@@ -1,5 +1,5 @@
 ---
-name: mobile-developer
+name: frontend-mobile-development-mobile-developer
 description: Develop React Native, Flutter, or native mobile apps with modern architecture patterns. Masters cross-platform development, native integrations, offline sync, and app store optimization. Use PROACTIVELY for mobile features, cross-platform code, or app optimization.
 model: inherit
 ---

--- a/plugins/frontend-mobile-security/agents/frontend-developer.md
+++ b/plugins/frontend-mobile-security/agents/frontend-developer.md
@@ -1,5 +1,5 @@
 ---
-name: frontend-developer
+name: frontend-mobile-security-frontend-developer
 description: Build React components, implement responsive layouts, and handle client-side state management. Masters React 19, Next.js 15, and modern frontend architecture. Optimizes performance and ensures accessibility. Use PROACTIVELY when creating UI components or fixing frontend issues.
 model: inherit
 ---

--- a/plugins/full-stack-orchestration/agents/deployment-engineer.md
+++ b/plugins/full-stack-orchestration/agents/deployment-engineer.md
@@ -1,5 +1,5 @@
 ---
-name: deployment-engineer
+name: full-stack-orchestration-deployment-engineer
 description: Expert deployment engineer specializing in modern CI/CD pipelines, GitOps workflows, and advanced deployment automation. Masters GitHub Actions, ArgoCD/Flux, progressive delivery, container security, and platform engineering. Handles zero-downtime deployments, security scanning, and developer experience optimization. Use PROACTIVELY for CI/CD design, GitOps implementation, or deployment automation.
 model: haiku
 ---

--- a/plugins/full-stack-orchestration/agents/performance-engineer.md
+++ b/plugins/full-stack-orchestration/agents/performance-engineer.md
@@ -1,5 +1,5 @@
 ---
-name: performance-engineer
+name: full-stack-orchestration-performance-engineer
 description: Expert performance engineer specializing in modern observability, application optimization, and scalable system performance. Masters OpenTelemetry, distributed tracing, load testing, multi-tier caching, Core Web Vitals, and performance monitoring. Handles end-to-end optimization, real user monitoring, and scalability patterns. Use PROACTIVELY for performance optimization, observability, or scalability challenges.
 model: inherit
 ---

--- a/plugins/full-stack-orchestration/agents/security-auditor.md
+++ b/plugins/full-stack-orchestration/agents/security-auditor.md
@@ -1,5 +1,5 @@
 ---
-name: security-auditor
+name: full-stack-orchestration-security-auditor
 description: Expert security auditor specializing in DevSecOps, comprehensive cybersecurity, and compliance frameworks. Masters vulnerability assessment, threat modeling, secure authentication (OAuth2/OIDC), OWASP standards, cloud security, and security automation. Handles DevSecOps integration, compliance (GDPR/HIPAA/SOC2), and incident response. Use PROACTIVELY for security audits, DevSecOps, or compliance implementation.
 model: opus
 ---

--- a/plugins/full-stack-orchestration/agents/test-automator.md
+++ b/plugins/full-stack-orchestration/agents/test-automator.md
@@ -1,5 +1,5 @@
 ---
-name: test-automator
+name: full-stack-orchestration-test-automator
 description: Master AI-powered test automation with modern frameworks, self-healing tests, and comprehensive quality engineering. Build scalable testing strategies with advanced CI/CD integration. Use PROACTIVELY for testing automation or quality assurance.
 model: sonnet
 ---

--- a/plugins/full-stack-orchestration/commands/full-stack-feature.md
+++ b/plugins/full-stack-orchestration/commands/full-stack-feature.md
@@ -348,7 +348,7 @@ Launch three agents in parallel using multiple Task tool calls in a single respo
 
 ```
 Task:
-  subagent_type: "test-automator"
+  subagent_type: "full-stack-orchestration-test-automator"
   description: "Create test suite for $FEATURE"
   prompt: |
     Create a comprehensive test suite for this full-stack feature.
@@ -379,7 +379,7 @@ Task:
 
 ```
 Task:
-  subagent_type: "security-auditor"
+  subagent_type: "full-stack-orchestration-security-auditor"
   description: "Security review of $FEATURE"
   prompt: |
     Perform a security review of this full-stack feature implementation.
@@ -407,7 +407,7 @@ Task:
 
 ```
 Task:
-  subagent_type: "performance-engineer"
+  subagent_type: "full-stack-orchestration-performance-engineer"
   description: "Performance review of $FEATURE"
   prompt: |
     Review the performance of this full-stack feature implementation.
@@ -489,7 +489,7 @@ Use the Task tool:
 
 ```
 Task:
-  subagent_type: "deployment-engineer"
+  subagent_type: "full-stack-orchestration-deployment-engineer"
   description: "Create deployment config for $FEATURE"
   prompt: |
     Create the deployment and infrastructure configuration for this full-stack feature.

--- a/plugins/git-pr-workflows/agents/code-reviewer.md
+++ b/plugins/git-pr-workflows/agents/code-reviewer.md
@@ -1,5 +1,5 @@
 ---
-name: code-reviewer
+name: git-pr-workflows-code-reviewer
 description: Elite code review expert specializing in modern AI-powered code analysis, security vulnerabilities, performance optimization, and production reliability. Masters static analysis tools, security scanning, and configuration review with 2024/2025 best practices. Use PROACTIVELY for code quality assurance.
 model: opus
 ---

--- a/plugins/git-pr-workflows/commands/git-workflow.md
+++ b/plugins/git-pr-workflows/commands/git-workflow.md
@@ -88,7 +88,7 @@ Use the Task tool to launch the code reviewer:
 
 ```
 Task:
-  subagent_type: "code-reviewer"
+  subagent_type: "git-pr-workflows-code-reviewer"
   description: "Review uncommitted changes for code quality"
   prompt: |
     Review all uncommitted changes for code quality issues.
@@ -127,7 +127,7 @@ Use the Task tool:
 
 ```
 Task:
-  subagent_type: "code-reviewer"
+  subagent_type: "git-pr-workflows-code-reviewer"
   description: "Analyze changes for dependencies and breaking changes"
   prompt: |
     Analyze the changes for dependency and breaking change issues.
@@ -305,7 +305,7 @@ Use the Task tool:
 
 ```
 Task:
-  subagent_type: "code-reviewer"
+  subagent_type: "git-pr-workflows-code-reviewer"
   description: "Categorize changes for commit message"
   prompt: |
     Analyze all changes and categorize them according to Conventional Commits specification.

--- a/plugins/incident-response/agents/code-reviewer.md
+++ b/plugins/incident-response/agents/code-reviewer.md
@@ -1,5 +1,5 @@
 ---
-name: code-reviewer
+name: incident-response-code-reviewer
 description: Reviews code for logic flaws, type safety gaps, error handling issues, architectural concerns, and similar vulnerability patterns. Provides fix design recommendations.
 model: sonnet
 ---

--- a/plugins/incident-response/agents/debugger.md
+++ b/plugins/incident-response/agents/debugger.md
@@ -1,5 +1,5 @@
 ---
-name: debugger
+name: incident-response-debugger
 description: Performs deep root cause analysis through code path tracing, git bisect automation, dependency analysis, and systematic hypothesis testing for production bugs.
 model: sonnet
 ---

--- a/plugins/incident-response/agents/devops-troubleshooter.md
+++ b/plugins/incident-response/agents/devops-troubleshooter.md
@@ -1,5 +1,5 @@
 ---
-name: devops-troubleshooter
+name: incident-response-devops-troubleshooter
 description: Expert DevOps troubleshooter specializing in rapid incident response, advanced debugging, and modern observability. Masters log analysis, distributed tracing, Kubernetes debugging, performance optimization, and root cause analysis. Handles production outages, system reliability, and preventive monitoring. Use PROACTIVELY for debugging, incident response, or system troubleshooting.
 model: sonnet
 ---

--- a/plugins/incident-response/agents/error-detective.md
+++ b/plugins/incident-response/agents/error-detective.md
@@ -1,5 +1,5 @@
 ---
-name: error-detective
+name: incident-response-error-detective
 description: Analyzes error traces, logs, and observability data to identify error signatures, reproduction steps, user impact, and timeline context for production issues.
 model: sonnet
 ---

--- a/plugins/incident-response/agents/test-automator.md
+++ b/plugins/incident-response/agents/test-automator.md
@@ -1,5 +1,5 @@
 ---
-name: test-automator
+name: incident-response-test-automator
 description: Creates comprehensive test suites including unit, integration, regression, and security tests. Validates fixes with full coverage and cross-environment testing.
 model: sonnet
 ---

--- a/plugins/incident-response/commands/incident-response.md
+++ b/plugins/incident-response/commands/incident-response.md
@@ -188,7 +188,7 @@ Read `.incident-response/02-observability.md` and `.incident-response/03-mitigat
 
 ```
 Task:
-  subagent_type: "debugger"
+  subagent_type: "incident-response-debugger"
   description: "Deep debugging for: $INCIDENT"
   prompt: |
     Conduct deep debugging for this incident using observability data.
@@ -350,7 +350,7 @@ Read `.incident-response/06-fix.md`.
 
 ```
 Task:
-  subagent_type: "devops-troubleshooter"
+  subagent_type: "incident-response-devops-troubleshooter"
   description: "Deploy and validate fix for: $INCIDENT"
   prompt: |
     Execute emergency deployment for incident fix.

--- a/plugins/incident-response/commands/smart-fix.md
+++ b/plugins/incident-response/commands/smart-fix.md
@@ -72,7 +72,7 @@ Use the Task tool to launch the error detective agent:
 
 ```
 Task:
-  subagent_type: "error-detective"
+  subagent_type: "incident-response-error-detective"
   description: "Analyze error context for: $ISSUE"
   prompt: |
     Analyze error traces, logs, and observability data for: $ISSUE
@@ -112,7 +112,7 @@ Use the Task tool to launch the debugger agent:
 
 ```
 Task:
-  subagent_type: "debugger"
+  subagent_type: "incident-response-debugger"
   description: "Identify root cause for: $ISSUE"
   prompt: |
     Perform root cause investigation using error-detective output:
@@ -179,7 +179,7 @@ Use the Task tool to launch the debugger agent:
 
 ```
 Task:
-  subagent_type: "debugger"
+  subagent_type: "incident-response-debugger"
   description: "Deep code analysis for: $ISSUE"
   prompt: |
     Perform deep code analysis and bisect investigation:
@@ -213,7 +213,7 @@ Use the Task tool to launch the code reviewer agent:
 
 ```
 Task:
-  subagent_type: "code-reviewer"
+  subagent_type: "incident-response-code-reviewer"
   description: "Review code logic for: $ISSUE"
   prompt: |
     Review code logic and identify design issues:
@@ -325,7 +325,7 @@ Use the Task tool to launch the test automator:
 
 ```
 Task:
-  subagent_type: "test-automator"
+  subagent_type: "incident-response-test-automator"
   description: "Regression testing for: $ISSUE fix"
   prompt: |
     Run comprehensive regression testing and verify fix quality:
@@ -448,7 +448,7 @@ Read `.smart-fix/05-implementation.md` and `.smart-fix/06-verification.md`.
 
 ```
 Task:
-  subagent_type: "code-reviewer"
+  subagent_type: "incident-response-code-reviewer"
   description: "Final review for: $ISSUE fix"
   prompt: |
     Perform final code review and approve for deployment:

--- a/plugins/kubernetes-operations/agents/kubernetes-architect.md
+++ b/plugins/kubernetes-operations/agents/kubernetes-architect.md
@@ -1,5 +1,5 @@
 ---
-name: kubernetes-architect
+name: kubernetes-operations-kubernetes-architect
 description: Expert Kubernetes architect specializing in cloud-native infrastructure, advanced GitOps workflows (ArgoCD/Flux), and enterprise container orchestration. Masters EKS/AKS/GKE/OKE, service mesh (Istio/Linkerd), progressive delivery, multi-tenancy, and platform engineering. Handles security, observability, cost optimization, and developer experience. Use PROACTIVELY for K8s architecture, GitOps implementation, or cloud-native platform design.
 model: opus
 ---

--- a/plugins/machine-learning-ops/commands/ml-pipeline.md
+++ b/plugins/machine-learning-ops/commands/ml-pipeline.md
@@ -209,7 +209,7 @@ Provide Kubernetes manifests and Helm charts for entire ML platform.
 subagent_type: observability-monitoring-observability-engineer
 prompt: |
   Implement comprehensive monitoring for ML system deployed in: {phase3.mlops-engineer.output}
-  Using Kubernetes infrastructure: {phase3.kubernetes-architect.output}
+  Using Kubernetes infrastructure: {phase3.kubernetes-operations-kubernetes-architect.output}
 
 Monitoring framework:
 

--- a/plugins/machine-learning-ops/commands/ml-pipeline.md
+++ b/plugins/machine-learning-ops/commands/ml-pipeline.md
@@ -176,7 +176,7 @@ Provide complete deployment configuration and automation scripts.
 </Task>
 
 <Task>
-subagent_type: kubernetes-architect
+subagent_type: kubernetes-operations-kubernetes-architect
 prompt: |
   Design Kubernetes infrastructure for ML workloads from: {phase3.mlops-engineer.output}
 
@@ -206,7 +206,7 @@ Provide Kubernetes manifests and Helm charts for entire ML platform.
 ## Phase 4: Monitoring & Continuous Improvement
 
 <Task>
-subagent_type: observability-engineer
+subagent_type: observability-monitoring-observability-engineer
 prompt: |
   Implement comprehensive monitoring for ML system deployed in: {phase3.mlops-engineer.output}
   Using Kubernetes infrastructure: {phase3.kubernetes-architect.output}

--- a/plugins/multi-platform-apps/agents/backend-architect.md
+++ b/plugins/multi-platform-apps/agents/backend-architect.md
@@ -1,5 +1,5 @@
 ---
-name: backend-architect
+name: multi-platform-apps-backend-architect
 description: Expert backend architect specializing in scalable API design, microservices architecture, and distributed systems. Masters REST/GraphQL/gRPC APIs, event-driven architectures, service mesh patterns, and modern backend frameworks. Handles service boundary definition, inter-service communication, resilience patterns, and observability. Use PROACTIVELY when creating new backend services or APIs.
 model: inherit
 ---

--- a/plugins/multi-platform-apps/agents/frontend-developer.md
+++ b/plugins/multi-platform-apps/agents/frontend-developer.md
@@ -1,5 +1,5 @@
 ---
-name: frontend-developer
+name: multi-platform-apps-frontend-developer
 description: Build React components, implement responsive layouts, and handle client-side state management. Masters React 19, Next.js 15, and modern frontend architecture. Optimizes performance and ensures accessibility. Use PROACTIVELY when creating UI components or fixing frontend issues.
 model: inherit
 ---

--- a/plugins/multi-platform-apps/agents/mobile-developer.md
+++ b/plugins/multi-platform-apps/agents/mobile-developer.md
@@ -1,5 +1,5 @@
 ---
-name: mobile-developer
+name: multi-platform-apps-mobile-developer
 description: Develop React Native, Flutter, or native mobile apps with modern architecture patterns. Masters cross-platform development, native integrations, offline sync, and app store optimization. Use PROACTIVELY for mobile features, cross-platform code, or app optimization.
 model: inherit
 ---

--- a/plugins/multi-platform-apps/commands/multi-platform.md
+++ b/plugins/multi-platform-apps/commands/multi-platform.md
@@ -72,7 +72,7 @@ Use the Task tool to launch the backend architect:
 
 ```
 Task:
-  subagent_type: "backend-architect"
+  subagent_type: "multi-platform-apps-backend-architect"
   description: "Design API contract for $FEATURE"
   prompt: |
     Design the API contract for feature: $FEATURE.
@@ -223,7 +223,7 @@ Launch platform implementations in parallel using multiple Task tool calls. Only
 
 ```
 Task:
-  subagent_type: "frontend-developer"
+  subagent_type: "multi-platform-apps-frontend-developer"
   description: "Implement web version of $FEATURE"
   prompt: |
     Implement web version of feature: $FEATURE.
@@ -287,7 +287,7 @@ Save output to `.multi-platform/04b-ios.md`.
 
 ```
 Task:
-  subagent_type: "mobile-developer"
+  subagent_type: "multi-platform-apps-mobile-developer"
   description: "Implement Android version of $FEATURE"
   prompt: |
     Implement Android version of feature: $FEATURE.
@@ -322,7 +322,7 @@ Only if "desktop" is in the platforms list:
 
 ```
 Task:
-  subagent_type: "frontend-developer"
+  subagent_type: "multi-platform-apps-frontend-developer"
   description: "Implement desktop version of $FEATURE"
   prompt: |
     Implement desktop version of feature: $FEATURE using Tauri 2.0 or Electron.

--- a/plugins/observability-monitoring/agents/database-optimizer.md
+++ b/plugins/observability-monitoring/agents/database-optimizer.md
@@ -1,5 +1,5 @@
 ---
-name: database-optimizer
+name: observability-monitoring-database-optimizer
 description: Expert database optimizer specializing in modern performance tuning, query optimization, and scalable architectures. Masters advanced indexing, N+1 resolution, multi-tier caching, partitioning strategies, and cloud database optimization. Handles complex query analysis, migration strategies, and performance monitoring. Use PROACTIVELY for database optimization, performance issues, or scalability challenges.
 model: inherit
 ---

--- a/plugins/observability-monitoring/agents/network-engineer.md
+++ b/plugins/observability-monitoring/agents/network-engineer.md
@@ -1,5 +1,5 @@
 ---
-name: network-engineer
+name: observability-monitoring-network-engineer
 description: Expert network engineer specializing in modern cloud networking, security architectures, and performance optimization. Masters multi-cloud connectivity, service mesh, zero-trust networking, SSL/TLS, global load balancing, and advanced troubleshooting. Handles CDN optimization, network automation, and compliance. Use PROACTIVELY for network design, connectivity issues, or performance optimization.
 model: sonnet
 ---

--- a/plugins/observability-monitoring/agents/observability-engineer.md
+++ b/plugins/observability-monitoring/agents/observability-engineer.md
@@ -1,5 +1,5 @@
 ---
-name: observability-engineer
+name: observability-monitoring-observability-engineer
 description: Build production-ready monitoring, logging, and tracing systems. Implements comprehensive observability strategies, SLI/SLO management, and incident response workflows. Use PROACTIVELY for monitoring infrastructure, performance optimization, or production reliability.
 model: inherit
 ---

--- a/plugins/observability-monitoring/agents/performance-engineer.md
+++ b/plugins/observability-monitoring/agents/performance-engineer.md
@@ -1,5 +1,5 @@
 ---
-name: performance-engineer
+name: observability-monitoring-performance-engineer
 description: Expert performance engineer specializing in modern observability, application optimization, and scalable system performance. Masters OpenTelemetry, distributed tracing, load testing, multi-tier caching, Core Web Vitals, and performance monitoring. Handles end-to-end optimization, real user monitoring, and scalability patterns. Use PROACTIVELY for performance optimization, observability, or scalability challenges.
 model: inherit
 ---

--- a/plugins/performance-testing-review/agents/performance-engineer.md
+++ b/plugins/performance-testing-review/agents/performance-engineer.md
@@ -1,5 +1,5 @@
 ---
-name: performance-engineer
+name: performance-testing-review-performance-engineer
 description: Expert performance engineer specializing in modern observability, application optimization, and scalable system performance. Masters OpenTelemetry, distributed tracing, load testing, multi-tier caching, Core Web Vitals, and performance monitoring. Handles end-to-end optimization, real user monitoring, and scalability patterns. Use PROACTIVELY for performance optimization, observability, or scalability challenges.
 model: inherit
 ---

--- a/plugins/performance-testing-review/agents/test-automator.md
+++ b/plugins/performance-testing-review/agents/test-automator.md
@@ -1,5 +1,5 @@
 ---
-name: test-automator
+name: performance-testing-review-test-automator
 description: Master AI-powered test automation with modern frameworks, self-healing tests, and comprehensive quality engineering. Build scalable testing strategies with advanced CI/CD integration. Use PROACTIVELY for testing automation or quality assurance.
 model: sonnet
 ---

--- a/plugins/python-development/agents/django-pro.md
+++ b/plugins/python-development/agents/django-pro.md
@@ -1,5 +1,5 @@
 ---
-name: django-pro
+name: python-development-django-pro
 description: Master Django 5.x with async views, DRF, Celery, and Django Channels. Build scalable web applications with proper architecture, testing, and deployment. Use PROACTIVELY for Django development, ORM optimization, or complex Django patterns.
 model: opus
 ---

--- a/plugins/python-development/agents/fastapi-pro.md
+++ b/plugins/python-development/agents/fastapi-pro.md
@@ -1,5 +1,5 @@
 ---
-name: fastapi-pro
+name: python-development-fastapi-pro
 description: Build high-performance async APIs with FastAPI, SQLAlchemy 2.0, and Pydantic V2. Master microservices, WebSockets, and modern Python async patterns. Use PROACTIVELY for FastAPI development, async optimization, or API architecture.
 model: opus
 ---

--- a/plugins/security-compliance/agents/security-auditor.md
+++ b/plugins/security-compliance/agents/security-auditor.md
@@ -1,5 +1,5 @@
 ---
-name: security-auditor
+name: security-compliance-security-auditor
 description: Expert security auditor specializing in DevSecOps, comprehensive cybersecurity, and compliance frameworks. Masters vulnerability assessment, threat modeling, secure authentication (OAuth2/OIDC), OWASP standards, cloud security, and security automation. Handles DevSecOps integration, compliance (GDPR/HIPAA/SOC2), and incident response. Use PROACTIVELY for security audits, DevSecOps, or compliance implementation.
 model: opus
 ---

--- a/plugins/security-scanning/agents/security-auditor.md
+++ b/plugins/security-scanning/agents/security-auditor.md
@@ -1,5 +1,5 @@
 ---
-name: security-auditor
+name: security-scanning-security-auditor
 description: Expert security auditor specializing in DevSecOps, comprehensive cybersecurity, and compliance frameworks. Masters vulnerability assessment, threat modeling, secure authentication (OAuth2/OIDC), OWASP standards, cloud security, and security automation. Handles DevSecOps integration, compliance (GDPR/HIPAA/SOC2), and incident response. Use PROACTIVELY for security audits, DevSecOps, or compliance implementation.
 model: opus
 ---

--- a/plugins/security-scanning/commands/security-hardening.md
+++ b/plugins/security-scanning/commands/security-hardening.md
@@ -72,7 +72,7 @@ Use the Task tool to launch the security auditor agent:
 
 ```
 Task:
-  subagent_type: "security-auditor"
+  subagent_type: "security-scanning-security-auditor"
   description: "Comprehensive vulnerability scan of $TARGET"
   prompt: |
     Perform a comprehensive security assessment on: $TARGET.
@@ -196,7 +196,7 @@ Use the Task tool:
 
 ```
 Task:
-  subagent_type: "security-auditor"
+  subagent_type: "security-scanning-security-auditor"
   description: "Remediate critical vulnerabilities for $TARGET"
   prompt: |
     Coordinate immediate remediation of critical vulnerabilities (CVSS 7+) in: $TARGET.
@@ -369,7 +369,7 @@ Use the Task tool:
 
 ```
 Task:
-  subagent_type: "security-auditor"
+  subagent_type: "security-scanning-security-auditor"
   description: "Enhance authentication and authorization for $TARGET"
   prompt: |
     Implement a modern authentication system for: $TARGET.
@@ -499,7 +499,7 @@ Use the Task tool:
 
 ```
 Task:
-  subagent_type: "security-auditor"
+  subagent_type: "security-scanning-security-auditor"
   description: "Penetration testing and validation for $TARGET"
   prompt: |
     Execute comprehensive penetration testing for: $TARGET.
@@ -537,7 +537,7 @@ Use the Task tool:
 
 ```
 Task:
-  subagent_type: "security-auditor"
+  subagent_type: "security-scanning-security-auditor"
   description: "Compliance verification for $TARGET"
   prompt: |
     Verify compliance with security frameworks for: $TARGET.

--- a/plugins/tdd-workflows/agents/code-reviewer.md
+++ b/plugins/tdd-workflows/agents/code-reviewer.md
@@ -1,5 +1,5 @@
 ---
-name: code-reviewer
+name: tdd-workflows-code-reviewer
 description: Elite code review expert specializing in modern AI-powered code analysis, security vulnerabilities, performance optimization, and production reliability. Masters static analysis tools, security scanning, and configuration review with 2024/2025 best practices. Use PROACTIVELY for code quality assurance.
 model: opus
 ---

--- a/plugins/tdd-workflows/agents/tdd-orchestrator.md
+++ b/plugins/tdd-workflows/agents/tdd-orchestrator.md
@@ -1,5 +1,5 @@
 ---
-name: tdd-orchestrator
+name: tdd-workflows-tdd-orchestrator
 description: Master TDD orchestrator specializing in red-green-refactor discipline, multi-agent workflow coordination, and comprehensive test-driven development practices. Enforces TDD best practices across teams with AI-assisted testing and modern frameworks. Use PROACTIVELY for TDD implementation and governance.
 model: opus
 ---

--- a/plugins/tdd-workflows/commands/tdd-cycle.md
+++ b/plugins/tdd-workflows/commands/tdd-cycle.md
@@ -210,7 +210,7 @@ Use the Task tool with the local code-reviewer agent:
 
 ```
 Task:
-  subagent_type: "code-reviewer"
+  subagent_type: "tdd-workflows-code-reviewer"
   description: "Verify tests fail correctly for $FEATURE"
   prompt: |
     Verify that all tests for: $FEATURE are failing correctly.
@@ -356,7 +356,7 @@ Use the Task tool with the local code-reviewer agent:
 
 ```
 Task:
-  subagent_type: "code-reviewer"
+  subagent_type: "tdd-workflows-code-reviewer"
   description: "Refactor implementation for $FEATURE"
   prompt: |
     Refactor the implementation for: $FEATURE while keeping all tests green.
@@ -538,7 +538,7 @@ Use the Task tool with the local code-reviewer agent:
 
 ```
 Task:
-  subagent_type: "code-reviewer"
+  subagent_type: "tdd-workflows-code-reviewer"
   description: "Final TDD review of $FEATURE"
   prompt: |
     Perform comprehensive final review of: $FEATURE

--- a/plugins/tdd-workflows/commands/tdd-refactor.md
+++ b/plugins/tdd-workflows/commands/tdd-refactor.md
@@ -4,7 +4,7 @@ Refactor code with confidence using comprehensive test safety net:
 
 ## Usage
 
-Use Task tool with subagent_type="tdd-orchestrator" to perform safe refactoring.
+Use Task tool with subagent_type="tdd-workflows-tdd-orchestrator" to perform safe refactoring.
 
 Prompt: "Refactor this code while keeping all tests green: $ARGUMENTS. Apply TDD refactor phase:
 

--- a/plugins/team-collaboration/agents/dx-optimizer.md
+++ b/plugins/team-collaboration/agents/dx-optimizer.md
@@ -1,5 +1,5 @@
 ---
-name: dx-optimizer
+name: team-collaboration-dx-optimizer
 description: Developer Experience specialist. Improves tooling, setup, and workflows. Use PROACTIVELY when setting up new projects, after team feedback, or when development friction is noticed.
 model: sonnet
 ---

--- a/plugins/unit-testing/agents/debugger.md
+++ b/plugins/unit-testing/agents/debugger.md
@@ -1,5 +1,5 @@
 ---
-name: debugger
+name: unit-testing-debugger
 description: Debugging specialist for errors, test failures, and unexpected behavior. Use proactively when encountering any issues.
 model: sonnet
 ---

--- a/plugins/unit-testing/agents/test-automator.md
+++ b/plugins/unit-testing/agents/test-automator.md
@@ -1,5 +1,5 @@
 ---
-name: test-automator
+name: unit-testing-test-automator
 description: Master AI-powered test automation with modern frameworks, self-healing tests, and comprehensive quality engineering. Build scalable testing strategies with advanced CI/CD integration. Use PROACTIVELY for testing automation or quality assurance.
 model: sonnet
 ---

--- a/tools/tests/test_real_world.py
+++ b/tools/tests/test_real_world.py
@@ -45,6 +45,13 @@ _TRIGGER_PATTERN = re.compile(
 # Codex built-in agent names that custom agents must NOT collide with.
 _CODEX_BUILTIN_AGENTS = {"default", "worker", "explorer"}
 
+# Multi-agent command workflows use phase placeholders such as
+# `{phase3.agent-name.output}`. The task key must match the producing
+# `subagent_type`, otherwise later phases cannot read earlier outputs.
+_PHASE_HEADING_PATTERN = re.compile(r"^##\s+Phase\s+(\d+)\b")
+_TASK_SUBAGENT_PATTERN = re.compile(r'^\s*subagent_type:\s*"?([^"\n]+?)"?\s*$')
+_PHASE_OUTPUT_REF_PATTERN = re.compile(r"\{phase(?P<phase>\d+)\.(?P<task>[^{}.]+)\.output\}")
+
 
 # ── Marketplace consistency ─────────────────────────────────────────────────
 
@@ -162,6 +169,36 @@ class TestPluginSourceIntegrity:
         assert not duplicates, "Duplicate agent frontmatter names:\n  " + "\n  ".join(
             f"{name}: {', '.join(paths)}" for name, paths in duplicates.items()
         )
+
+    def test_command_phase_output_references_match_task_keys(self):
+        """Phase output placeholders must match a task key from the referenced phase."""
+        problems = []
+        for command_path in sorted(PLUGINS_DIR.glob("*/commands/*.md")):
+            current_phase: int | None = None
+            phase_tasks: dict[int, set[str]] = {}
+            references: list[tuple[int, int, str]] = []
+
+            for lineno, line in enumerate(command_path.read_text().splitlines(), 1):
+                if match := _PHASE_HEADING_PATTERN.match(line):
+                    current_phase = int(match.group(1))
+                    phase_tasks.setdefault(current_phase, set())
+
+                if (match := _TASK_SUBAGENT_PATTERN.match(line)) and current_phase is not None:
+                    phase_tasks.setdefault(current_phase, set()).add(match.group(1).strip())
+
+                for match in _PHASE_OUTPUT_REF_PATTERN.finditer(line):
+                    references.append((lineno, int(match.group("phase")), match.group("task")))
+
+            for lineno, phase, task_key in references:
+                available = phase_tasks.get(phase, set())
+                if task_key not in available:
+                    problems.append(
+                        f"{command_path.relative_to(PLUGINS_DIR)}:{lineno}: "
+                        f"phase{phase}.{task_key}.output has no matching subagent_type "
+                        f"in Phase {phase} (available: {sorted(available)})"
+                    )
+
+        assert not problems, "Broken command phase output references:\n  " + "\n  ".join(problems)
 
 
 # ── Progressive-disclosure refactor integrity ────────────────────────────────

--- a/tools/tests/test_real_world.py
+++ b/tools/tests/test_real_world.py
@@ -158,11 +158,7 @@ class TestPluginSourceIntegrity:
                 if name:
                     by_name.setdefault(name, []).append(f"{plugin_name}/agents/{agent.name}.md")
 
-        duplicates = {
-            name: paths
-            for name, paths in sorted(by_name.items())
-            if len(paths) > 1
-        }
+        duplicates = {name: paths for name, paths in sorted(by_name.items()) if len(paths) > 1}
         assert not duplicates, "Duplicate agent frontmatter names:\n  " + "\n  ".join(
             f"{name}: {', '.join(paths)}" for name, paths in duplicates.items()
         )

--- a/tools/tests/test_real_world.py
+++ b/tools/tests/test_real_world.py
@@ -146,6 +146,27 @@ class TestPluginSourceIntegrity:
             f"Agent names colliding with Codex built-ins (default/worker/explorer): {collisions}"
         )
 
+    def test_agent_frontmatter_names_are_unique_across_plugins(self):
+        """Claude Code keys subagents by frontmatter `name`; cross-plugin duplicates collide."""
+        by_name: dict[str, list[str]] = {}
+        for plugin_name in list_plugins():
+            plugin = load_plugin(plugin_name)
+            if not plugin:
+                continue
+            for agent in plugin.agents:
+                name = (agent.frontmatter.get("name") or "").strip()
+                if name:
+                    by_name.setdefault(name, []).append(f"{plugin_name}/agents/{agent.name}.md")
+
+        duplicates = {
+            name: paths
+            for name, paths in sorted(by_name.items())
+            if len(paths) > 1
+        }
+        assert not duplicates, "Duplicate agent frontmatter names:\n  " + "\n  ".join(
+            f"{name}: {', '.join(paths)}" for name, paths in duplicates.items()
+        )
+
 
 # ── Progressive-disclosure refactor integrity ────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes #500 by addressing the actual source-level collision: Claude Code keys installed agents by YAML frontmatter `name`, so duplicated `plugins/*/agents/*.md` names can silently overwrite each other when multiple plugins are installed.

This PR:

- Renames the 95 colliding agent frontmatter names to plugin-scoped names.
- Updates bundled command `subagent_type` references to use the new plugin-scoped agent names.
- Switches CI from the old collision baseline to `--fail-on-duplicates`.
- Adds a real-source regression test that fails on duplicate agent frontmatter names.
- Documents the authoring rule for globally unique agent names.

The latest issue comment about Codex generated TOMLs was a useful signal but not a Codex overwrite bug: Codex already emits plugin-namespaced agent IDs. This PR fixes the underlying source/Claude Code collision class instead.

## Verification

- `python3 tools/check_agent_name_collisions.py --root . --fail-on-duplicates`
- `git diff --check`
- `make validate STRICT=1`
- `make test` (`381 passed, 5 skipped`)
- `make garden` (`0 error(s), 10 existing SKILL_OVER_CODEX_CAP warnings`)
- `make smoke-test` (`3 passed, 5 skipped`)