### PR TITLE
Bump meigen-ai-design to 1.0.9 (meigen@1.3.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -976,7 +976,7 @@
       "name": "meigen-ai-design",
       "source": "./plugins/meigen-ai-design",
       "description": "AI image generation with creative workflow orchestration, prompt engineering, and curated inspiration library via MCP server",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "author": {
         "name": "MeiGen",
         "url": "https://github.com/jau123"

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -618,7 +618,7 @@
     {
       "name": "meigen-ai-design",
       "source": "./plugins/meigen-ai-design",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "description": "AI image generation with creative workflow orchestration, parallel multi-direction output, prompt engineering, and a 1,300+ curated inspiration library. Requires MeiGen MCP server (supports MeiGen Cloud, local ComfyUI, and OpenAI-compatible APIs).",
       "author": {
         "name": "MeiGen",

--- a/.cursor-plugin/plugins/meigen-ai-design.json
+++ b/.cursor-plugin/plugins/meigen-ai-design.json
@@ -1,7 +1,7 @@
 {
   "name": "meigen-ai-design",
   "displayName": "Meigen Ai Design",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "AI image generation with creative workflow orchestration, parallel multi-direction output, prompt engineering, and a 1,300+ curated inspiration library. Requires MeiGen MCP server (supports MeiGen Cloud, local ComfyUI, and OpenAI-compatible APIs).",
   "author": {
     "name": "MeiGen",

--- a/plugins/meigen-ai-design/.claude-plugin/plugin.json
+++ b/plugins/meigen-ai-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "meigen-ai-design",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "AI image generation with creative workflow orchestration, parallel multi-direction output, prompt engineering, and a 1,300+ curated inspiration library. Requires MeiGen MCP server (supports MeiGen Cloud, local ComfyUI, and OpenAI-compatible APIs).",
   "author": {
     "name": "MeiGen",

--- a/plugins/meigen-ai-design/.codex-plugin/plugin.json
+++ b/plugins/meigen-ai-design/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "meigen-ai-design",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "AI image generation with creative workflow orchestration, parallel multi-direction output, prompt engineering, and a 1,300+ curated inspiration library. Requires MeiGen MCP server (supports MeiGen Cloud, local ComfyUI, and OpenAI-compatible APIs).",
   "skills": "./skills/",
   "author": {

--- a/plugins/meigen-ai-design/README.md
+++ b/plugins/meigen-ai-design/README.md
@@ -11,7 +11,7 @@ This plugin requires the **meigen** MCP server. Install it by adding to your pro
   "mcpServers": {
     "meigen": {
       "command": "npx",
-      "args": ["-y", "meigen@1.3.2"]
+      "args": ["-y", "meigen@1.3.3"]
     }
   }
 }


### PR DESCRIPTION
Updates the **meigen-ai-design** plugin to 1.0.9 and pins the MCP server to `meigen@1.3.3`.

Highlights in meigen@1.3.3:
- New models: **Grok Imagine Quality** (image) and **Grok Video 1.5** (image-to-video).
- **Seedance 2.0**: mini tier (cheapest default) + native **4K** on the pro tier.
- Model-capability doc fixes (per-tier resolutions, reference-video continuation).

Changes are limited to version bumps and the pinned `meigen@` version (marketplace entry, plugin manifest, plugin README). No other changes.