### PR TITLE
Add file-conversion plugin (ChangeThisFile)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -482,6 +482,18 @@
       "category": "Coding"
     },
     {
+      "name": "file-conversion",
+      "source": {
+        "source": "local",
+        "path": "./plugins/file-conversion"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_USE"
+      },
+      "category": "Coding"
+    },
+    {
       "name": "framework-migration",
       "source": {
         "source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
     {
       "name": "documentation-standards",
       "source": "./plugins/documentation-standards",
-      "description": "HADS (Human-AI Document Standard) — semantic tagging convention for writing docs that work efficiently for both humans and AI models. Reduces token consumption by separating machine-critical facts from human context.",
+      "description": "HADS (Human-AI Document Standard) \u2014 semantic tagging convention for writing docs that work efficiently for both humans and AI models. Reduces token consumption by separating machine-critical facts from human context.",
       "version": "1.0.1",
       "author": {
         "name": "Niksa Barlovic",
@@ -48,19 +48,6 @@
       "homepage": "https://github.com/wshobson/agents",
       "license": "MIT",
       "category": "development"
-    },
-    {
-      "name": "file-conversion",
-      "source": "./plugins/file-conversion",
-      "description": "Convert files between 999 routes — PDF to Word, HEIC to JPG, MP4 to MP3, CSV to JSON, EPUB to MOBI — via the free ChangeThisFile API. MCP-aware with a zero-dependency script fallback; no API key required.",
-      "version": "1.0.0",
-      "author": {
-        "name": "Aadil Razvi",
-        "url": "https://changethisfile.com"
-      },
-      "homepage": "https://github.com/aadilr/changethisfile-mcp",
-      "license": "MIT",
-      "category": "utilities"
     },
     {
       "name": "git-pr-workflows",
@@ -715,7 +702,7 @@
     {
       "name": "social-publishing",
       "source": "./plugins/social-publishing",
-      "description": "Schedule and publish social media posts across 13 platforms (X, LinkedIn Profile + Page, Instagram Business + Standalone, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, Pinterest) via SocialClaw — one workspace API key covers everything",
+      "description": "Schedule and publish social media posts across 13 platforms (X, LinkedIn Profile + Page, Instagram Business + Standalone, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, Pinterest) via SocialClaw \u2014 one workspace API key covers everything",
       "version": "1.0.0",
       "author": {
         "name": "ndesv21",
@@ -926,7 +913,7 @@
       "description": "Binary reverse engineering, malware analysis, firmware security, and software protection research for authorized security research, CTF competitions, and defensive security",
       "version": "1.0.1",
       "author": {
-        "name": "Dávid Balatoni",
+        "name": "D\u00e1vid Balatoni",
         "url": "https://github.com/balcsida"
       },
       "homepage": "https://github.com/wshobson/agents",
@@ -935,7 +922,7 @@
     },
     {
       "name": "conductor",
-      "description": "Context-Driven Development plugin that transforms Claude Code into a project management tool with structured workflow: Context → Spec & Plan → Implement",
+      "description": "Context-Driven Development plugin that transforms Claude Code into a project management tool with structured workflow: Context \u2192 Spec & Plan \u2192 Implement",
       "version": "1.2.2",
       "author": {
         "name": "Seth Hobson",
@@ -1058,7 +1045,7 @@
         "url": "https://github.com/Anasss/qa-orchestra.git",
         "path": "."
       },
-      "description": "Multi-agent QA toolkit with 10 specialized agents covering the full QA lifecycle — orchestrator, environment-manager, functional-reviewer, test-scenario-designer, browser-validator, automation-writer, manual-validator, bug-reporter, release-analyzer, and smart-test-selector. Stack-agnostic, output-chained, designed around live validation via Chrome MCP.",
+      "description": "Multi-agent QA toolkit with 10 specialized agents covering the full QA lifecycle \u2014 orchestrator, environment-manager, functional-reviewer, test-scenario-designer, browser-validator, automation-writer, manual-validator, bug-reporter, release-analyzer, and smart-test-selector. Stack-agnostic, output-chained, designed around live validation via Chrome MCP.",
       "version": "1.0.0",
       "author": {
         "name": "Anass Rach",
@@ -1071,7 +1058,7 @@
     {
       "name": "protect-mcp",
       "source": "./plugins/protect-mcp",
-      "description": "Cedar policy enforcement + Ed25519 signed receipts for every Claude Code tool call. First cryptographic governance plugin — decisions are policy-gated before they run and every decision produces a tamper-evident receipt verifiable offline.",
+      "description": "Cedar policy enforcement + Ed25519 signed receipts for every Claude Code tool call. First cryptographic governance plugin \u2014 decisions are policy-gated before they run and every decision produces a tamper-evident receipt verifiable offline.",
       "version": "0.1.1",
       "author": {
         "name": "Tom Farley",
@@ -1141,7 +1128,7 @@
     {
       "name": "ship-mate",
       "source": "./plugins/ship-mate",
-      "description": "Your AI development teammate. Turns a story file into a shipped, reviewed, and tested feature via orchestrator → architect → developer → PR reviewer → QA → Playwright.",
+      "description": "Your AI development teammate. Turns a story file into a shipped, reviewed, and tested feature via orchestrator \u2192 architect \u2192 developer \u2192 PR reviewer \u2192 QA \u2192 Playwright.",
       "version": "1.0.1",
       "author": {
         "name": "Pranay Yadav",
@@ -1160,6 +1147,19 @@
         "multi-agent",
         "dev-workflow"
       ]
+    },
+    {
+      "name": "file-conversion",
+      "source": "./plugins/file-conversion",
+      "description": "Convert files between 999 routes \u2014 PDF to Word, HEIC to JPG, MP4 to MP3, CSV to JSON, EPUB to MOBI \u2014 via the free ChangeThisFile API. MCP-aware with a zero-dependency script fallback; no API key required.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Aadil Razvi",
+        "url": "https://changethisfile.com"
+      },
+      "homepage": "https://github.com/aadilr/changethisfile-mcp",
+      "license": "MIT",
+      "category": "utilities"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
     {
       "name": "documentation-standards",
       "source": "./plugins/documentation-standards",
-      "description": "HADS (Human-AI Document Standard) \u2014 semantic tagging convention for writing docs that work efficiently for both humans and AI models. Reduces token consumption by separating machine-critical facts from human context.",
+      "description": "HADS (Human-AI Document Standard) — semantic tagging convention for writing docs that work efficiently for both humans and AI models. Reduces token consumption by separating machine-critical facts from human context.",
       "version": "1.0.1",
       "author": {
         "name": "Niksa Barlovic",
@@ -48,6 +48,19 @@
       "homepage": "https://github.com/wshobson/agents",
       "license": "MIT",
       "category": "development"
+    },
+    {
+      "name": "file-conversion",
+      "source": "./plugins/file-conversion",
+      "description": "Convert files between 999 routes — PDF to Word, HEIC to JPG, MP4 to MP3, CSV to JSON, EPUB to MOBI — via the free ChangeThisFile API. MCP-aware with a zero-dependency script fallback; no API key required.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Aadil Razvi",
+        "url": "https://changethisfile.com"
+      },
+      "homepage": "https://github.com/aadilr/changethisfile-mcp",
+      "license": "MIT",
+      "category": "utilities"
     },
     {
       "name": "git-pr-workflows",
@@ -913,7 +926,7 @@
       "description": "Binary reverse engineering, malware analysis, firmware security, and software protection research for authorized security research, CTF competitions, and defensive security",
       "version": "1.0.1",
       "author": {
-        "name": "D\u00e1vid Balatoni",
+        "name": "Dávid Balatoni",
         "url": "https://github.com/balcsida"
       },
       "homepage": "https://github.com/wshobson/agents",
@@ -922,7 +935,7 @@
     },
     {
       "name": "conductor",
-      "description": "Context-Driven Development plugin that transforms Claude Code into a project management tool with structured workflow: Context \u2192 Spec & Plan \u2192 Implement",
+      "description": "Context-Driven Development plugin that transforms Claude Code into a project management tool with structured workflow: Context → Spec & Plan → Implement",
       "version": "1.2.2",
       "author": {
         "name": "Seth Hobson",
@@ -1045,7 +1058,7 @@
         "url": "https://github.com/Anasss/qa-orchestra.git",
         "path": "."
       },
-      "description": "Multi-agent QA toolkit with 10 specialized agents covering the full QA lifecycle \u2014 orchestrator, environment-manager, functional-reviewer, test-scenario-designer, browser-validator, automation-writer, manual-validator, bug-reporter, release-analyzer, and smart-test-selector. Stack-agnostic, output-chained, designed around live validation via Chrome MCP.",
+      "description": "Multi-agent QA toolkit with 10 specialized agents covering the full QA lifecycle — orchestrator, environment-manager, functional-reviewer, test-scenario-designer, browser-validator, automation-writer, manual-validator, bug-reporter, release-analyzer, and smart-test-selector. Stack-agnostic, output-chained, designed around live validation via Chrome MCP.",
       "version": "1.0.0",
       "author": {
         "name": "Anass Rach",
@@ -1058,7 +1071,7 @@
     {
       "name": "protect-mcp",
       "source": "./plugins/protect-mcp",
-      "description": "Cedar policy enforcement + Ed25519 signed receipts for every Claude Code tool call. First cryptographic governance plugin \u2014 decisions are policy-gated before they run and every decision produces a tamper-evident receipt verifiable offline.",
+      "description": "Cedar policy enforcement + Ed25519 signed receipts for every Claude Code tool call. First cryptographic governance plugin — decisions are policy-gated before they run and every decision produces a tamper-evident receipt verifiable offline.",
       "version": "0.1.1",
       "author": {
         "name": "Tom Farley",
@@ -1128,7 +1141,7 @@
     {
       "name": "ship-mate",
       "source": "./plugins/ship-mate",
-      "description": "Your AI development teammate. Turns a story file into a shipped, reviewed, and tested feature via orchestrator \u2192 architect \u2192 developer \u2192 PR reviewer \u2192 QA \u2192 Playwright.",
+      "description": "Your AI development teammate. Turns a story file into a shipped, reviewed, and tested feature via orchestrator → architect → developer → PR reviewer → QA → Playwright.",
       "version": "1.0.1",
       "author": {
         "name": "Pranay Yadav",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -451,6 +451,18 @@
       "license": "MIT"
     },
     {
+      "name": "file-conversion",
+      "source": "./plugins/file-conversion",
+      "version": "1.0.0",
+      "description": "Convert files between 999 routes \u2014 PDF to Word, HEIC to JPG, MP4 to MP3, CSV to JSON, EPUB to MOBI \u2014 via the free ChangeThisFile API. MCP-aware with a zero-dependency script fallback; no API key required.",
+      "author": {
+        "name": "Aadil Razvi",
+        "email": ""
+      },
+      "homepage": "https://github.com/aadilr/changethisfile-mcp",
+      "license": "MIT"
+    },
+    {
       "name": "framework-migration",
       "source": "./plugins/framework-migration",
       "version": "1.3.2",

--- a/.cursor-plugin/plugins/file-conversion.json
+++ b/.cursor-plugin/plugins/file-conversion.json
@@ -1,0 +1,12 @@
+{
+  "name": "file-conversion",
+  "displayName": "File Conversion",
+  "version": "1.0.0",
+  "description": "Convert files between 999 routes \u2014 PDF to Word, HEIC to JPG, MP4 to MP3, CSV to JSON, EPUB to MOBI \u2014 via the free ChangeThisFile API. MCP-aware with a zero-dependency script fallback; no API key required.",
+  "author": {
+    "name": "Aadil Razvi",
+    "email": ""
+  },
+  "homepage": "https://github.com/aadilr/changethisfile-mcp",
+  "license": "MIT"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # claude-agents — multi-harness agentic plugin marketplace
 
-Production-ready agentic-workflow building blocks: **84 plugins** (82 local + 2 external), **192 agents**, **156 skills**, **102 commands**. Native source-of-truth for Claude Code; also consumed by OpenAI Codex CLI, Cursor, OpenCode, and Gemini CLI from a single Markdown source.
+Production-ready agentic-workflow building blocks: **85 plugins** (83 local + 2 external), **192 agents**, **156 skills**, **102 commands**. Native source-of-truth for Claude Code; also consumed by OpenAI Codex CLI, Cursor, OpenCode, and Gemini CLI from a single Markdown source.
 
 This file is the canonical context file. Codex / Cursor / OpenCode read it directly. Claude Code reads it via `CLAUDE.md`, a symlink to this file. Gemini CLI reads it via `gemini-extension.json` (`contextFileName`) / `.gemini/settings.json`.
 
@@ -10,7 +10,7 @@ This file is the canonical context file. Codex / Cursor / OpenCode read it direc
 
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — top-level architectural overview (adapter framework, source-of-truth invariant, capability matrix summary)
 - **[docs/architecture.md](docs/architecture.md)** — detailed design principles
-- **[docs/plugins.md](docs/plugins.md)** — full plugin catalog (84 plugins by category)
+- **[docs/plugins.md](docs/plugins.md)** — full plugin catalog (85 plugins by category)
 - **[docs/agents.md](docs/agents.md)** — agent reference (192 agents, model tiers)
 - **[docs/agent-skills.md](docs/agent-skills.md)** — skill reference (progressive disclosure model)
 - **[docs/usage.md](docs/usage.md)** — commands, workflows, examples

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,7 +26,7 @@ claude-agents/
 ├── CONTRIBUTING.md                 # Contributor entry point
 ├── .claude-plugin/marketplace.json # Plugin registry (source of truth)
 ├── .gemini/settings.json           # Gemini CLI → AGENTS.md redirect
-├── plugins/                        # SOURCE OF TRUTH (82 local plugins; 2 externals in marketplace)
+├── plugins/                        # SOURCE OF TRUTH (83 local plugins; 2 externals in marketplace)
 │   └── <name>/
 │       ├── .claude-plugin/plugin.json
 │       ├── agents/*.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agentic Plugin Marketplace
 
-> Production-ready agentic workflow building blocks: **84 plugins**, **192 agents**,
+> Production-ready agentic workflow building blocks: **85 plugins**, **192 agents**,
 > **156 skills**, **102 commands** — built for Claude Code and consumed natively by
 > OpenAI Codex CLI, Cursor, OpenCode, Gemini CLI, and GitHub Copilot from a single Markdown source.
 
@@ -19,7 +19,7 @@ Pick your harness:
 
 ```bash
 /plugin marketplace add wshobson/agents
-/plugin install python-development          # or any of 84 plugins
+/plugin install python-development          # or any of 85 plugins
 ```
 
 [→ Full Claude Code setup, troubleshooting, and plugin catalog](docs/usage.md)
@@ -47,7 +47,7 @@ Setup details and per-harness gotchas: [docs/harnesses.md](docs/harnesses.md). G
 
 | | Count | What it is |
 |---|---:|---|
-| **Plugins** | 84 | Granular, single-purpose installable units (82 local + 2 external via git-subdir) |
+| **Plugins** | 85 | Granular, single-purpose installable units (83 local + 2 external via git-subdir) |
 | **Agents** | 192 | Domain experts (architecture, languages, infra, security, data, ML, docs, business, SEO) |
 | **Skills** | 156 | Modular knowledge packages with progressive disclosure (load when activated) |
 | **Commands** | 102 | Slash commands: scaffolding, security scans, test gen, infrastructure setup |
@@ -124,7 +124,7 @@ uv run plugin-eval certify path/to/skill
 
 Detail lives in `docs/`. Read in this order:
 
-- **[docs/plugins.md](docs/plugins.md)** — full catalog of all 84 plugins
+- **[docs/plugins.md](docs/plugins.md)** — full catalog of all 85 plugins
 - **[docs/agents.md](docs/agents.md)** — all 192 agents by category
 - **[docs/agent-skills.md](docs/agent-skills.md)** — 156 skills with progressive disclosure
 - **[docs/usage.md](docs/usage.md)** — commands, workflows, examples

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,7 +36,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 
 ### Plugin Distribution
 
-- **84 marketplace plugins** (82 local + 2 external via git-subdir) optimized for specific use cases
+- **85 marketplace plugins** (83 local + 2 external via git-subdir) optimized for specific use cases
 - **26 clear categories** with 1-10 plugins each for easy discovery
 - Organized by domain:
   - **Development**: 6 plugins (debugging, backend, frontend, UI, multi-platform, essentials)
@@ -81,7 +81,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 ```
 claude-agents/
 ├── .claude-plugin/
-│   └── marketplace.json          # Marketplace catalog (84 plugins)
+│   └── marketplace.json          # Marketplace catalog (85 plugins)
 ├── plugins/                       # Isolated plugin directories
 │   ├── python-development/
 │   │   ├── agents/               # Python language agents
@@ -392,5 +392,5 @@ Feature Development Workflow:
 
 - [Agent Skills](./agent-skills.md) - Modular knowledge packages
 - [Agent Reference](./agents.md) - Complete agent catalog
-- [Plugin Reference](./plugins.md) - All 84 marketplace plugins
+- [Plugin Reference](./plugins.md) - All 85 marketplace plugins
 - [Usage Guide](./usage.md) - Commands and workflows

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,6 +1,6 @@
 # Complete Plugin Reference
 
-Browse all **84 marketplace plugins** organized by category: 82 local plugins plus 2 externally hosted `git-subdir` entries (`pensyve`, `qa-orchestra`).
+Browse all **85 marketplace plugins** organized by category: 83 local plugins plus 2 externally hosted `git-subdir` entries (`pensyve`, `qa-orchestra`).
 
 ## Quick Start - Essential Plugins
 
@@ -154,13 +154,14 @@ Next.js, React + Vite, and Node.js project setup with pnpm and TypeScript best p
 | **performance-testing-review** | Performance analysis and test coverage review | `/plugin install performance-testing-review` |
 | **plugin-eval**                | Three-layer quality evaluation framework for Claude Code plugins | `/plugin install plugin-eval`                |
 
-### 🛠️ Utilities (4 plugins)
+### 🛠️ Utilities (5 plugins)
 
 | Plugin                    | Description                                | Install                                 |
 | ------------------------- | ------------------------------------------ | --------------------------------------- |
 | **code-refactoring**      | Code cleanup and technical debt management | `/plugin install code-refactoring`      |
 | **dependency-management** | Dependency auditing and version management | `/plugin install dependency-management` |
 | **error-debugging**       | Error analysis and trace debugging         | `/plugin install error-debugging`       |
+| **file-conversion**       | Convert files across 1,000+ format pairs   | `/plugin install file-conversion`       |
 | **team-collaboration**    | Team workflows and standup automation      | `/plugin install team-collaboration`    |
 
 ### 🤖 AI & ML (4 plugins)
@@ -356,7 +357,7 @@ plugins/python-development/
 /plugin marketplace add wshobson/agents
 ```
 
-This makes all 84 marketplace plugins available for installation, but **does not load any agents or tools** into your context.
+This makes all 85 marketplace plugins available for installation, but **does not load any agents or tools** into your context.
 
 ### Step 2: Install Specific Plugins
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -391,5 +391,5 @@ See [Agent Skills](./agent-skills.md) for details on the 156 specialized skills.
 
 - [Agent Skills](./agent-skills.md) - Specialized knowledge packages
 - [Agent Reference](./agents.md) - Complete agent catalog
-- [Plugin Reference](./plugins.md) - All 84 marketplace plugins
+- [Plugin Reference](./plugins.md) - All 85 marketplace plugins
 - [Architecture](./architecture.md) - Design principles

--- a/plugins/file-conversion/.claude-plugin/plugin.json
+++ b/plugins/file-conversion/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "file-conversion",
+  "version": "1.0.0",
+  "description": "Convert files between 999 routes — PDF to Word, HEIC to JPG, MP4 to MP3, CSV to JSON, EPUB to MOBI — via the free ChangeThisFile API. MCP-aware with a zero-dependency script fallback; no API key required.",
+  "author": {
+    "name": "Aadil Razvi",
+    "url": "https://changethisfile.com"
+  },
+  "homepage": "https://github.com/aadilr/changethisfile-mcp",
+  "license": "MIT"
+}

--- a/plugins/file-conversion/.codex-plugin/plugin.json
+++ b/plugins/file-conversion/.codex-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "file-conversion",
+  "version": "1.0.0",
+  "description": "Convert files between 999 routes \u2014 PDF to Word, HEIC to JPG, MP4 to MP3, CSV to JSON, EPUB to MOBI \u2014 via the free ChangeThisFile API. MCP-aware with a zero-dependency script fallback; no API key required.",
+  "skills": "./skills/",
+  "author": {
+    "name": "Aadil Razvi",
+    "url": "https://changethisfile.com"
+  },
+  "homepage": "https://github.com/aadilr/changethisfile-mcp",
+  "license": "MIT",
+  "interface": {
+    "displayName": "File Conversion",
+    "shortDescription": "Convert files between 999 routes \u2014 PDF to Word, HEIC to JPG, MP4 to MP3, CSV to JSON, EPUB to MOBI \u2014 via the free\u2026",
+    "category": "Coding"
+  }
+}

--- a/plugins/file-conversion/skills/file-conversion/SKILL.md
+++ b/plugins/file-conversion/skills/file-conversion/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: file-conversion
+description: Convert files between formats — PDF to Word, HEIC to JPG, MP4 to MP3, CSV to JSON, EPUB to MOBI, and 999 total routes across images, video, audio, documents, data, fonts, ebooks, and archives. Free via changethisfile.com, no API key or signup. Use when the user needs a file converted to a different format.
+---
+
+# File Conversion (ChangeThisFile)
+
+Convert files between 999 conversion routes using the free ChangeThisFile service. No account or API key required. Conversions run server-side (FFmpeg, LibreOffice, Calibre, 7-Zip, sharp, Ghostscript); files are deleted within 24 hours.
+
+## Decision order
+
+1. **If ChangeThisFile MCP tools are available** (`changethisfile:convert_file`, `changethisfile:list_conversions`) — use them directly. `convert_file` takes `source_url` OR `base64_content` + `source_format`, plus `target_format`, and returns a temporary download URL.
+2. **Otherwise, use the bundled script** (requires network access to changethisfile.com):
+
+```bash
+scripts/convert.sh <input-file> <target-format> [output-file]
+# e.g. scripts/convert.sh report.docx pdf
+# prints the output file path on success
+```
+
+The script path is relative to this skill's directory. It base64-encodes the file, calls the hosted MCP endpoint over plain HTTPS, downloads the result, and writes it next to the input (or to `[output-file]`).
+
+3. **Remote file (you have a URL, not a local file)** — skip the download/re-upload; one curl does it:
+
+```bash
+curl -sS -X POST https://changethisfile.com/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"convert_file","arguments":{"source_url":"<FILE_URL>","target_format":"pdf"}}}'
+```
+
+The response text contains a download URL — fetch it with `curl -o <output>`.
+
+## Discovering supported routes
+
+Ask before guessing if a conversion is exotic:
+
+```bash
+curl -sS -X POST https://changethisfile.com/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_conversions","arguments":{"source_format":"docx"}}}'
+```
+
+Omit `source_format` for a grouped summary of all 999 routes.
+
+## Limits and errors
+
+- Max input: **25 MB** (free path). Larger files: get a free API key (1,000 conversions/month) at https://changethisfile.com/docs/authentication and use `POST /v1/convert`.
+- Rate limit: **5 conversions/minute per IP**. On "Rate limit exceeded", wait 60 seconds and retry once.
+- "Unsupported conversion: X→Y" errors list the valid targets for that source format.
+- Download URLs expire after 1 hour — download immediately, then work with the local file.
+
+## Environment notes
+
+- Needs outbound HTTPS to `changethisfile.com`. On claude.ai, the code-execution sandbox restricts egress by default — prefer the MCP connector there, or the user can allow the domain under Settings → Capabilities.
+- Full docs: https://changethisfile.com/docs/mcp

--- a/plugins/file-conversion/skills/file-conversion/scripts/convert.sh
+++ b/plugins/file-conversion/skills/file-conversion/scripts/convert.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Convert a file via the free ChangeThisFile API (no API key required).
+#
+# Usage: convert.sh <input-file> <target-format> [output-file]
+# Prints the output file path on success. Non-zero exit + stderr message on failure.
+#
+# Limits: 25MB input, 5 conversions/min per IP. Files deleted server-side within 24h.
+set -euo pipefail
+
+ENDPOINT="${CHANGETHISFILE_MCP_URL:-https://changethisfile.com/mcp}"
+
+IN="${1:-}"; TARGET="${2:-}"; OUT="${3:-}"
+if [ -z "$IN" ] || [ -z "$TARGET" ]; then
+  echo "usage: convert.sh <input-file> <target-format> [output-file]" >&2
+  exit 2
+fi
+[ -f "$IN" ] || { echo "error: input file not found: $IN" >&2; exit 2; }
+
+SIZE=$(wc -c < "$IN" | tr -d ' ')
+if [ "$SIZE" -gt 25000000 ]; then
+  echo "error: file is $((SIZE / 1048576))MB — free limit is 25MB. Get a free API key for larger files: https://changethisfile.com/docs/authentication" >&2
+  exit 3
+fi
+
+TARGET=$(printf '%s' "$TARGET" | tr '[:upper:]' '[:lower:]' | sed 's/^\.//')
+BASENAME=$(basename "$IN" | tr -d '"\\')
+SRC=$(printf '%s' "${BASENAME##*.}" | tr '[:upper:]' '[:lower:]')
+[ -z "$OUT" ] && OUT="${IN%.*}.${TARGET}"
+
+# base64 -w0 is GNU; macOS base64 has no -w flag
+B64=$(base64 -w0 < "$IN" 2>/dev/null || base64 < "$IN" | tr -d '\n')
+
+REQ_FILE=$(mktemp)
+RESP_FILE=$(mktemp)
+trap 'rm -f "$REQ_FILE" "$RESP_FILE"' EXIT
+
+printf '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"convert_file","arguments":{"base64_content":"%s","source_format":"%s","target_format":"%s","filename":"%s"}}}' \
+  "$B64" "$SRC" "$TARGET" "$BASENAME" > "$REQ_FILE"
+
+HTTP_CODE=$(curl -sS --max-time 300 -o "$RESP_FILE" -w "%{http_code}" \
+  -X POST "$ENDPOINT" -H "Content-Type: application/json" --data-binary "@$REQ_FILE")
+
+if [ "$HTTP_CODE" != "200" ]; then
+  echo "error: conversion service returned HTTP $HTTP_CODE: $(head -c 300 "$RESP_FILE")" >&2
+  exit 4
+fi
+
+DOWNLOAD_URL=$(grep -o 'https://changethisfile.com/v1/jobs/download/[A-Za-z0-9_-]*' "$RESP_FILE" | head -1 || true)
+if [ -z "$DOWNLOAD_URL" ]; then
+  # Surface the tool's error text (rate limit, unsupported route, etc.)
+  ERR=$(sed 's/\\n/ /g' "$RESP_FILE" | grep -o '"text":"[^"]*"' | head -1 | sed 's/^"text":"//; s/"$//')
+  echo "error: ${ERR:-unexpected response: $(head -c 300 "$RESP_FILE")}" >&2
+  exit 5
+fi
+
+curl -sS --max-time 120 -o "$OUT" "$DOWNLOAD_URL"
+[ -s "$OUT" ] || { echo "error: download produced an empty file" >&2; exit 6; }
+
+echo "$OUT"

--- a/plugins/file-conversion/skills/file-conversion/scripts/convert.sh
+++ b/plugins/file-conversion/skills/file-conversion/scripts/convert.sh
@@ -30,29 +30,39 @@ case "$TARGET" in
 esac
 BASENAME=$(basename "$IN")
 SRC=$(printf '%s' "${BASENAME##*.}" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9')
+# Reject traversal AND absolute / home-relative paths in a USER-SUPPLIED output
+# path — OUT is written with `curl -o`, so an unvalidated path could clobber
+# arbitrary files. Only relative, non-traversing paths are accepted. (The
+# auto-derived default below safely inherits the input file's own directory.)
+if [ -n "$OUT" ]; then
+  case "$OUT" in
+    /*|~*|*../*|*/..|..) echo "error: output path must be relative and must not contain '..': $OUT" >&2; exit 2 ;;
+  esac
+fi
 [ -z "$OUT" ] && OUT="${IN%.*}.${TARGET}"
 
-# Reject path traversal in a user-supplied output path — OUT is written with
-# `curl -o`, so an unvalidated "../../etc/passwd" could clobber arbitrary files.
-case "$OUT" in
-  *../*|*/..|..) echo "error: output path must not contain '..': $OUT" >&2; exit 2 ;;
-esac
-
-# base64 -w0 is GNU; macOS base64 has no -w flag
-B64=$(base64 -w0 < "$IN" 2>/dev/null || base64 < "$IN" | tr -d '\n')
-
+B64_FILE=$(mktemp)
 REQ_FILE=$(mktemp)
 RESP_FILE=$(mktemp)
-trap 'rm -f "$REQ_FILE" "$RESP_FILE"' EXIT
+trap 'rm -f "$B64_FILE" "$REQ_FILE" "$RESP_FILE"' EXIT
+
+# Encode to a file (not a shell variable / argv) so multi-MB payloads never hit
+# the OS per-argument limit. base64 -w0 is GNU; macOS base64 has no -w flag.
+base64 -w0 < "$IN" > "$B64_FILE" 2>/dev/null || base64 < "$IN" | tr -d '\n' > "$B64_FILE"
 
 # Build the JSON-RPC payload with jq so the filename (arbitrary user input) is
 # escaped correctly — newlines, control chars, quotes, backslashes. Falls back
 # to a strict printable-ASCII sanitization of the filename if jq is unavailable.
 if command -v jq >/dev/null 2>&1; then
-  jq -n --arg b64 "$B64" --arg src "$SRC" --arg tgt "$TARGET" --arg fn "$BASENAME" \
-    '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"convert_file",arguments:{base64_content:$b64,source_format:$src,target_format:$tgt,filename:$fn}}}' \
+  # --rawfile reads the base64 from a file, avoiding the ~128KB single-argument
+  # limit that `--arg b64 "$B64"` hits on inputs larger than ~96KB.
+  jq -n --rawfile b64 "$B64_FILE" --arg src "$SRC" --arg tgt "$TARGET" --arg fn "$BASENAME" \
+    '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"convert_file",arguments:{base64_content:($b64|rtrimstr("\n")),source_format:$src,target_format:$tgt,filename:$fn}}}' \
     > "$REQ_FILE"
 else
+  # printf is a shell builtin, so the large payload here is not subject to argv
+  # limits; read it back from the encoded file.
+  B64=$(cat "$B64_FILE")
   SAFE_FN=$(printf '%s' "$BASENAME" | tr -d '"\\' | LC_ALL=C tr -cd '[:print:]')
   printf '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"convert_file","arguments":{"base64_content":"%s","source_format":"%s","target_format":"%s","filename":"%s"}}}' \
     "$B64" "$SRC" "$TARGET" "$SAFE_FN" > "$REQ_FILE"

--- a/plugins/file-conversion/skills/file-conversion/scripts/convert.sh
+++ b/plugins/file-conversion/skills/file-conversion/scripts/convert.sh
@@ -22,10 +22,21 @@ if [ "$SIZE" -gt 25000000 ]; then
   exit 3
 fi
 
+# Only allow plain format tokens (letters/digits), e.g. "pdf", "mp3". Reject
+# anything else so TARGET can't smuggle path/JSON metacharacters downstream.
 TARGET=$(printf '%s' "$TARGET" | tr '[:upper:]' '[:lower:]' | sed 's/^\.//')
-BASENAME=$(basename "$IN" | tr -d '"\\')
-SRC=$(printf '%s' "${BASENAME##*.}" | tr '[:upper:]' '[:lower:]')
+case "$TARGET" in
+  *[!a-z0-9]*|'') echo "error: invalid target format: '$2' (use a plain extension like pdf, mp3, docx)" >&2; exit 2 ;;
+esac
+BASENAME=$(basename "$IN")
+SRC=$(printf '%s' "${BASENAME##*.}" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9')
 [ -z "$OUT" ] && OUT="${IN%.*}.${TARGET}"
+
+# Reject path traversal in a user-supplied output path — OUT is written with
+# `curl -o`, so an unvalidated "../../etc/passwd" could clobber arbitrary files.
+case "$OUT" in
+  *../*|*/..|..) echo "error: output path must not contain '..': $OUT" >&2; exit 2 ;;
+esac
 
 # base64 -w0 is GNU; macOS base64 has no -w flag
 B64=$(base64 -w0 < "$IN" 2>/dev/null || base64 < "$IN" | tr -d '\n')
@@ -34,8 +45,18 @@ REQ_FILE=$(mktemp)
 RESP_FILE=$(mktemp)
 trap 'rm -f "$REQ_FILE" "$RESP_FILE"' EXIT
 
-printf '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"convert_file","arguments":{"base64_content":"%s","source_format":"%s","target_format":"%s","filename":"%s"}}}' \
-  "$B64" "$SRC" "$TARGET" "$BASENAME" > "$REQ_FILE"
+# Build the JSON-RPC payload with jq so the filename (arbitrary user input) is
+# escaped correctly — newlines, control chars, quotes, backslashes. Falls back
+# to a strict printable-ASCII sanitization of the filename if jq is unavailable.
+if command -v jq >/dev/null 2>&1; then
+  jq -n --arg b64 "$B64" --arg src "$SRC" --arg tgt "$TARGET" --arg fn "$BASENAME" \
+    '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"convert_file",arguments:{base64_content:$b64,source_format:$src,target_format:$tgt,filename:$fn}}}' \
+    > "$REQ_FILE"
+else
+  SAFE_FN=$(printf '%s' "$BASENAME" | tr -d '"\\' | LC_ALL=C tr -cd '[:print:]')
+  printf '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"convert_file","arguments":{"base64_content":"%s","source_format":"%s","target_format":"%s","filename":"%s"}}}' \
+    "$B64" "$SRC" "$TARGET" "$SAFE_FN" > "$REQ_FILE"
+fi
 
 HTTP_CODE=$(curl -sS --max-time 300 -o "$RESP_FILE" -w "%{http_code}" \
   -X POST "$ENDPOINT" -H "Content-Type: application/json" --data-binary "@$REQ_FILE")


### PR DESCRIPTION
Adds a `file-conversion` plugin under **utilities** — converts files between 999 routes (PDF↔Word, HEIC→JPG, MP4→MP3, CSV→JSON, EPUB→MOBI, and more across images, video, audio, documents, data, fonts, ebooks, archives) via the free [ChangeThisFile](https://changethisfile.com) API. No API key or signup.

- One skill: `file-conversion` — MCP-aware (uses `changethisfile:convert_file` when connected) with a zero-dependency `curl` script fallback (`scripts/convert.sh`), so it works in every harness this marketplace targets.
- Upstream repo: https://github.com/aadilr/changethisfile-mcp (MIT; also in the official MCP registry as `com.changethisfile/mcp`).
- Script tested end-to-end (md→pdf, csv→xlsx, clean error surfaces for unsupported routes; 25MB/5-per-min limits documented in the skill).
- `make generate-all` run (adapters regenerated), `make validate STRICT=1` passes across all 5 harnesses; `make garden` warnings are all pre-existing in other plugins (SKILL_OVER_CODEX_CAP), none introduced — our SKILL.md body is well under the Codex cap.