### PR TITLE
feat: add before-you-build plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -110,6 +110,18 @@
       "category": "Coding"
     },
     {
+      "name": "before-you-build",
+      "source": {
+        "source": "local",
+        "path": "./plugins/before-you-build"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_USE"
+      },
+      "category": "Coding"
+    },
+    {
       "name": "block-no-verify",
       "source": {
         "source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/wshobson"
   },
   "metadata": {
-    "description": "Production-ready workflow orchestration with 84 marketplace plugins, 192 local specialized agents, and 156 local skills - optimized for granular installation and minimal token usage",
+    "description": "Production-ready workflow orchestration with 85 marketplace plugins, 192 local specialized agents, and 158 local skills - optimized for granular installation and minimal token usage",
     "version": "1.7.1"
   },
   "plugins": [
@@ -659,6 +659,19 @@
       "category": "business",
       "homepage": "https://github.com/wshobson/agents",
       "license": "MIT"
+    },
+    {
+      "name": "before-you-build",
+      "source": "./plugins/before-you-build",
+      "description": "Pre-build product risk review for founders, product teams, and AI-assisted builders before implementation starts",
+      "version": "0.1.1",
+      "author": {
+        "name": "bin1874",
+        "url": "https://github.com/bin1874/before-you-build-skill"
+      },
+      "homepage": "https://github.com/bin1874/before-you-build-skill",
+      "license": "MIT",
+      "category": "business"
     },
     {
       "name": "hr-legal-compliance",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/wshobson"
   },
   "metadata": {
-    "description": "Production-ready workflow orchestration with 84 marketplace plugins, 192 local specialized agents, and 156 local skills - optimized for granular installation and minimal token usage",
+    "description": "Production-ready workflow orchestration with 85 marketplace plugins, 192 local specialized agents, and 158 local skills - optimized for granular installation and minimal token usage",
     "version": "1.7.1"
   },
   "plugins": [
@@ -106,6 +106,17 @@
       "author": {
         "name": "Seth Hobson",
         "email": "seth@major7apps.com"
+      },
+      "license": "MIT"
+    },
+    {
+      "name": "before-you-build",
+      "source": "./plugins/before-you-build",
+      "version": "0.1.1",
+      "description": "Pre-build product risk review for founders, product teams, and AI-assisted builders before implementation starts.",
+      "author": {
+        "name": "bin1874",
+        "email": ""
       },
       "license": "MIT"
     },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-code-workflows",
   "displayName": "Claude Code Workflows",
   "version": "1.7.1",
-  "description": "Production-ready workflow orchestration with 84 marketplace plugins, 192 local specialized agents, and 156 local skills - optimized for granular installation and minimal token usage",
+  "description": "Production-ready workflow orchestration with 85 marketplace plugins, 192 local specialized agents, and 158 local skills - optimized for granular installation and minimal token usage",
   "author": {
     "name": "Seth Hobson",
     "email": "seth@major7apps.com"

--- a/.cursor-plugin/plugins/before-you-build.json
+++ b/.cursor-plugin/plugins/before-you-build.json
@@ -1,0 +1,11 @@
+{
+  "name": "before-you-build",
+  "displayName": "Before You Build",
+  "version": "0.1.1",
+  "description": "Pre-build product risk review for founders, product teams, and AI-assisted builders before implementation starts.",
+  "author": {
+    "name": "bin1874",
+    "email": ""
+  },
+  "license": "MIT"
+}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Agentic Plugin Marketplace
 
-> Production-ready agentic workflow building blocks: **84 plugins**, **192 agents**,
-> **156 skills**, **102 commands** — built for Claude Code and consumed natively by
+> Production-ready agentic workflow building blocks: **85 plugins**, **192 agents**,
+> **158 skills**, **102 commands** — built for Claude Code and consumed natively by
 > OpenAI Codex CLI, Cursor, OpenCode, Gemini CLI, and GitHub Copilot from a single Markdown source.
 
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-native-blueviolet)](#claude-code) [![Codex CLI](https://img.shields.io/badge/Codex%20CLI-supported-black)](docs/harnesses.md) [![Cursor](https://img.shields.io/badge/Cursor-supported-purple)](docs/harnesses.md) [![OpenCode](https://img.shields.io/badge/OpenCode-supported-green)](docs/harnesses.md) [![Gemini CLI](https://img.shields.io/badge/Gemini%20CLI-supported-blue)](GEMINI.md) [![Copilot](https://img.shields.io/badge/Copilot-supported-lightgrey)](docs/harnesses.md)
@@ -19,7 +19,7 @@ Pick your harness:
 
 ```bash
 /plugin marketplace add wshobson/agents
-/plugin install python-development          # or any of 84 plugins
+/plugin install python-development          # or any of 85 plugins
 ```
 
 [→ Full Claude Code setup, troubleshooting, and plugin catalog](docs/usage.md)
@@ -47,9 +47,9 @@ Setup details and per-harness gotchas: [docs/harnesses.md](docs/harnesses.md). G
 
 | | Count | What it is |
 |---|---:|---|
-| **Plugins** | 84 | Granular, single-purpose installable units (82 local + 2 external via git-subdir) |
+| **Plugins** | 85 | Granular, single-purpose installable units (83 local + 2 external via git-subdir) |
 | **Agents** | 192 | Domain experts (architecture, languages, infra, security, data, ML, docs, business, SEO) |
-| **Skills** | 156 | Modular knowledge packages with progressive disclosure (load when activated) |
+| **Skills** | 158 | Modular knowledge packages with progressive disclosure (load when activated) |
 | **Commands** | 102 | Slash commands: scaffolding, security scans, test gen, infrastructure setup |
 | **Orchestrators** | 16 | Multi-agent coordination workflows (full-stack, security, ML, incident response) |
 
@@ -125,9 +125,9 @@ uv run plugin-eval certify path/to/skill
 
 Detail lives in `docs/`. Read in this order:
 
-- **[docs/plugins.md](docs/plugins.md)** — full catalog of all 84 plugins
+- **[docs/plugins.md](docs/plugins.md)** — full catalog of all 85 plugins
 - **[docs/agents.md](docs/agents.md)** — all 192 agents by category
-- **[docs/agent-skills.md](docs/agent-skills.md)** — 156 skills with progressive disclosure
+- **[docs/agent-skills.md](docs/agent-skills.md)** — 158 skills with progressive disclosure
 - **[docs/usage.md](docs/usage.md)** — commands, workflows, examples
 - **[docs/architecture.md](docs/architecture.md)** — design principles
 - **[docs/harnesses.md](docs/harnesses.md)** — cross-harness capability matrix

--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -1,6 +1,6 @@
 # Agent Skills
 
-Agent Skills are modular packages that extend Claude's capabilities with specialized domain knowledge, following Anthropic's [Agent Skills Specification](https://github.com/anthropics/skills/blob/main/agent_skills_spec.md). This plugin ecosystem includes **156 local specialized skills** across 41 plugins, enabling progressive disclosure and efficient token usage.
+Agent Skills are modular packages that extend Claude's capabilities with specialized domain knowledge, following Anthropic's [Agent Skills Specification](https://github.com/anthropics/skills/blob/main/agent_skills_spec.md). This plugin ecosystem includes **158 local specialized skills** across 43 plugins, enabling progressive disclosure and efficient token usage.
 
 ## Overview
 
@@ -176,6 +176,12 @@ Skills provide Claude with deep expertise in specific domains without loading ev
 | ------------------------ | ---------------------------------------------------------------------------- |
 | **kpi-dashboard-design** | Design executive dashboards with actionable KPIs and drill-down capabilities |
 | **data-storytelling**    | Transform data insights into compelling narratives for stakeholders          |
+
+### Before You Build (1 skill)
+
+| Skill                | Description                                                                                                                    |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| **before-you-build** | Review demand, positioning, monetization, retention, trust, distribution, and feature-adoption risk before implementation starts |
 
 ### Data Engineering (4 skills)
 
@@ -386,7 +392,7 @@ fastapi-templates skill → Supplies production-ready templates
 
 ## Specification Compliance
 
-All 156 skills follow the [Agent Skills Specification](https://agentskills.io/specification):
+All 158 skills follow the [Agent Skills Specification](https://agentskills.io/specification):
 
 - ✓ Required `name` field (hyphen-case)
 - ✓ Required `description` field with "Use when" clause

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,7 +36,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 
 ### Plugin Distribution
 
-- **84 marketplace plugins** (82 local + 2 external via git-subdir) optimized for specific use cases
+- **85 marketplace plugins** (83 local + 2 external via git-subdir) optimized for specific use cases
 - **26 clear categories** with 1-10 plugins each for easy discovery
 - Organized by domain:
   - **Development**: 6 plugins (debugging, backend, frontend, UI, multi-platform, essentials)
@@ -81,7 +81,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 ```
 claude-agents/
 ├── .claude-plugin/
-│   └── marketplace.json          # Marketplace catalog (84 plugins)
+│   └── marketplace.json          # Marketplace catalog (85 plugins)
 ├── plugins/                       # Isolated plugin directories
 │   ├── python-development/
 │   │   ├── agents/               # Python language agents
@@ -194,7 +194,7 @@ description: What the skill does. Use when [trigger]. # Required: < 1024 chars
 - **Composability**: Mix and match skills across workflows
 - **Maintainability**: Isolated updates don't affect other skills
 
-See [Agent Skills](./agent-skills.md) for complete details on the 156 skills.
+See [Agent Skills](./agent-skills.md) for complete details on the 158 skills.
 
 ## Model Configuration Strategy
 
@@ -392,5 +392,5 @@ Feature Development Workflow:
 
 - [Agent Skills](./agent-skills.md) - Modular knowledge packages
 - [Agent Reference](./agents.md) - Complete agent catalog
-- [Plugin Reference](./plugins.md) - All 84 marketplace plugins
+- [Plugin Reference](./plugins.md) - All 85 marketplace plugins
 - [Usage Guide](./usage.md) - Commands and workflows

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,6 +1,6 @@
 # Complete Plugin Reference
 
-Browse all **84 marketplace plugins** organized by category: 82 local plugins plus 2 externally hosted `git-subdir` entries (`pensyve`, `qa-orchestra`).
+Browse all **85 marketplace plugins** organized by category: 83 local plugins plus 2 externally hosted `git-subdir` entries (`pensyve`, `qa-orchestra`).
 
 ## Quick Start - Essential Plugins
 
@@ -261,12 +261,13 @@ Next.js, React + Vite, and Node.js project setup with pnpm and TypeScript best p
 | **content-marketing**          | Content strategy and web research       | `/plugin install content-marketing`          |
 | **social-publishing**          | Multi-platform social media publishing  | `/plugin install social-publishing`          |
 
-### 💼 Business (4 plugins)
+### 💼 Business (5 plugins)
 
 | Plugin                        | Description                          | Install                                     |
 | ----------------------------- | ------------------------------------ | ------------------------------------------- |
 | **business-analytics**        | KPI tracking and financial reporting | `/plugin install business-analytics`        |
 | **startup-business-analyst**  | Market sizing, financial modeling, team planning, and strategic research for startups | `/plugin install startup-business-analyst`  |
+| **before-you-build**          | Pre-build product risk review for founders, product teams, and AI-assisted builders | `/plugin install before-you-build`          |
 | **hr-legal-compliance**       | HR policies and legal templates      | `/plugin install hr-legal-compliance`       |
 | **customer-sales-automation** | Support and sales automation         | `/plugin install customer-sales-automation` |
 
@@ -356,7 +357,7 @@ plugins/python-development/
 /plugin marketplace add wshobson/agents
 ```
 
-This makes all 84 marketplace plugins available for installation, but **does not load any agents or tools** into your context.
+This makes all 85 marketplace plugins available for installation, but **does not load any agents or tools** into your context.
 
 ### Step 2: Install Specific Plugins
 
@@ -399,7 +400,7 @@ Each installed plugin loads **only its specific agents and commands** into Claud
 
 ## See Also
 
-- [Agent Skills](./agent-skills.md) - 156 specialized skills across plugins
+- [Agent Skills](./agent-skills.md) - 158 specialized skills across plugins
 - [Agent Reference](./agents.md) - Complete agent catalog
 - [Usage Guide](./usage.md) - Commands and workflows
 - [Architecture](./architecture.md) - Design principles

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -385,11 +385,11 @@ User: "Implement Kubernetes deployment with Helm"
 → Result: Production-grade K8s manifests with Helm charts
 ```
 
-See [Agent Skills](./agent-skills.md) for details on the 156 specialized skills.
+See [Agent Skills](./agent-skills.md) for details on the 158 specialized skills.
 
 ## See Also
 
 - [Agent Skills](./agent-skills.md) - Specialized knowledge packages
 - [Agent Reference](./agents.md) - Complete agent catalog
-- [Plugin Reference](./plugins.md) - All 84 marketplace plugins
+- [Plugin Reference](./plugins.md) - All 85 marketplace plugins
 - [Architecture](./architecture.md) - Design principles

--- a/plugins/before-you-build/.claude-plugin/plugin.json
+++ b/plugins/before-you-build/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "before-you-build",
+  "version": "0.1.1",
+  "description": "Pre-build product risk review for founders, product teams, and AI-assisted builders before implementation starts.",
+  "author": {
+    "name": "bin1874",
+    "url": "https://github.com/bin1874/before-you-build-skill"
+  },
+  "license": "MIT"
+}

--- a/plugins/before-you-build/.codex-plugin/plugin.json
+++ b/plugins/before-you-build/.codex-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "before-you-build",
+  "version": "0.1.1",
+  "description": "Pre-build product risk review for founders, product teams, and AI-assisted builders before implementation starts.",
+  "skills": "./skills/",
+  "author": {
+    "name": "bin1874",
+    "url": "https://github.com/bin1874/before-you-build-skill"
+  },
+  "license": "MIT",
+  "interface": {
+    "displayName": "Before You Build",
+    "shortDescription": "Pre-build product risk review for founders, product teams, and AI-assisted builders before implementation starts.",
+    "category": "Coding"
+  }
+}

--- a/plugins/before-you-build/README.md
+++ b/plugins/before-you-build/README.md
@@ -1,0 +1,7 @@
+# Before You Build
+
+Before You Build is a markdown-only pre-mortem skill for checking product and feature risk before implementation starts.
+
+Use it when a user wants to build a landing page, MVP, SaaS product, internal tool, major feature, or agent workflow and needs a short product-risk verdict before spending engineering time.
+
+The upstream standalone skill lives at <https://github.com/bin1874/before-you-build-skill>.

--- a/plugins/before-you-build/skills/before-you-build/SKILL.md
+++ b/plugins/before-you-build/skills/before-you-build/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: before-you-build
+description: Pre-build product and feature risk review for founders, product managers, and AI-assisted builders. Use this skill when the user is about to build a landing page, MVP, SaaS product, internal tool, agent workflow, or major feature and needs to check demand, positioning, monetization, retention, trust, distribution, and adoption risk before implementation starts.
+---
+
+# Before You Build
+
+Run a compact pre-mortem before implementation. The goal is not to block building; it is to identify the highest-risk assumption, the smallest validation step, and the build scope that should be delayed until evidence improves.
+
+## When To Use
+
+Use this skill when a user asks to build or ship:
+
+- A new product, MVP, prototype, landing page, SaaS app, marketplace, content site, agent workflow, or internal tool
+- A major feature with unclear adoption, revenue, retention, trust, or distribution impact
+- A public launch asset where weak positioning could waste development or promotion effort
+
+Skip this skill when the task is a narrow implementation fix, refactor, test repair, dependency update, or already-validated change with clear acceptance criteria.
+
+## Risk Checklist
+
+Review the idea across these risks:
+
+- **Demand:** Is there evidence that a specific buyer or user urgently wants this?
+- **Positioning:** Can the target user understand what it is and why it matters in one sentence?
+- **Monetization:** Is there a credible path to payment, budget, or strategic value?
+- **Retention:** Is there a reason users would return after the first try?
+- **Trust:** Does the product require credibility, data access, integrations, or behavior change that users may resist?
+- **Distribution:** Is there a repeatable way to reach the target user?
+- **Feature adoption:** For feature work, will the feature change user behavior or just add surface area?
+
+If the verdict is not obvious, use `references/risk-checklist.md` for deeper questions.
+
+## Output Format
+
+Keep the response short and decision-oriented:
+
+1. **Risk verdict:** Low, medium, or high risk, with one sentence explaining why.
+2. **Main assumption:** The single assumption most likely to break the project.
+3. **Evidence to find first:** The smallest useful signal before building more.
+4. **Do next:** One concrete validation step or reduced build scope.
+5. **Delay:** What not to build yet.
+
+## Guidance
+
+- Be direct about weak evidence, but avoid dismissing the user's idea.
+- Prefer smaller validation steps over large research plans.
+- Separate product risk from engineering difficulty.
+- If the idea is already validated, say what evidence makes it lower risk and suggest the smallest implementation slice.
+- If facts are missing, name the missing evidence instead of inventing market claims.

--- a/plugins/before-you-build/skills/before-you-build/references/risk-checklist.md
+++ b/plugins/before-you-build/skills/before-you-build/references/risk-checklist.md
@@ -1,0 +1,45 @@
+# Risk Checklist
+
+Use these questions when the basic verdict is not obvious.
+
+## Demand
+
+- Who has the painful problem today?
+- What workaround are they using now?
+- What behavior shows urgency: payment, repeated manual work, switching tools, or asking for the same outcome more than once?
+
+## Positioning
+
+- Can the target user say what this is for without hearing the implementation details?
+- Is the promise tied to a concrete outcome rather than a broad category?
+- Does the idea have a clear alternative it must beat?
+
+## Monetization
+
+- Who controls the budget or time savings?
+- Is the value large enough to support the required build and maintenance cost?
+- Would the first useful version create enough value to justify payment, adoption, or internal sponsorship?
+
+## Retention
+
+- What makes the product useful after the first session?
+- Does it create a saved workflow, history, collaboration loop, or recurring decision?
+- Would users remember to come back without reminders?
+
+## Trust
+
+- What data, permissions, integrations, or behavior changes does this require?
+- What proof would make a cautious user comfortable trying it?
+- What failure would make the product feel unsafe or unserious?
+
+## Distribution
+
+- Where can the exact target user be reached repeatedly?
+- What existing channel, community, workflow, or integration can expose the product?
+- Is there a realistic path beyond one launch post?
+
+## Feature Adoption
+
+- What existing user behavior will this feature change?
+- Is the feature tied to an active user pain or just a product idea?
+- Can adoption be measured with one clear event?


### PR DESCRIPTION
## Summary
- Add a focused `before-you-build` single-skill plugin under `plugins/`
- Register it in the Claude, Codex, and Cursor marketplace metadata
- Update public catalog counts and Business / Agent Skills docs

## Validation
- `make generate-all`
- `make validate STRICT=1`
- `git diff --check`
- `uv run --project plugins/plugin-eval plugin-eval score plugins/before-you-build/skills/before-you-build --depth quick` (no anti-patterns detected)

Closes #565