### PR TITLE
defi-protocol-templates: align advertised use cases with delivered templates

### DIFF
--- a/plugins/blockchain-web3/skills/defi-protocol-templates/SKILL.md
+++ b/plugins/blockchain-web3/skills/defi-protocol-templates/SKILL.md
@@ -1,20 +1,18 @@
 ---
 name: defi-protocol-templates
-description: Implement DeFi protocols with production-ready templates for staking, AMMs, governance, and lending systems. Use when building decentralized finance applications or smart contract protocols.
+description: Implement DeFi protocols with production-ready templates for staking, AMMs, governance, and flash loans. Use when building decentralized finance applications or smart contract protocols.
 ---
 
 # DeFi Protocol Templates
 
-Production-ready templates for common DeFi protocols including staking, AMMs, governance, lending, and flash loans.
+Production-ready templates for common DeFi protocols including staking, AMMs, governance, and flash loans.
 
 ## When to Use This Skill
 
 - Building staking platforms with reward distribution
 - Implementing AMM (Automated Market Maker) protocols
 - Creating governance token systems
-- Developing lending/borrowing protocols
 - Integrating flash loan functionality
-- Launching yield farming platforms
 
 ## Staking Contract
 


### PR DESCRIPTION
Fixes https://github.com/wshobson/agents/issues/593.

The description and "When to Use" list advertised six use cases, but
only four template families actually ship (Staking + AMM in SKILL.md
and Governance + Flash Loan in `references/details.md`). Remove the
two undelivered entries — lending/borrowing and yield farming — from
the description, preamble, and use-case list so the advertised count
matches reality. Alternatively, add the two missing templates; this PR
takes the smaller "trim the description" path.