### PR TITLE
Skip Claude review on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,7 +9,8 @@ jobs:
     if: |
       github.event.pull_request.draft == false &&
       github.actor != 'dependabot[bot]' &&
-      github.event.pull_request.user.login != 'dependabot[bot]'
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Skip the `claude-review` CI job for cross-repository (fork) PRs
- Fork PRs don't have access to repo secrets or OIDC tokens, so `claude-code-action` fails on OIDC authentication (see [PR #558](https://github.com/wshobson/agents/pull/558) for example)
- The job now shows as skipped (grey) instead of failed (red) for fork PRs

## Test plan

- [ ] Verify existing same-repo PRs still trigger Claude review
- [ ] Verify fork PRs skip the job gracefully