### PR TITLE
Add runapi-mcp plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -794,6 +794,18 @@
       "category": "Coding"
     },
     {
+      "name": "runapi-mcp",
+      "source": {
+        "source": "local",
+        "path": "./plugins/runapi-mcp"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_USE"
+      },
+      "category": "ai-ml"
+    },
+    {
       "name": "security-compliance",
       "source": {
         "source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1147,6 +1147,19 @@
         "multi-agent",
         "dev-workflow"
       ]
+    },
+    {
+      "name": "runapi-mcp",
+      "source": "./plugins/runapi-mcp",
+      "description": "RunAPI MCP server for browsing models, checking pricing, and creating image, video, music, audio, and LLM tasks.",
+      "version": "0.1.3",
+      "author": {
+        "name": "RunAPI",
+        "url": "https://runapi.ai"
+      },
+      "homepage": "https://github.com/runapi-ai/mcp",
+      "license": "Apache-2.0",
+      "category": "ai-ml"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -731,6 +731,19 @@
       "license": "MIT"
     },
     {
+      "name": "runapi-mcp",
+      "source": "./plugins/runapi-mcp",
+      "version": "0.1.3",
+      "description": "RunAPI MCP server for browsing models, checking pricing, and creating image, video, music, audio, and LLM tasks.",
+      "author": {
+        "name": "RunAPI",
+        "email": ""
+      },
+      "homepage": "https://github.com/runapi-ai/mcp",
+      "license": "Apache-2.0",
+      "category": "ai-ml"
+    },
+    {
       "name": "security-compliance",
       "source": "./plugins/security-compliance",
       "version": "1.2.1",

--- a/.cursor-plugin/plugins/runapi-mcp.json
+++ b/.cursor-plugin/plugins/runapi-mcp.json
@@ -1,0 +1,12 @@
+{
+  "name": "runapi-mcp",
+  "displayName": "Runapi Mcp",
+  "version": "0.1.3",
+  "description": "RunAPI MCP server for browsing models, checking pricing, and creating image, video, music, audio, and LLM tasks.",
+  "author": {
+    "name": "RunAPI",
+    "email": ""
+  },
+  "homepage": "https://github.com/runapi-ai/mcp",
+  "license": "Apache-2.0"
+}

--- a/plugins/runapi-mcp/.claude-plugin/plugin.json
+++ b/plugins/runapi-mcp/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "runapi",
+  "description": "RunAPI model discovery, pricing lookup, media task creation, polling, balance checks, and LLM chat for Claude Code.",
+  "version": "0.1.3",
+  "author": {
+    "name": "RunAPI",
+    "url": "https://runapi.ai"
+  }
+}

--- a/plugins/runapi-mcp/.claude-plugin/plugin.json
+++ b/plugins/runapi-mcp/.claude-plugin/plugin.json
@@ -1,9 +1,12 @@
 {
-  "name": "runapi",
-  "description": "RunAPI model discovery, pricing lookup, media task creation, polling, balance checks, and LLM chat for Claude Code.",
+  "name": "runapi-mcp",
+  "description": "RunAPI MCP server for browsing models, checking pricing, and creating image, video, music, audio, and LLM tasks.",
   "version": "0.1.3",
   "author": {
     "name": "RunAPI",
     "url": "https://runapi.ai"
-  }
+  },
+  "homepage": "https://github.com/runapi-ai/mcp",
+  "license": "Apache-2.0",
+  "category": "ai-ml"
 }

--- a/plugins/runapi-mcp/.codex-plugin/plugin.json
+++ b/plugins/runapi-mcp/.codex-plugin/plugin.json
@@ -1,10 +1,17 @@
 {
   "name": "runapi-mcp",
   "version": "0.1.3",
-  "description": "AI image generation, video generation, music creation, text-to-speech, and LLM chat — 130+ models from 18 providers via RunAPI MCP server.",
+  "description": "RunAPI MCP server for browsing models, checking pricing, and creating image, video, music, audio, and LLM tasks.",
+  "skills": "./skills/",
   "author": {
     "name": "RunAPI",
     "url": "https://runapi.ai"
   },
-  "license": "Apache-2.0"
+  "homepage": "https://github.com/runapi-ai/mcp",
+  "license": "Apache-2.0",
+  "interface": {
+    "displayName": "Runapi Mcp",
+    "shortDescription": "RunAPI MCP server for browsing models, checking pricing, and creating image, video, music, audio, and LLM tasks.",
+    "category": "ai-ml"
+  }
 }

--- a/plugins/runapi-mcp/.codex-plugin/plugin.json
+++ b/plugins/runapi-mcp/.codex-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "runapi-mcp",
+  "version": "0.1.3",
+  "description": "AI image generation, video generation, music creation, text-to-speech, and LLM chat — 130+ models from 18 providers via RunAPI MCP server.",
+  "author": {
+    "name": "RunAPI",
+    "url": "https://runapi.ai"
+  },
+  "license": "Apache-2.0"
+}

