### PR TITLE
Add storymap-skill (external git-subdir entry) — user story mapping skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1155,7 +1155,7 @@
         "url": "https://github.com/MartinForReal/storymap-skill.git",
         "path": "."
       },
-      "description": "User story mapping (Jeff Patton style). Turns a goal, brief, or messy backlog into a sliced, prioritized delivery plan with per-persona stories. Four invocation modes (from scratch / brief / backlog / refinement), three prioritization methods (WSJF, RICE, MoSCoW), three slicing strategies (Patton classic, SAFe PI, Now/Next/Later). OKR coverage, dependency cycle detection, persona conflict resolution, slice-1 acceptance criteria, E2E test contract. Auto-activates in the Plan stage of Superpowers / gstack / GSD. Benchmark: 99.6% (255/256) on 25-eval suite, +79.2pp over no-skill baseline.",
+      "description": "User story mapping (Jeff Patton style). Turns a goal, brief, or messy backlog into a sliced, prioritized delivery plan with per-persona stories. Four invocation modes (from scratch / brief / backlog / refinement), three prioritization methods (WSJF, RICE, MoSCoW), three slicing strategies (Patton classic, SAFe PI, Now/Next/Later). OKR coverage, dependency cycle detection, persona conflict resolution, slice-1 acceptance criteria, E2E test contract. Auto-activates in the Plan stage of Superpowers / gstack / GSD.",
       "version": "0.0.3",
       "author": {
         "name": "MartinForReal",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1147,6 +1147,38 @@
         "multi-agent",
         "dev-workflow"
       ]
+    },
+    {
+      "name": "storymap-skill",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/MartinForReal/storymap-skill.git",
+        "path": "."
+      },
+      "description": "User story mapping (Jeff Patton style). Turns a goal, brief, or messy backlog into a sliced, prioritized delivery plan with per-persona stories. Four invocation modes (from scratch / brief / backlog / refinement), three prioritization methods (WSJF, RICE, MoSCoW), three slicing strategies (Patton classic, SAFe PI, Now/Next/Later). OKR coverage, dependency cycle detection, persona conflict resolution, slice-1 acceptance criteria, E2E test contract. Auto-activates in the Plan stage of Superpowers / gstack / GSD. Benchmark: 99.6% (255/256) on 25-eval suite, +79.2pp over no-skill baseline.",
+      "version": "0.0.3",
+      "author": {
+        "name": "MartinForReal",
+        "url": "https://github.com/MartinForReal"
+      },
+      "homepage": "https://github.com/MartinForReal/storymap-skill",
+      "license": "MIT",
+      "category": "workflows",
+      "keywords": [
+        "user-story-mapping",
+        "story-mapping",
+        "agile",
+        "safe",
+        "wsjf",
+        "rice",
+        "moscow",
+        "mvp",
+        "pi-planning",
+        "product-discovery",
+        "jeff-patton",
+        "backlog-management",
+        "personas"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds **storymap-skill** as an external `git-subdir` plugin entry, following the [Pensyve precedent](https://github.com/wshobson/agents/blob/main/.claude-plugin/marketplace.json). Source repo: https://github.com/MartinForReal/storymap-skill (MIT, v0.0.3).

## What it does

User story mapping (Jeff Patton style). Turns a goal, brief, or messy backlog into a sliced, prioritized delivery plan with per-persona stories that act as the blueprint for the team's test playbook.

- **4 invocation modes** — from scratch, from brief/PRD, from existing backlog, iterative refinement
- **3 prioritization methods** — WSJF, RICE, MoSCoW
- **3 slicing strategies** — Patton classic, SAFe PI, Now/Next/Later
- **6 canonical output files** — design doc, story map (Markdown + Mermaid + CSV), prioritized backlog
- **Sister-framework integration** — auto-activates in the Plan stage of Superpowers, gstack, and GSD
- **Quality gates** — OKR coverage matrix, dependency cycle detection, persona conflict resolution, slice-1 acceptance criteria (Given/When/Then + INVEST), E2E test contract derived from backbone

## Why this fills a marketplace gap

Browsing the current 84 plugins / 156 skills, none target Patton-style user story mapping or PI planning. Closest neighbors (`conductor`, `ship-mate`) handle planning-adjacent engineering workflows but not product discovery, hence the choice of `category: "workflows"`.

## Benchmark

99.6% (255/256) on a 25-eval suite. +79.2pp over no-skill baseline. Per-eval breakdown in [`benchmark/benchmark.md`](https://github.com/MartinForReal/storymap-skill/blob/main/benchmark/benchmark.md); raw data in `benchmark/benchmark.json`.

## Verification

- [x] `source.path = "."` — plugin lives at the repo root (matches `qa-orchestra` pattern)
- [x] Source repo has valid `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` at the root
- [x] License: MIT (SPDX)
- [x] No collision with existing plugin names
- [x] Category: `workflows` (planning-adjacent, alongside `conductor` and `ship-mate`)
- [x] `tools/validate_generated.py` passes — "OK: no issues across 5 harness(es)."

`make generate-all` was intentionally not run: external `git-subdir` entries (pensyve, qa-orchestra) have no local plugin directory and no generated per-harness artifacts in the tree — confirmed by inspecting both precedents.

## Test installation

After merging, users can install with:

```
/plugin marketplace add wshobson/agents
/plugin install storymap-skill
```

Happy to adjust the entry — different category, shorter description, different keywords — whatever fits the marketplace's conventions.