--- a/plugins/runapi-mcp/.mcp.json
+++ b/plugins/runapi-mcp/.mcp.json
@@ -1,9 +1,11 @@
 {
-  "runapi": {
-    "command": "npx",
-    "args": ["-y", "@runapi.ai/mcp@0.1.8"],
-    "env": {
-      "RUNAPI_API_KEY": "${RUNAPI_API_KEY}"
+  "mcpServers": {
+    "runapi": {
+      "command": "npx",
+      "args": ["-y", "@runapi.ai/mcp@0.1.8"],
+      "env": {
+        "RUNAPI_API_KEY": "${RUNAPI_API_KEY}"
+      }
     }
   }
 }

--- a/plugins/runapi-mcp/.mcp.json
+++ b/plugins/runapi-mcp/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "runapi": {
+    "command": "npx",
+    "args": ["-y", "@runapi.ai/mcp"],
+    "env": {
+      "RUNAPI_API_KEY": "${RUNAPI_API_KEY}"
+    }
+  }
+}

--- a/plugins/runapi-mcp/.mcp.json
+++ b/plugins/runapi-mcp/.mcp.json
@@ -1,7 +1,7 @@
 {
   "runapi": {
     "command": "npx",
-    "args": ["-y", "@runapi.ai/mcp"],
+    "args": ["-y", "@runapi.ai/mcp@0.1.8"],
     "env": {
       "RUNAPI_API_KEY": "${RUNAPI_API_KEY}"
     }

--- a/plugins/runapi-mcp/README.md
+++ b/plugins/runapi-mcp/README.md
@@ -19,7 +19,7 @@ Or add manually to `.mcp.json`:
   "mcpServers": {
     "runapi": {
       "command": "npx",
-      "args": ["-y", "@runapi.ai/mcp"]
+      "args": ["-y", "@runapi.ai/mcp@0.1.8"]
     }
   }
 }

--- a/plugins/runapi-mcp/README.md
+++ b/plugins/runapi-mcp/README.md
@@ -1,0 +1,56 @@
+# RunAPI MCP
+
+AI image generation, video generation, music creation, text-to-speech, and LLM chat — 130+ models from Flux, Kling, Seedance, Veo, Suno, ElevenLabs, Claude, GPT, Gemini, and 18 providers in one MCP server.
+
+## Install
+
+```bash
+# Claude Code
+/plugin install runapi-mcp@agents
+
+# Codex
+codex plugin install runapi-mcp@agents
+```
+
+Or add manually to `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "runapi": {
+      "command": "npx",
+      "args": ["-y", "@runapi.ai/mcp"]
+    }
+  }
+}
+```
+
+## Setup
+
+1. Sign up at [runapi.ai](https://runapi.ai) and go to Dashboard > API Keys
+2. Save your key:
+   ```bash
+   mkdir -p ~/.config/runapi && echo '{"api_key":"YOUR_KEY"}' > ~/.config/runapi/config.json
+   ```
+3. Restart your MCP host
+
+Free catalog tools (model browsing, pricing) work without a key.
+
+## Tools
+
+| Tool | Auth | Description |
+|---|---|---|
+| list_models | Free | Browse 130+ AI models by modality, service, or action |
+| get_model_info | Free | Inspect params, constraints, and pricing for a model |
+| list_actions | Free | List endpoint actions grouped by modality |
+| check_pricing | Free | Check pricing for a service + action + model |
+| check_balance | Key | Check account balance and spending |
+| create_task | Key | Create image/video/music/audio tasks, optionally poll until done |
+| get_task | Key | Check status of an existing task |
+| chat | Key | Call Claude, GPT, Gemini, DeepSeek LLM endpoints |
+
+## Links
+
+- [GitHub](https://github.com/runapi-ai/mcp)
+- [npm](https://www.npmjs.com/package/@runapi.ai/mcp)
+- [Pricing](https://runapi.ai/pricing)

--- a/plugins/runapi-mcp/agents/model-advisor.md
+++ b/plugins/runapi-mcp/agents/model-advisor.md
@@ -28,5 +28,4 @@ You are a RunAPI model advisor. You help choose a current model by using RunAPI 
 
 - Do not rely on memorized model names.
 - Do not hardcode prices.
-- Do not mention hidden infrastructure providers.
 - Keep recommendations short and grounded in returned tool data.

--- a/plugins/runapi-mcp/agents/model-advisor.md
+++ b/plugins/runapi-mcp/agents/model-advisor.md
@@ -1,0 +1,30 @@
+---
+description: >-
+  Model discovery and recommendation agent. Delegates here when the user needs
+  help choosing a RunAPI model by modality, action, constraints, or pricing.
+model: haiku
+---
+
+You are a RunAPI model advisor. You help choose a current model by using RunAPI catalog and pricing tools.
+
+## When You're Called
+
+- The user asks what models are available.
+- The user asks which model to use for a modality or action.
+- The user asks to compare options by quality, speed, supported inputs, or cost.
+- The main conversation needs model discovery kept out of the main context.
+
+## Process
+
+1. Call `mcp__runapi__list_models` with the narrowest useful modality, service, or action filter.
+2. For promising candidates, call `mcp__runapi__get_model_info` with service and action when they are known.
+3. When cost matters, call `mcp__runapi__check_pricing`.
+4. Recommend one option and name up to two alternatives.
+5. Include the exact service, action, and model slug needed for `create_task`.
+
+## Rules
+
+- Do not rely on memorized model names.
+- Do not hardcode prices.
+- Do not mention hidden infrastructure providers.
+- Keep recommendations short and grounded in returned tool data.

--- a/plugins/runapi-mcp/agents/model-advisor.md
+++ b/plugins/runapi-mcp/agents/model-advisor.md
@@ -1,9 +1,11 @@
 ---
+name: model-advisor
 description: >-
   Model discovery and recommendation agent. Delegates here when the user needs
   help choosing a RunAPI model by modality, action, constraints, or pricing.
 model: haiku
 ---
+name: model-advisor
 
 You are a RunAPI model advisor. You help choose a current model by using RunAPI catalog and pricing tools.
 

--- a/plugins/runapi-mcp/agents/task-executor.md
+++ b/plugins/runapi-mcp/agents/task-executor.md
@@ -1,0 +1,32 @@
+---
+description: >-
+  Media task execution agent. Delegates here for create_task calls so the
+  main conversation stays focused. Spawn one per task for parallel generation.
+model: inherit
+tools: mcp__runapi__create_task, mcp__runapi__get_task
+---
+
+You are a RunAPI task execution agent. Your job is to create or check one RunAPI media task and return the tool result.
+
+## When You're Called
+
+- The main conversation already selected a service, action, model slug, and params.
+- The user approved a generation request.
+- Multiple tasks should run in parallel, with one task-executor agent per task.
+- An existing task needs a focused status check.
+
+## Process
+
+1. Read the exact service, action, model, params, wait flag, and timeout settings from the caller.
+2. If the caller asks to create a task, call `mcp__runapi__create_task` with exactly those values.
+3. If the caller asks to check a task, call `mcp__runapi__get_task`.
+4. Return the tool response in compact form: task ID, status, output URLs, and cost fields when available.
+
+## Rules
+
+- Do not modify prompts or params.
+- Do not choose models.
+- Do not retry create_task after timeout.
+- Do not describe generated media as if you inspected it.
+- Do not read files.
+- Keep output minimal.

--- a/plugins/runapi-mcp/agents/task-executor.md
+++ b/plugins/runapi-mcp/agents/task-executor.md
@@ -1,10 +1,12 @@
 ---
+name: task-executor
 description: >-
   Media task execution agent. Delegates here for create_task calls so the
   main conversation stays focused. Spawn one per task for parallel generation.
 model: inherit
 tools: mcp__runapi__create_task, mcp__runapi__get_task
 ---
+name: task-executor
 
 You are a RunAPI task execution agent. Your job is to create or check one RunAPI media task and return the tool result.
 

--- a/plugins/runapi-mcp/commands/balance.md
+++ b/plugins/runapi-mcp/commands/balance.md
@@ -1,0 +1,12 @@
+---
+description: >-
+  Check the authenticated RunAPI account balance and spending metrics.
+---
+
+# RunAPI Balance
+
+Call `mcp__runapi__check_balance`.
+
+If the tool returns an API key error, explain how to configure `RUNAPI_API_KEY` or `~/.config/runapi/config.json`.
+Do not ask for the user's API key in chat.
+Do not print raw JSON unless the user asks.

--- a/plugins/runapi-mcp/commands/balance.md
+++ b/plugins/runapi-mcp/commands/balance.md
@@ -1,6 +1,7 @@
 ---
 description: >-
   Check the authenticated RunAPI account balance and spending metrics.
+argument-hint: ""
 ---
 
 # RunAPI Balance

--- a/plugins/runapi-mcp/commands/gen.md
+++ b/plugins/runapi-mcp/commands/gen.md
@@ -1,0 +1,23 @@
+---
+description: >-
+  Quick RunAPI generation. Use when the user runs /runapi:gen with a prompt
+  and wants to skip broad exploration.
+argument-hint: <prompt>
+---
+
+# Quick Generate
+
+Create a RunAPI media task from `$ARGUMENTS`.
+
+## Instructions
+
+1. If `$ARGUMENTS` is empty, ask for the prompt or task description.
+2. Call `mcp__runapi__list_models` with the most likely modality filter.
+3. Call `mcp__runapi__get_model_info` with the selected service, action, and model slug, then obey returned input rules.
+4. If the selected task is video, music, or a batch, ask for confirmation before creating it.
+5. Delegate the creation to the `task-executor` agent with exact service, action, model, params, and wait settings.
+6. Present task ID, status, output URLs, and cost fields when available.
+
+Do not invent model slugs.
+Do not quote prices without `mcp__runapi__check_pricing`.
+Do not describe generated media content.

--- a/plugins/runapi-mcp/commands/models.md
+++ b/plugins/runapi-mcp/commands/models.md
@@ -1,0 +1,20 @@
+---
+description: >-
+  List and compare RunAPI models by modality, service, or action.
+argument-hint: [modality|service|action]
+---
+
+# RunAPI Models
+
+List current RunAPI models from the embedded catalog.
+
+## Instructions
+
+1. Interpret `$ARGUMENTS` as a modality, service, action, or free-form filter.
+2. Call `mcp__runapi__list_models` with the narrowest matching filter.
+3. Present a compact table with model slug, service, action, modality, and required fields.
+4. If the user asks about one model, call `mcp__runapi__get_model_info`; include service and action when the row is already known.
+5. If the user asks about cost, call `mcp__runapi__check_pricing`.
+
+Keep output concise.
+Do not list hidden infrastructure providers.

--- a/plugins/runapi-mcp/commands/models.md
+++ b/plugins/runapi-mcp/commands/models.md
@@ -1,7 +1,7 @@
 ---
 description: >-
   List and compare RunAPI models by modality, service, or action.
-argument-hint: [modality|service|action]
+argument-hint: "[modality|service|action]"
 ---
 
 # RunAPI Models
@@ -17,4 +17,3 @@ List current RunAPI models from the embedded catalog.
 5. If the user asks about cost, call `mcp__runapi__check_pricing`.
 
 Keep output concise.
-Do not list hidden infrastructure providers.

--- a/plugins/runapi-mcp/commands/setup.md
+++ b/plugins/runapi-mcp/commands/setup.md
@@ -2,6 +2,7 @@
 description: >-
   Guide the user through RunAPI API key setup for Claude Code and other MCP
   hosts.
+argument-hint: ""
 ---
 
 # RunAPI Setup

--- a/plugins/runapi-mcp/commands/setup.md
+++ b/plugins/runapi-mcp/commands/setup.md
@@ -1,0 +1,35 @@
+---
+description: >-
+  Guide the user through RunAPI API key setup for Claude Code and other MCP
+  hosts.
+---
+
+# RunAPI Setup
+
+Guide the user through local RunAPI MCP configuration.
+
+## Instructions
+
+1. Explain that free catalog tools work without a key.
+2. Explain that `create_task`, `get_task`, `check_balance`, and `chat` require `RUNAPI_API_KEY`.
+3. Tell the user to create a key in the RunAPI dashboard.
+4. Show one setup option:
+
+```bash
+export RUNAPI_API_KEY="your_runapi_key"
+```
+
+5. If they prefer a config file, show:
+
+```json
+{
+  "apiKey": "your_runapi_key"
+}
+```
+
+stored at `~/.config/runapi/config.json`.
+
+6. Tell them to restart the MCP host after changing environment variables.
+
+Do not ask the user to paste the key into the conversation.
+Do not run shell commands unless the user explicitly asks.


### PR DESCRIPTION
## Summary

Adds **RunAPI MCP**, a media generation plugin that gives Claude Code, Codex, and other MCP hosts access to 130+ AI models across 18 providers.

### What it does
- **8 MCP tools** for model discovery, pricing lookup, image/video/music/audio task creation, task polling, balance checks, and LLM chat
- **2 sub-agents** for parallel task execution and model recommendation
- **4 slash commands**: /runapi:gen, /runapi:models, /runapi:balance, /runapi:setup
- **Free catalog tools** work without API key (model browsing, pricing)

### Models covered
- Image: Flux, GPT Image 2, Imagen 4, Ideogram V3, Nano Banana, Seedream, Qwen
- Video: Seedance, Veo 3.1, Kling, Wan, Hailuo, Runway, HappyHorse
- Music: Suno (v4, v4.5, v5, v5.5)
- Audio: ElevenLabs (TTS, sound effects, dialogue, transcription)
- LLM: Claude, GPT, Gemini, DeepSeek

### Install
```
npx @runapi.ai/mcp init claude
```

### Links
- npm: [@runapi.ai/mcp](https://www.npmjs.com/package/@runapi.ai/mcp)
- GitHub: [runapi-ai/mcp](https://github.com/runapi-ai/mcp)