### PR TITLE
fix: plugin-eval judge silent-failure (#591) + review-agent-governance Cedar hardening (#598)

### DIFF
--- a/docs/plugin-eval.md
+++ b/docs/plugin-eval.md
@@ -91,7 +91,6 @@ uv run plugin-eval score path/to/skill --threshold 70
 | `--output` | `markdown` | `json`, `markdown`, `html` |
 | `--verbose` | `false` | Show detailed output |
 | `--concurrency` | `4` | Max concurrent LLM calls (1–20) |
-| `--auth` | `max` | Auth mode: `max` (Claude Code Max plan) or `api-key` |
 | `--threshold` | none | Minimum score; exit 1 if below |
 
 ### `certify` — Full certification with badge

--- a/docs/superpowers/plans/2026-06-25-open-issue-resolution.md
+++ b/docs/superpowers/plans/2026-06-25-open-issue-resolution.md
@@ -698,9 +698,11 @@ action "WebFetch" appliesTo {
 
 ```bash
 cd plugins/review-agent-governance/policies
-command -v cedar >/dev/null 2>&1 && \
-  cedar validate --policies review-agent-governance.cedar --schema review-agent-governance.cedarschema || \
+if command -v cedar >/dev/null 2>&1; then
+  cedar validate --policies review-agent-governance.cedar --schema review-agent-governance.cedarschema
+else
   echo "cedar CLI not present — schema is documentation/validation-only"
+fi
 ```
 Expected: `cedar validate` reports success (no validation errors), or the skip message. Note: the shipped hook uses `protect-mcp`, which may not consume this schema — its value is `cedar validate` + documentation.
 
@@ -822,7 +824,7 @@ git commit -m "test(review-agent-governance): guard against in-on-String forbid 
 - [ ] **Step 1: Full repo gates**
 
 ```bash
-cd /Users/wshobson/workspace/agents
+cd "$(git rev-parse --show-toplevel)"   # run from the repo root
 make test            # plugin-eval + tools — must pass
 make validate STRICT=1
 make garden

--- a/docs/superpowers/plans/2026-06-25-open-issue-resolution.md
+++ b/docs/superpowers/plans/2026-06-25-open-issue-resolution.md
@@ -1,0 +1,843 @@
+# Open-Issue Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the plugin-eval LLM-judge silent-failure bug (#591), harden the review-agent-governance Cedar policy (#598), and close the four stale/superseded issues (#579, #580, #570, #595).
+
+**Architecture:** Two independent code changes on branch `fix/issues-591-598`. (A) plugin-eval: correct the Agent-SDK message extraction, route genuine measurement failures through the engine's existing "unmeasured" path instead of fabricating 0.5, and drop dead config. (B) review-agent-governance: rewrite `in`-on-String forbid rules to validator-clean `.contains()`, add a `.cedarschema`, and add a graceful-skip round-trip test. Triage closes are outward-facing and happen last, only with maintainer approval.
+
+**Tech Stack:** Python 3.12, `claude-agent-sdk` 0.2.101, pytest + pytest-asyncio, `uv`; Cedar policy language via `protect-mcp@0.5.5` (npx).
+
+## Global Constraints
+
+- Python tooling is **uv / ruff / ty** — never pip/black/mypy. Run commands from `plugins/plugin-eval/` as `uv run --project . pytest ...` or repo-root `make test`.
+- Do not change generated harness artifacts by hand; none of these changes affect them, but run `make generate-all` at the end to confirm zero drift.
+- `claude-agent-sdk` message types: `AssistantMessage(content: list, model: str, ...)`, `TextBlock(text: str)`, `ResultMessage(subtype, duration_ms, duration_api_ms, is_error, num_turns, session_id, ..., result: str|None, structured_output, ...)`. `ResultMessage` has **no** `content` attribute — that is the bug.
+- The composite engine treats a dimension as **unmeasured** when its key is **absent** from a layer's `sub_scores` (see `engine.py:_blend_layer_scores`, the `if dim in judge_scores` guard) or when the blended value is `< 0.0`. "Unmeasured" is therefore expressed by **omitting the key**, not by writing a 0.
+- Outward-facing GitHub actions (issue closes, the #598 reply) are posted **only after explicit maintainer approval**.
+
+---
+
+## Phase A — #591: plugin-eval judge silent-failure fix
+
+### Task 1: Correct message extraction + unmeasured signal in `query_llm`
+
+**Files:**
+- Modify: `plugins/plugin-eval/src/plugin_eval/layers/judge.py` (`query_llm`, ~L55-98; add a pure helper `_extract_and_parse`)
+- Test: `plugins/plugin-eval/tests/test_judge.py`
+
+**Interfaces:**
+- Produces: `_extract_and_parse(messages: list) -> dict` — returns the parsed JSON dict on success, or `{"unmeasured": True, "error": str, "raw": str}` when the run errored / produced no text / was not valid JSON. `query_llm(prompt, system="", model=...) -> dict` keeps its signature but now returns an `unmeasured` dict instead of raising on missing SDK / call failure.
+
+- [ ] **Step 1: Write the failing tests** (append to `tests/test_judge.py`)
+
+```python
+from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
+from plugin_eval.layers.judge import _extract_and_parse
+
+
+def _assistant(text: str) -> AssistantMessage:
+    return AssistantMessage(content=[TextBlock(text=text)], model="claude-sonnet-4-6")
+
+
+def _result(*, is_error: bool = False, result: str | None = None) -> ResultMessage:
+    return ResultMessage(
+        subtype="success" if not is_error else "error",
+        duration_ms=1,
+        duration_api_ms=1,
+        is_error=is_error,
+        num_turns=1,
+        session_id="t",
+        result=result,
+    )
+
+
+class TestExtractAndParse:
+    def test_parses_assistant_text_json(self):
+        msgs = [_assistant('{"f1": 1.0}'), _result(result="ignored")]
+        assert _extract_and_parse(msgs) == {"f1": 1.0}
+
+    def test_parses_json_in_code_fence(self):
+        msgs = [_assistant('```json\n{"score": 0.8}\n```'), _result()]
+        assert _extract_and_parse(msgs) == {"score": 0.8}
+
+    def test_falls_back_to_result_field_when_no_assistant_text(self):
+        msgs = [_result(result='{"score": 0.7}')]
+        assert _extract_and_parse(msgs) == {"score": 0.7}
+
+    def test_errored_result_is_unmeasured(self):
+        msgs = [_result(is_error=True)]
+        out = _extract_and_parse(msgs)
+        assert out["unmeasured"] is True
+
+    def test_empty_output_is_unmeasured(self):
+        assert _extract_and_parse([_result()])["unmeasured"] is True
+
+    def test_non_json_is_unmeasured(self):
+        out = _extract_and_parse([_assistant("not json at all"), _result()])
+        assert out["unmeasured"] is True
+        assert out["raw"] == "not json at all"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd plugins/plugin-eval && uv run --project . pytest tests/test_judge.py::TestExtractAndParse -v`
+Expected: FAIL with `ImportError: cannot import name '_extract_and_parse'`.
+
+- [ ] **Step 3: Implement the helper and rewrite `query_llm`**
+
+Replace the body of `query_llm` (judge.py ~L55-98) with:
+
+```python
+def _extract_and_parse(messages: list) -> dict:
+    """Pull assistant text from SDK messages and parse JSON.
+
+    Returns the parsed dict on success, or an {"unmeasured": True, ...} marker
+    when the run errored, produced no text, or returned non-JSON.
+    """
+    from claude_agent_sdk import (  # type: ignore[import-untyped]
+        AssistantMessage,
+        ResultMessage,
+        TextBlock,
+    )
+
+    text = ""
+    fallback = ""
+    errored = False
+    for message in messages:
+        if isinstance(message, AssistantMessage):
+            for block in message.content:
+                if isinstance(block, TextBlock):
+                    text += block.text
+        elif isinstance(message, ResultMessage):
+            if message.is_error:
+                errored = True
+            if message.result:
+                fallback = message.result
+
+    raw = text or fallback
+    if errored:
+        return {"unmeasured": True, "error": "judge LLM call returned an error result"}
+    if not raw.strip():
+        return {"unmeasured": True, "error": "judge LLM returned no text"}
+
+    stripped = raw.strip()
+    fence_match = re.search(r"```(?:json)?\s*([\s\S]+?)\s*```", stripped)
+    if fence_match:
+        stripped = fence_match.group(1).strip()
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        return {"unmeasured": True, "error": "judge response was not valid JSON", "raw": raw}
+
+
+async def query_llm(prompt: str, system: str = "", model: str = "claude-sonnet-4-6") -> dict:
+    """Call Claude via the Agent SDK and return a parsed JSON dict.
+
+    Degrades to an {"unmeasured": True, ...} marker (never raises) when the SDK
+    is missing or the call fails, so the judge layer can be skipped instead of
+    crashing the whole evaluation.
+    """
+    try:
+        from claude_agent_sdk import (  # type: ignore[import-untyped]
+            ClaudeAgentOptions,
+            query,
+        )
+    except ImportError:
+        return {
+            "unmeasured": True,
+            "error": "claude-agent-sdk not installed (uv sync --extra llm)",
+        }
+
+    full_prompt = f"{system}\n\n{prompt}" if system else prompt
+    try:
+        messages = [
+            message
+            async for message in query(
+                prompt=full_prompt,
+                options=ClaudeAgentOptions(model=model, allowed_tools=[]),
+            )
+        ]
+    except Exception as exc:  # noqa: BLE001 — judge is best-effort; degrade to unmeasured
+        return {"unmeasured": True, "error": f"judge LLM call failed: {exc}"}
+
+    return _extract_and_parse(messages)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd plugins/plugin-eval && uv run --project . pytest tests/test_judge.py::TestExtractAndParse -v`
+Expected: PASS (6 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/plugin-eval/src/plugin_eval/layers/judge.py plugins/plugin-eval/tests/test_judge.py
+git commit -m "fix(plugin-eval): read judge LLM text from AssistantMessage/ResultMessage (#591)
+
+ResultMessage has no .content attribute, so the judge always read empty
+text and silently fell back to 0.5. Extract from AssistantMessage TextBlocks
+with ResultMessage.result fallback; mark errored/empty/non-JSON as unmeasured."
+```
+
+---
+
+### Task 2: Propagate "unmeasured" through `JudgeAnalyzer.analyze_skill`
+
+**Files:**
+- Modify: `plugins/plugin-eval/src/plugin_eval/layers/judge.py` (`analyze_skill`, ~L130-168; add helper `_measured_score`)
+- Test: `plugins/plugin-eval/tests/test_judge.py`
+
+**Interfaces:**
+- Consumes: assessment dicts from `assess_*` (each is `query_llm`'s return — either real JSON or `{"unmeasured": True}`).
+- Produces: `LayerResult(layer="judge", score, sub_scores, metadata)` where `sub_scores` contains **only measured** dimensions (unmeasured keys omitted), and `metadata["unmeasured"]` is a sorted list of the dimension names that could not be measured.
+
+- [ ] **Step 1: Write the failing tests** (append to `tests/test_judge.py`)
+
+```python
+class TestUnmeasuredPropagation:
+    @pytest.mark.asyncio
+    @patch("plugin_eval.layers.judge.query_llm")
+    async def test_all_unmeasured_yields_empty_sub_scores(self, mock_query, sample_skill_dir: Path):
+        mock_query.return_value = {"unmeasured": True, "error": "no text"}
+        analyzer = JudgeAnalyzer(JudgeConfig())
+        result = await analyzer.analyze_skill(sample_skill_dir)
+        assert result.sub_scores == {}
+        assert result.score == 0.0
+        assert set(result.metadata["unmeasured"]) == {
+            "triggering_accuracy",
+            "orchestration_fitness",
+            "output_quality",
+            "scope_calibration",
+        }
+
+    @pytest.mark.asyncio
+    @patch("plugin_eval.layers.judge.query_llm")
+    async def test_partial_measurement_omits_only_failed(self, mock_query, sample_skill_dir: Path):
+        mock_query.side_effect = [
+            {"f1": 0.9, "predictions": []},          # triggering measured
+            {"unmeasured": True, "error": "x"},       # orchestration failed
+            {"score": 0.8, "simulations": []},        # output measured
+            {"unmeasured": True, "error": "x"},       # scope failed
+        ]
+        analyzer = JudgeAnalyzer(JudgeConfig())
+        result = await analyzer.analyze_skill(sample_skill_dir)
+        assert set(result.sub_scores) == {"triggering_accuracy", "output_quality"}
+        assert result.sub_scores["triggering_accuracy"] == 0.9
+        assert set(result.metadata["unmeasured"]) == {"orchestration_fitness", "scope_calibration"}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd plugins/plugin-eval && uv run --project . pytest tests/test_judge.py::TestUnmeasuredPropagation -v`
+Expected: FAIL (current code defaults missing scores to 0.5, so `sub_scores` is never empty and there is no `metadata["unmeasured"]`).
+
+- [ ] **Step 3: Implement** — replace the composite/sub_scores/return block in `analyze_skill` (judge.py ~L140-168) with:
+
+```python
+        raw_scores: dict[str, float | None] = {
+            "triggering_accuracy": _measured_score(triggering, "f1"),
+            "orchestration_fitness": _measured_score(orchestration, "score"),
+            "output_quality": _measured_score(output_quality, "score"),
+            "scope_calibration": _measured_score(scope, "score"),
+        }
+        sub_scores: dict[str, float] = {k: v for k, v in raw_scores.items() if v is not None}
+        unmeasured = sorted(k for k, v in raw_scores.items() if v is None)
+
+        # Layer score is display-only; the composite engine blends per-dimension
+        # sub_scores (omitted keys are excluded). Use the mean of measured dims.
+        score = sum(sub_scores.values()) / len(sub_scores) if sub_scores else 0.0
+
+        metadata: dict = {
+            "triggering": triggering,
+            "orchestration": orchestration,
+            "output_quality": output_quality,
+            "scope": scope,
+            "unmeasured": unmeasured,
+        }
+
+        return LayerResult(
+            layer="judge",
+            score=score,
+            sub_scores=sub_scores,
+            metadata=metadata,
+        )
+```
+
+Add this helper just above the `JudgeAnalyzer` class (after `query_llm` / `_extract_and_parse`):
+
+```python
+def _measured_score(result: dict, key: str) -> float | None:
+    """Return the numeric score for an assessment, or None if it was unmeasured."""
+    if result.get("unmeasured"):
+        return None
+    val = result.get(key)
+    return float(val) if isinstance(val, (int, float)) else None
+```
+
+- [ ] **Step 4: Run to verify they pass** (and the existing judge tests still pass)
+
+Run: `cd plugins/plugin-eval && uv run --project . pytest tests/test_judge.py -v`
+Expected: PASS. Note: the existing `test_full_analysis` asserts `result.score > 0` — still true (all four measured).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/plugin-eval/src/plugin_eval/layers/judge.py plugins/plugin-eval/tests/test_judge.py
+git commit -m "fix(plugin-eval): omit unmeasured judge dimensions instead of scoring 0.5 (#591)"
+```
+
+---
+
+### Task 3: Fix the same extraction bug in Monte Carlo `run_simulation`
+
+**Files:**
+- Modify: `plugins/plugin-eval/src/plugin_eval/layers/monte_carlo.py` (`run_simulation`, ~L53-111; add helper `_simresult_from_messages`)
+- Test: `plugins/plugin-eval/tests/test_monte_carlo.py`
+
+**Interfaces:**
+- Produces: `_simresult_from_messages(messages: list, prompt: str, duration_ms: int) -> SimResult` — `activated` is True iff assistant text was produced; `quality_score = min(1.0, len(text)/500)`; `errored` True iff a `ResultMessage.is_error`.
+
+- [ ] **Step 1: Write the failing test** (append to `tests/test_monte_carlo.py`)
+
+```python
+from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
+from plugin_eval.layers.monte_carlo import _simresult_from_messages
+
+
+def _assistant(text: str) -> AssistantMessage:
+    return AssistantMessage(content=[TextBlock(text=text)], model="claude-sonnet-4-6")
+
+
+def _result(*, is_error: bool = False) -> ResultMessage:
+    return ResultMessage(
+        subtype="success" if not is_error else "error",
+        duration_ms=1, duration_api_ms=1, is_error=is_error, num_turns=1, session_id="t",
+    )
+
+
+class TestSimResultFromMessages:
+    def test_activated_when_assistant_text_present(self):
+        sim = _simresult_from_messages([_assistant("x" * 250), _result()], "p", 10)
+        assert sim.activated is True
+        assert sim.quality_score == 0.5
+        assert sim.errored is False
+
+    def test_not_activated_when_no_text(self):
+        sim = _simresult_from_messages([_result()], "p", 10)
+        assert sim.activated is False
+        assert sim.quality_score == 0.0
+
+    def test_errored_result_flagged(self):
+        sim = _simresult_from_messages([_result(is_error=True)], "p", 10)
+        assert sim.errored is True
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd plugins/plugin-eval && uv run --project . pytest tests/test_monte_carlo.py::TestSimResultFromMessages -v`
+Expected: FAIL with `ImportError: cannot import name '_simresult_from_messages'`.
+
+- [ ] **Step 3: Implement** — add the helper above `run_simulation` and rewrite the message loop. Replace `run_simulation` body (monte_carlo.py ~L53-111) with:
+
+```python
+def _simresult_from_messages(messages: list, prompt: str, duration_ms: int) -> SimResult:
+    """Build a SimResult from SDK messages (assistant text => activation + quality)."""
+    from claude_agent_sdk import (  # type: ignore[import-untyped]
+        AssistantMessage,
+        ResultMessage,
+        TextBlock,
+    )
+
+    text = ""
+    tokens = 0
+    errored = False
+    for message in messages:
+        if isinstance(message, AssistantMessage):
+            for block in message.content:
+                if isinstance(block, TextBlock):
+                    text += block.text
+        elif isinstance(message, ResultMessage):
+            if message.is_error:
+                errored = True
+            if isinstance(message.usage, dict):
+                tokens = message.usage.get("total_tokens", tokens)
+
+    activated = bool(text)
+    quality_score = min(1.0, len(text) / 500) if activated else 0.0
+    return SimResult(
+        activated=activated,
+        quality_score=quality_score,
+        tokens=tokens,
+        duration_ms=duration_ms,
+        errored=errored,
+        prompt=prompt,
+    )
+
+
+async def run_simulation(skill_content: str, prompt: str) -> SimResult:
+    """Run a single simulation via Agent SDK. Returns SimResult. On error, errored=True."""
+    try:
+        import time
+
+        from claude_agent_sdk import (  # type: ignore[import-untyped]
+            ClaudeAgentOptions,
+            query,
+        )
+
+        full_prompt = (
+            f"You are evaluating a skill. Apply the skill if appropriate.\n\n"
+            f"{skill_content}\n\n{prompt}"
+        )
+        start = time.monotonic()
+        messages = [
+            message
+            async for message in query(
+                prompt=full_prompt,
+                options=ClaudeAgentOptions(allowed_tools=[]),
+            )
+        ]
+        duration_ms = int((time.monotonic() - start) * 1000)
+        return _simresult_from_messages(messages, prompt, duration_ms)
+    except Exception:  # noqa: BLE001 — a failed run is recorded as errored, not fatal
+        return SimResult(
+            activated=False,
+            quality_score=0.0,
+            tokens=0,
+            duration_ms=0,
+            errored=True,
+            prompt=prompt,
+        )
+```
+
+Note the signature change: `run_simulation(skill_content, prompt)` — the `auth` parameter is removed (Task 4 removes its only call-site argument).
+
+- [ ] **Step 4: Update the call site** — `monte_carlo.py:248`, change `run_simulation(skill_content, prompt, self.config.auth)` to `run_simulation(skill_content, prompt)`.
+
+- [ ] **Step 5: Run to verify it passes** (and existing MC tests still pass)
+
+Run: `cd plugins/plugin-eval && uv run --project . pytest tests/test_monte_carlo.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/plugin-eval/src/plugin_eval/layers/monte_carlo.py plugins/plugin-eval/tests/test_monte_carlo.py
+git commit -m "fix(plugin-eval): fix Monte Carlo SDK message extraction (#591)"
+```
+
+---
+
+### Task 4: Remove dead `auth` / `model_tier` config
+
+**Files:**
+- Modify: `plugins/plugin-eval/src/plugin_eval/models.py` (`EvalConfig`, L39 + L43)
+- Modify: `plugins/plugin-eval/src/plugin_eval/layers/judge.py` (`JudgeConfig`, L109 + L111)
+- Modify: `plugins/plugin-eval/src/plugin_eval/layers/monte_carlo.py` (`MonteCarloConfig`, L43)
+- Modify: `plugins/plugin-eval/src/plugin_eval/engine.py` (L86, L101 — drop `auth=` args)
+- Modify: `plugins/plugin-eval/src/plugin_eval/cli.py` (remove `--auth` from `score`/`certify`, `_run_score` param, and `EvalConfig(...)`)
+- Modify: `plugins/plugin-eval/tests/test_judge.py` (L13) and `tests/test_models.py` (L24) — drop the `auth` assertions
+- Modify: `docs/plugin-eval.md` (L94 — remove the `--auth` row)
+
+**Interfaces:**
+- Produces: `EvalConfig`, `JudgeConfig`, `MonteCarloConfig` without `auth`/`model_tier`; `_run_score(path, depth, output, verbose, concurrency, threshold)` (no `auth` param); `score`/`certify` commands without `--auth`.
+
+- [ ] **Step 1: Update the failing-config tests first** (they currently assert removed fields)
+
+In `tests/test_judge.py`, the `test_default_config` body becomes:
+```python
+    def test_default_config(self):
+        config = JudgeConfig()
+        assert config.judges == 1
+        assert config.concurrency == 4
+```
+In `tests/test_models.py:24`, remove the line `assert config.auth == "max"` (keep the rest of that test).
+
+- [ ] **Step 2: Run to verify the suite fails on the new expectation**
+
+Run: `cd plugins/plugin-eval && uv run --project . pytest tests/test_judge.py::TestJudgeConfig tests/test_models.py -v`
+Expected: PASS for the edited asserts is not yet possible — they still reference `auth` in source via defaults; run to confirm current state, then proceed. (If green already, that's fine — these asserts just stop checking `auth`.)
+
+- [ ] **Step 3: Remove the fields and arguments**
+
+- `models.py`: delete `model_tier: str = "auto"` (L39) and `auth: str = "max"` (L43) from `EvalConfig`.
+- `judge.py` `JudgeConfig`: delete `auth: str = "max"` and `model_tier: str = "auto"`, leaving:
+  ```python
+  @dataclass
+  class JudgeConfig:
+      judges: int = 1
+      concurrency: int = 4
+  ```
+- `monte_carlo.py` `MonteCarloConfig`: delete `auth: str = "max"`.
+- `engine.py`: `JudgeConfig(judges=self.config.judges, auth=self.config.auth, concurrency=self.config.concurrency)` → drop `auth=` (L86). `MonteCarloConfig(n_runs=n_runs, concurrency=self.config.concurrency, auth=self.config.auth)` → drop `auth=` (L101).
+- `cli.py`: in `_run_score` remove the `auth: str` parameter (L38) and remove `auth=auth` from `EvalConfig(...)` (L51). In `score` (L99) and `certify` (L116) remove the `auth` typer.Option; update the calls (L105, L120) to `_run_score(path, depth, output, verbose, concurrency, threshold)` / `_run_score(path, Depth.DEEP, output, verbose, concurrency, threshold)`.
+- `docs/plugin-eval.md`: delete the `| `--auth` | ... |` table row (L94).
+
+- [ ] **Step 4: Run the full plugin-eval suite + lint + type check**
+
+Run: `cd plugins/plugin-eval && uv run --project . pytest -q && uv run --project . ruff check src tests && uv run --project . ruff format --check src tests`
+Expected: all pass, no ruff findings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/plugin-eval/src docs/plugin-eval.md plugins/plugin-eval/tests
+git commit -m "refactor(plugin-eval): remove dead auth/model_tier config (#591)"
+```
+
+---
+
+### Task 5: Surface a stderr warning when the judge is unmeasured
+
+**Files:**
+- Modify: `plugins/plugin-eval/src/plugin_eval/cli.py` (`_run_score`, after the report is produced, before the threshold check)
+- Test: `plugins/plugin-eval/tests/test_cli.py`
+
+**Interfaces:**
+- Consumes: `result.layers` (the judge `LayerResult` with `metadata["unmeasured"]` from Task 2).
+
+- [ ] **Step 1: Write the failing test** (append to `tests/test_cli.py`)
+
+```python
+from typer.testing import CliRunner
+from unittest.mock import patch
+from plugin_eval.cli import app
+from plugin_eval.models import (
+    CompositeResult, Depth, EvalConfig, LayerResult, PluginEvalResult,
+)
+
+
+def test_score_warns_when_judge_unmeasured(sample_skill_dir, tmp_path):
+    fake = PluginEvalResult(
+        plugin_path=str(sample_skill_dir),
+        timestamp="t",
+        config=EvalConfig(depth=Depth.STANDARD),
+        layers=[
+            LayerResult(layer="static", score=0.8, sub_scores={}),
+            LayerResult(layer="judge", score=0.0, sub_scores={},
+                        metadata={"unmeasured": ["triggering_accuracy", "output_quality"]}),
+        ],
+        composite=CompositeResult(score=60.0),
+    )
+    with patch("plugin_eval.cli.EvalEngine") as Eng:
+        Eng.return_value.evaluate_skill.return_value = fake
+        result = CliRunner(mix_stderr=False).invoke(
+            app, ["score", str(sample_skill_dir), "--output", "json"]
+        )
+    assert result.exit_code == 0
+    assert "judge" in result.stderr.lower()
+    assert "unmeasured" in result.stderr.lower() or "could not" in result.stderr.lower()
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd plugins/plugin-eval && uv run --project . pytest tests/test_cli.py::test_score_warns_when_judge_unmeasured -v`
+Expected: FAIL (no warning emitted).
+
+- [ ] **Step 3: Implement** — in `cli.py` `_run_score`, immediately after the `reporter`/`typer.echo` output block (after L80, before the threshold check at L82) add:
+
+```python
+    judge_layer = next((lr for lr in result.layers if lr.layer == "judge"), None)
+    if judge_layer is not None:
+        unmeasured = judge_layer.metadata.get("unmeasured") or []
+        if unmeasured:
+            stderr_console.print(
+                f"[yellow]warning:[/yellow] LLM judge could not measure "
+                f"{', '.join(unmeasured)}; composite computed from the remaining "
+                f"layers. Check that claude-agent-sdk is installed and a model is "
+                f"configured (run with --verbose for details)."
+            )
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd plugins/plugin-eval && uv run --project . pytest tests/test_cli.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/plugin-eval/src/plugin_eval/cli.py plugins/plugin-eval/tests/test_cli.py
+git commit -m "feat(plugin-eval): warn on stderr when the LLM judge is unmeasured (#591)"
+```
+
+---
+
+## Phase B — #598: review-agent-governance Cedar hardening
+
+### Task 6: Live-verify the real engine's behavior
+
+**Files:** none (investigation; records the result that gates Task 10's reply wording).
+
+- [ ] **Step 1: Run a deny-case and a permit-case through the real evaluator**
+
+```bash
+cd plugins/review-agent-governance/policies
+# Deny case — should exit 2 if the gate fires:
+npx --yes protect-mcp@0.5.5 evaluate \
+  --policy review-agent-governance.cedar \
+  --tool Bash \
+  --input '{"command":"gh pr merge 123 --squash"}' \
+  --fail-on-missing-policy false; echo "exit=$?"
+# Permit case — should exit 0:
+npx --yes protect-mcp@0.5.5 evaluate \
+  --policy review-agent-governance.cedar \
+  --tool Bash \
+  --input '{"command":"ls -la"}' \
+  --fail-on-missing-policy false; echo "exit=$?"
+```
+
+- [ ] **Step 2: Record the outcome and decide severity**
+
+- If deny→`exit=2` and permit→`exit=0`: gates work → #598 is a **false positive** for the shipped engine. Severity: informational. Proceed; the rewrite is still adopted as hardening.
+- If deny→`exit=0`: the disclosure is **correct** → severity **HIGH**. The rewrite (Task 7) becomes the priority fix and the reply credits a real vulnerability.
+- If `npx`/network unavailable in this environment: do not guess — surface the exact two commands above for the maintainer to run via `!`, and hold Task 10's reply until the result is known.
+
+- [ ] **Step 3: No commit** (record the result in the PR description / Task 10 draft).
+
+---
+
+### Task 7: Rewrite the 5 forbid rules to `.contains()`
+
+**Files:**
+- Modify: `plugins/review-agent-governance/policies/review-agent-governance.cedar`
+
+- [ ] **Step 1: Rewrite each `context.<attr> in [ ... ]` to `[ ... ].contains(context.<attr>)`.** The five edits:
+
+```cedar
+// Rule 1
+} when {
+    ["gh pr review", "gh pr comment", "gh pr close", "gh pr merge", "gh pr edit",
+     "gh issue comment", "gh issue close", "gh issue edit", "gh release create",
+     "gh release edit", "gh api repos"].contains(context.command_pattern)
+};
+
+// Rule 2
+} when {
+    ["glab mr comment", "glab mr approve", "glab mr merge",
+     "glab issue comment"].contains(context.command_pattern)
+};
+
+// Rule 3
+} when {
+    ["git push", "git push --force", "git push -f"].contains(context.command_pattern) &&
+    ["main", "master", "release", "production"].contains(context.target_branch)
+};
+
+// Rule 4
+} when {
+    [".github/workflows/", ".github/CODEOWNERS", ".gitlab-ci.yml",
+     ".circleci/config.yml", "buildkite/pipeline.yml"].contains(context.path_starts_with)
+};
+
+// Rule 5
+} when {
+    context.method == "POST" &&
+    ["api.github.com", "api.gitlab.com", "api.bitbucket.org",
+     "hooks.slack.com", "discord.com"].contains(context.url_host)
+};
+```
+
+Keep all comments and the terminal `permit (principal, action, resource);` unchanged.
+
+- [ ] **Step 2: Re-run the Task 6 deny/permit commands to confirm behavior is unchanged-or-fixed**
+
+Run the two `npx ... evaluate` commands from Task 6 against the rewritten policy.
+Expected: deny→`exit=2`, permit→`exit=0`. (If Task 6 showed the gates were already working, this confirms no regression; if it showed them broken, this confirms the fix.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/review-agent-governance/policies/review-agent-governance.cedar
+git commit -m "fix(review-agent-governance): use set .contains() instead of in-on-String in forbid rules (#598)
+
+context.<attr> in [strings] is a type error under standard Cedar (in expects
+an entity LHS) and is silently discarded, which would disable the gate. Rewrite
+to [strings].contains(context.<attr>), which validates and is portable."
+```
+
+---
+
+### Task 8: Add a `.cedarschema` typing the context attributes
+
+**Files:**
+- Create: `plugins/review-agent-governance/policies/review-agent-governance.cedarschema`
+
+- [ ] **Step 1: Write the schema** declaring the actions and their String context attributes, so `cedar validate` flags any future `in`-on-String mistake at load time.
+
+```cedarschema
+entity User;
+entity Resource;
+
+action "Bash" appliesTo {
+  principal: [User],
+  resource: [Resource],
+  context: { command_pattern: String, target_branch: String }
+};
+
+action "Write" appliesTo {
+  principal: [User],
+  resource: [Resource],
+  context: { path_starts_with: String }
+};
+
+action "Edit" appliesTo {
+  principal: [User],
+  resource: [Resource],
+  context: { path_starts_with: String }
+};
+
+action "WebFetch" appliesTo {
+  principal: [User],
+  resource: [Resource],
+  context: { method: String, url_host: String }
+};
+```
+
+- [ ] **Step 2: Validate the policy against the schema if the `cedar` CLI is available** (best-effort; document the command in the policy folder README later)
+
+```bash
+cd plugins/review-agent-governance/policies
+command -v cedar >/dev/null 2>&1 && \
+  cedar validate --policies review-agent-governance.cedar --schema review-agent-governance.cedarschema || \
+  echo "cedar CLI not present — schema is documentation/validation-only"
+```
+Expected: `cedar validate` reports success (no validation errors), or the skip message. Note: the shipped hook uses `protect-mcp`, which may not consume this schema — its value is `cedar validate` + documentation.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/review-agent-governance/policies/review-agent-governance.cedarschema
+git commit -m "feat(review-agent-governance): add cedarschema typing context attrs as String (#598)"
+```
+
+---
+
+### Task 9: Add a graceful-skip deny/permit round-trip test
+
+**Files:**
+- Create: `plugins/review-agent-governance/test/run-tests.sh` (executable)
+- Create: `plugins/review-agent-governance/test/fixtures/deny-gh-pr-merge.json`
+- Create: `plugins/review-agent-governance/test/fixtures/permit-ls.json`
+- Create: `plugins/review-agent-governance/test/README.md`
+
+**Interfaces:** mirrors `plugins/protect-mcp/test/run-tests.sh` conventions — exit `0` all pass, `1` a failure, `77` tools missing (treated as skipped).
+
+- [ ] **Step 1: Create the fixtures**
+
+`fixtures/deny-gh-pr-merge.json`:
+```json
+{ "tool_name": "Bash", "tool_input": { "command": "gh pr merge 123 --squash" } }
+```
+`fixtures/permit-ls.json`:
+```json
+{ "tool_name": "Bash", "tool_input": { "command": "ls -la" } }
+```
+
+- [ ] **Step 2: Create `test/run-tests.sh`** (mirrors protect-mcp's preflight + check_exit)
+
+```bash
+#!/usr/bin/env bash
+# run-tests.sh — exercise review-agent-governance.cedar against protect-mcp.
+# Exit codes: 0 pass, 1 fail, 77 required tools missing (skipped).
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+POLICY="../policies/review-agent-governance.cedar"
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "SKIP: '$1' not found."; exit 77; }; }
+need node; need npx; need python3
+
+PASS=0; FAIL=0
+pass() { echo "PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL+1)); }
+check_exit() { if [ "$1" -eq "$2" ]; then pass "$3"; else fail "$3 (exit $1, expected $2)"; fi; }
+tool() { python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["tool_name"])' "$1"; }
+inp() { python3 -c 'import json,sys;print(json.dumps(json.load(open(sys.argv[1]))["tool_input"]))' "$1"; }
+
+run() {
+  npx --yes protect-mcp@0.5.5 evaluate --policy "$POLICY" \
+    --tool "$(tool "$1")" --input "$(inp "$1")" --fail-on-missing-policy false >/dev/null 2>&1
+}
+
+echo "=== Deny: gh pr merge ==="
+run fixtures/deny-gh-pr-merge.json; check_exit $? 2 "gh pr merge is denied (exit 2)"
+
+echo "=== Permit: ls ==="
+run fixtures/permit-ls.json; check_exit $? 0 "ls is permitted (exit 0)"
+
+echo ""; echo "Passed: $PASS, Failed: $FAIL"
+[ "$FAIL" -eq 0 ] || exit 1
+```
+
+- [ ] **Step 3: Create `test/README.md`** documenting that the test requires node/npx/network and skips (exit 77) otherwise, mirroring `plugins/protect-mcp/test/README.md`.
+
+```markdown
+# review-agent-governance policy tests
+
+Round-trip deny/permit checks for `policies/review-agent-governance.cedar`,
+evaluated with `protect-mcp@0.5.5` (the engine the plugin's hook uses).
+
+```bash
+./run-tests.sh   # exit 0 pass · 1 fail · 77 tools missing (skipped)
+```
+
+Requires `node` (>=18), `npx`, and network access on first run.
+```
+
+- [ ] **Step 4: Make executable and run**
+
+```bash
+chmod +x plugins/review-agent-governance/test/run-tests.sh
+plugins/review-agent-governance/test/run-tests.sh; echo "suite exit=$?"
+```
+Expected: `exit=0` (both checks pass) where npx/network are available, or `exit=77` (skipped) otherwise. A `1` means the gate is not firing — escalate per Task 6.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/review-agent-governance/test
+git commit -m "test(review-agent-governance): add deny/permit round-trip test (skips without npx) (#598)"
+```
+
+---
+
+## Phase C — Integration + triage closes
+
+### Task 10: Final gates, PR, and the outward-facing closes/reply
+
+**Files:** none (verification + GitHub actions).
+
+- [ ] **Step 1: Full repo gates**
+
+```bash
+cd /Users/wshobson/workspace/agents
+make test            # plugin-eval + tools — must pass
+make validate STRICT=1
+make garden
+make generate-all && git status --porcelain   # expect: empty (no harness drift)
+```
+Expected: all pass; drift check prints nothing.
+
+- [ ] **Step 2: Open the PR** for `fix/issues-591-598` summarizing both fixes; reference issues #591 and #598. Do not merge without maintainer approval.
+
+- [ ] **Step 3: Draft the outward-facing actions (post only after explicit maintainer approval).**
+
+- **#591** — comment that the fix landed in the PR (judge now reads `AssistantMessage`/`ResultMessage` correctly, surfaces "unmeasured" instead of fake 0.5, removed dead config); thank lkjie; close when the PR merges.
+- **#598** — reply using the Task 6 result. If false positive: thank matiaszabal, explain the shipped engine is `protect-mcp@0.5.5` (their test used vanilla `cedar-policy 4.8.2`), note we adopted `.contains()` + a schema + a round-trip test as hardening, and reference `cedar-policy/cedar#2428`. If confirmed: credit a real high-severity finding and point to the fix PR. Close when the PR merges.
+- **#579** — close: fixed by the format-modernization commit (`4820385`); current marketplace carries no `strict`/component arrays. Ask the reporter to update the marketplace / unpin from 1.0.1/1.2.x.
+- **#580** — close: same modernization; `shell-scripting` is now 1.2.3 with auto-discovery and the skills load. Ask them to update.
+- **#570** — close as converted to PR #577 (trimmed 3-skill version); tracking moves there.
+- **#595** — close as converted to PR #596; tracking moves there.
+
+- [ ] **Step 4: No commit** (GitHub state only).
+
+---
+
+## Self-Review
+
+**Spec coverage:** #591 extraction fix (Tasks 1, 3) ✓; unmeasured-not-0.5 (Tasks 2, 5) ✓; remove dead config (Task 4) ✓; non-mocked extraction tests (Tasks 1, 3) ✓. #598 live-verify (Task 6) ✓; `.contains()` rewrite (Task 7) ✓; `.cedarschema` (Task 8) ✓; round-trip test (Task 9) ✓; severity-gated reply (Task 10) ✓. Triage closes #579/#580/#570/#595 (Task 10) ✓.
+
+**Placeholder scan:** none — every code/test/command step contains concrete content.
+
+**Type consistency:** `_extract_and_parse(list) -> dict`, `_measured_score(dict, str) -> float|None`, `_simresult_from_messages(list, str, int) -> SimResult`, `run_simulation(skill_content, prompt)` (auth removed, call-site updated in Task 3 Step 4) — consistent across tasks. `metadata["unmeasured"]` produced in Task 2, consumed in Tasks 5 and the Task 5 test.

--- a/docs/superpowers/plans/2026-06-25-open-issue-resolution.md
+++ b/docs/superpowers/plans/2026-06-25-open-issue-resolution.md
@@ -587,13 +587,14 @@ npx --yes protect-mcp@0.5.5 evaluate \
   --fail-on-missing-policy false; echo "exit=$?"
 ```
 
-- [ ] **Step 2: Record the outcome and decide severity**
+- [x] **Step 2: OUTCOME (2026-06-25) — premise invalid; `evaluate` subcommand does not exist**
 
-- If deny→`exit=2` and permit→`exit=0`: gates work → #598 is a **false positive** for the shipped engine. Severity: informational. Proceed; the rewrite is still adopted as hardening.
-- If deny→`exit=0`: the disclosure is **correct** → severity **HIGH**. The rewrite (Task 7) becomes the priority fix and the reply credits a real vulnerability.
-- If `npx`/network unavailable in this environment: do not guess — surface the exact two commands above for the maintainer to run via `!`, and hold Task 10's reply until the result is known.
+The live run revealed `protect-mcp@0.5.5` has **no `evaluate` or `sign` subcommand** (the invocation above falls through to "wrapper" mode). Its real CLI is `serve` (HTTP hook server), `simulate`, `init-hooks`, and Cedar-via-WASM (`--cedar <dir>`). Consequences:
+- The plugin's `hooks/hooks.json` (PreToolUse `… evaluate …`, PostToolUse `… sign …`) targets non-existent subcommands → **the gate does not run at all** against the pinned version. This is a separate, larger defect than #598 as filed.
+- protect-mcp's own `test/run-tests.sh` also uses `evaluate …`, so the earlier "its test expects deny → gates work" inference was unfounded.
+- protect-mcp evaluates Cedar "locally via WASM" = the real Cedar engine, which genuinely discards `in`-on-String forbid rules. So the disclosure (#598) is **essentially correct**, not a false positive. The `.contains()` rewrite (Task 7) is the right fix regardless.
 
-- [ ] **Step 3: No commit** (record the result in the PR description / Task 10 draft).
+Decision (maintainer-approved): proceed with the Cedar correctness fix (Tasks 7-8), retarget Task 9 to a `cedar validate`-based test that needs no `evaluate`, and in Task 10 reply to #598 acknowledging the reporter is right AND surface the broken-hook finding as its own issue (do NOT blind-fix the hook integration here).
 
 ---
 
@@ -640,10 +641,9 @@ npx --yes protect-mcp@0.5.5 evaluate \
 
 Keep all comments and the terminal `permit (principal, action, resource);` unchanged.
 
-- [ ] **Step 2: Re-run the Task 6 deny/permit commands to confirm behavior is unchanged-or-fixed**
+- [ ] **Step 2: Confirm the rewritten policy is syntactically well-formed**
 
-Run the two `npx ... evaluate` commands from Task 6 against the rewritten policy.
-Expected: deny→`exit=2`, permit→`exit=0`. (If Task 6 showed the gates were already working, this confirms no regression; if it showed them broken, this confirms the fix.)
+`protect-mcp evaluate` does not exist (Task 6), so semantic validation moves to Task 9 (`cedar validate` against the schema). Here, just confirm the rewrite parses: every `forbid` block still ends with a valid `when { … }`, the terminal `permit (principal, action, resource);` is intact, and brackets/quotes balance. If a local `cedar` CLI is present you may pre-check `cedar validate --policies review-agent-governance.cedar` (without schema it checks syntax only); otherwise rely on Task 9.
 
 - [ ] **Step 3: Commit**
 
@@ -713,91 +713,102 @@ git commit -m "feat(review-agent-governance): add cedarschema typing context att
 
 ---
 
-### Task 9: Add a graceful-skip deny/permit round-trip test
+### Task 9: Add a `cedar validate` + textual regression test (no `evaluate` dependency)
+
+Retargeted after Task 6: `protect-mcp evaluate` does not exist, so the test cannot route through protect-mcp. Instead it (a) always-on: greps the policy to ensure no `in`-on-String forbid pattern regresses; (b) when the `cedar` CLI is present: `cedar validate` the policy against the schema, which fails on `in`-on-String and passes on `.contains()`.
 
 **Files:**
 - Create: `plugins/review-agent-governance/test/run-tests.sh` (executable)
-- Create: `plugins/review-agent-governance/test/fixtures/deny-gh-pr-merge.json`
-- Create: `plugins/review-agent-governance/test/fixtures/permit-ls.json`
 - Create: `plugins/review-agent-governance/test/README.md`
 
-**Interfaces:** mirrors `plugins/protect-mcp/test/run-tests.sh` conventions — exit `0` all pass, `1` a failure, `77` tools missing (treated as skipped).
+**Interfaces:** exit `0` all pass, `1` a failure. Part A always runs (needs only grep); Part B prints a SKIP line (does not fail) when `cedar` is absent.
 
-- [ ] **Step 1: Create the fixtures**
-
-`fixtures/deny-gh-pr-merge.json`:
-```json
-{ "tool_name": "Bash", "tool_input": { "command": "gh pr merge 123 --squash" } }
-```
-`fixtures/permit-ls.json`:
-```json
-{ "tool_name": "Bash", "tool_input": { "command": "ls -la" } }
-```
-
-- [ ] **Step 2: Create `test/run-tests.sh`** (mirrors protect-mcp's preflight + check_exit)
+- [ ] **Step 1: Create `test/run-tests.sh`**
 
 ```bash
 #!/usr/bin/env bash
-# run-tests.sh — exercise review-agent-governance.cedar against protect-mcp.
-# Exit codes: 0 pass, 1 fail, 77 required tools missing (skipped).
+# run-tests.sh — guard review-agent-governance.cedar against the in-on-String
+# forbid bug (#598). Part A (grep) always runs; Part B (cedar validate) runs
+# only if the `cedar` CLI is installed, else SKIPs without failing.
+# Exit codes: 0 pass, 1 fail.
 set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 POLICY="../policies/review-agent-governance.cedar"
-
-need() { command -v "$1" >/dev/null 2>&1 || { echo "SKIP: '$1' not found."; exit 77; }; }
-need node; need npx; need python3
+SCHEMA="../policies/review-agent-governance.cedarschema"
 
 PASS=0; FAIL=0
 pass() { echo "PASS: $1"; PASS=$((PASS+1)); }
 fail() { echo "FAIL: $1"; FAIL=$((FAIL+1)); }
-check_exit() { if [ "$1" -eq "$2" ]; then pass "$3"; else fail "$3 (exit $1, expected $2)"; fi; }
-tool() { python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["tool_name"])' "$1"; }
-inp() { python3 -c 'import json,sys;print(json.dumps(json.load(open(sys.argv[1]))["tool_input"]))' "$1"; }
 
-run() {
-  npx --yes protect-mcp@0.5.5 evaluate --policy "$POLICY" \
-    --tool "$(tool "$1")" --input "$(inp "$1")" --fail-on-missing-policy false >/dev/null 2>&1
-}
+echo "=== Part A: no in-on-String forbid pattern (always runs) ==="
+# The bug pattern is `context.<attr> in [` inside a forbid rule. The fixed form
+# is `[ ... ].contains(context.<attr>)`. Assert the bad pattern is absent.
+if grep -nE 'context\.[a-z_]+[[:space:]]+in[[:space:]]*\[' "$POLICY" >/dev/null; then
+  fail "policy still uses 'context.<attr> in [ ... ]' (the discarded-forbid bug)"
+  grep -nE 'context\.[a-z_]+[[:space:]]+in[[:space:]]*\[' "$POLICY"
+else
+  pass "no in-on-String forbid pattern present"
+fi
+# And assert the fixed idiom is actually used.
+if grep -qE '\]\.contains\(context\.' "$POLICY"; then
+  pass "policy uses [ ... ].contains(context.<attr>)"
+else
+  fail "policy does not use the expected .contains() idiom"
+fi
 
-echo "=== Deny: gh pr merge ==="
-run fixtures/deny-gh-pr-merge.json; check_exit $? 2 "gh pr merge is denied (exit 2)"
-
-echo "=== Permit: ls ==="
-run fixtures/permit-ls.json; check_exit $? 0 "ls is permitted (exit 0)"
+echo "=== Part B: cedar validate against schema (if cedar CLI present) ==="
+if command -v cedar >/dev/null 2>&1; then
+  if cedar validate --policies "$POLICY" --schema "$SCHEMA"; then
+    pass "cedar validate succeeds (policy is well-typed)"
+  else
+    fail "cedar validate failed"
+  fi
+else
+  echo "SKIP: 'cedar' CLI not found — Part B skipped (Part A still gates)."
+fi
 
 echo ""; echo "Passed: $PASS, Failed: $FAIL"
 [ "$FAIL" -eq 0 ] || exit 1
 ```
 
-- [ ] **Step 3: Create `test/README.md`** documenting that the test requires node/npx/network and skips (exit 77) otherwise, mirroring `plugins/protect-mcp/test/README.md`.
+- [ ] **Step 2: Create `test/README.md`**
 
 ```markdown
 # review-agent-governance policy tests
 
-Round-trip deny/permit checks for `policies/review-agent-governance.cedar`,
-evaluated with `protect-mcp@0.5.5` (the engine the plugin's hook uses).
+Guards `policies/review-agent-governance.cedar` against the #598 `in`-on-String
+forbid bug.
 
 ```bash
-./run-tests.sh   # exit 0 pass · 1 fail · 77 tools missing (skipped)
+./run-tests.sh   # exit 0 pass · 1 fail
 ```
 
-Requires `node` (>=18), `npx`, and network access on first run.
+- **Part A** (always runs, needs only `grep`): asserts the policy contains no
+  `context.<attr> in [ ... ]` forbid pattern (which Cedar silently discards) and
+  uses `[ ... ].contains(context.<attr>)` instead.
+- **Part B** (runs only if the `cedar` CLI is installed): `cedar validate` the
+  policy against `review-agent-governance.cedarschema`. With the context
+  attributes typed as `String`, `cedar validate` rejects the `in`-on-String form
+  at load time and accepts `.contains()`.
+
+Note: the shipped runtime is `protect-mcp serve` (Cedar-via-WASM); this test
+validates the policy source directly and does not depend on protect-mcp.
 ```
 
-- [ ] **Step 4: Make executable and run**
+- [ ] **Step 3: Make executable and run**
 
 ```bash
 chmod +x plugins/review-agent-governance/test/run-tests.sh
 plugins/review-agent-governance/test/run-tests.sh; echo "suite exit=$?"
 ```
-Expected: `exit=0` (both checks pass) where npx/network are available, or `exit=77` (skipped) otherwise. A `1` means the gate is not firing — escalate per Task 6.
+Expected: `exit=0`. Part A passes (policy uses `.contains()` after Task 7); Part B passes if `cedar` is installed, else prints SKIP. A non-zero exit means Part A's regression guard caught the bad pattern — fix the policy.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 4: Commit**
 
 ```bash
 git add plugins/review-agent-governance/test
-git commit -m "test(review-agent-governance): add deny/permit round-trip test (skips without npx) (#598)"
+git commit -m "test(review-agent-governance): guard against in-on-String forbid bug (#598)"
 ```
 
 ---
@@ -824,7 +835,8 @@ Expected: all pass; drift check prints nothing.
 - [ ] **Step 3: Draft the outward-facing actions (post only after explicit maintainer approval).**
 
 - **#591** — comment that the fix landed in the PR (judge now reads `AssistantMessage`/`ResultMessage` correctly, surfaces "unmeasured" instead of fake 0.5, removed dead config); thank lkjie; close when the PR merges.
-- **#598** — reply using the Task 6 result. If false positive: thank matiaszabal, explain the shipped engine is `protect-mcp@0.5.5` (their test used vanilla `cedar-policy 4.8.2`), note we adopted `.contains()` + a schema + a round-trip test as hardening, and reference `cedar-policy/cedar#2428`. If confirmed: credit a real high-severity finding and point to the fix PR. Close when the PR merges.
+- **#598** — reply crediting matiaszabal: the finding is **essentially correct**, not a false positive. protect-mcp evaluates Cedar via the real engine (WASM), which discards `in`-on-String forbid rules. We adopted `[ ... ].contains(context.<attr>)` + a `.cedarschema` + a regression test (PR). Reference `cedar-policy/cedar#2428`. ALSO disclose the adjacent finding we hit while verifying: the plugin's `hooks/hooks.json` targets `protect-mcp evaluate`/`sign` subcommands that don't exist in the pinned `@0.5.5` (it now uses `serve`/`init-hooks`), so the gate doesn't run as shipped — tracked separately (see new issue below). Close #598 when the PR merges.
+- **NEW ISSUE (file it)** — open a bug for the broken protect-mcp integration: `review-agent-governance/hooks/hooks.json` (and `protect-mcp/test/run-tests.sh`) invoke non-existent `evaluate`/`sign` subcommands of `protect-mcp@0.5.5`; the current CLI is `serve`/`init-hooks`/`--cedar`. Enforcement does not run as shipped. Recommend regenerating hooks via `protect-mcp init-hooks` (serve-based) and updating the pin/tests. This is the larger defect surfaced by #598's verification.
 - **#579** — close: fixed by the format-modernization commit (`4820385`); current marketplace carries no `strict`/component arrays. Ask the reporter to update the marketplace / unpin from 1.0.1/1.2.x.
 - **#580** — close: same modernization; `shell-scripting` is now 1.2.3 with auto-discovery and the skills load. Ask them to update.
 - **#570** — close as converted to PR #577 (trimmed 3-skill version); tracking moves there.

--- a/docs/superpowers/specs/2026-06-25-open-issue-resolution-design.md
+++ b/docs/superpowers/specs/2026-06-25-open-issue-resolution-design.md
@@ -1,0 +1,181 @@
+# Open-Issue Resolution — Design
+
+- **Date:** 2026-06-25
+- **Status:** Approved (brainstorming) — pending implementation plan
+- **Branch:** `fix/issues-591-598`
+- **Scope decision:** Real fixes for **#591** and **#598**; triage-close (no code) for **#579, #580, #570, #595**. (#560 already closed — Antigravity harness is not being pursued.)
+
+## Context
+
+A review of the 7 open GitHub issues sorted them into three buckets:
+
+1. **Real engineering work:** #591 (confirmed plugin-eval bug) and #598 (Cedar policy hardening).
+2. **Already fixed on `main`** (reporter on stale pinned versions): #579, #580.
+3. **Already converted to PRs:** #570 → PR #577, #595 → PR #596.
+
+Both substantive bugs were confirmed at the code level, and the relevant library
+patterns were verified against current docs via Context7
+(`/anthropics/claude-agent-sdk-python`, `/cedar-policy/cedar-docs`).
+
+---
+
+## #591 — plugin-eval LLM judge silently emits fake 0.5 scores
+
+### Root cause (confirmed)
+
+`plugins/plugin-eval/src/plugin_eval/layers/judge.py` (`query_llm`, ~L83-85) reads the
+LLM response from a field that does not exist:
+
+```python
+if isinstance(message, ResultMessage):
+    for block in getattr(message, "content", []):   # ResultMessage has NO .content
+        if hasattr(block, "text"):
+            result_text += block.text
+```
+
+`ResultMessage` exposes `result: str | None` and `structured_output: Any` — there is
+no `content` attribute (confirmed against installed `claude-agent-sdk` 0.2.101 and the
+official SDK docs). So `result_text` is always `""`, `json.loads("")` raises, and the
+code silently falls back (`judge.py` ~L96-98):
+
+```python
+except json.JSONDecodeError:
+    return {"raw": result_text, "score": 0.5}   # fabricated 0.5 == grade F
+```
+
+Every judge sub-score becomes `0.5` with `raw: ""`, the composite reports confident
+**F grades**, and the command exits **0**. The judge layer carries ~72% of the rubric
+weight, so a genuinely strong skill is reported as failing. The **identical bug** exists
+in `monte_carlo.py` (~L81-84). The reporter (lkjie, issue #591) assumed it was their
+z.ai model; it is not — the bug fails for any ambient-configured model.
+
+### Fix
+
+1. **Correct extraction** (`judge.py` and `monte_carlo.py`): follow the documented SDK
+   pattern — iterate `AssistantMessage` messages and accumulate `TextBlock.text`; use
+   `ResultMessage.result` as a fallback when no assistant text was captured. Inspect
+   `ResultMessage.is_error` / `subtype` so a non-success result is treated as a *failed
+   measurement*, not as empty text.
+
+   ```python
+   from claude_agent_sdk import AssistantMessage, TextBlock, ResultMessage
+   result_text = ""
+   errored = False
+   async for message in query(prompt=full_prompt, options=...):
+       if isinstance(message, AssistantMessage):
+           for block in message.content:
+               if isinstance(block, TextBlock):
+                   result_text += block.text
+       elif isinstance(message, ResultMessage):
+           if message.is_error:
+               errored = True
+           if not result_text and message.result:
+               result_text = message.result
+   ```
+
+   (`structured_output` is noted as a possible future hardening, but we stay on the
+   documented text path for this fix.)
+
+2. **No more fabricated scores** (behavioral decision): when extraction yields no
+   parseable JSON *or* the run errored, return an explicit **"unmeasured"** signal
+   rather than `0.5`. Route the judge layer through the engine's existing
+   negative-sentinel "unmeasured" path (`engine.py` ~L269-271) so the composite is
+   computed **static-only** with a "judge unavailable" confidence note, and print a
+   clear **stderr warning** naming the cause. Exit code stays `0` unless `--threshold`
+   is set (a missing key / offline run must not become a hard failure when the static
+   layer succeeded).
+
+3. **Remove dead config:** drop `auth` and `model_tier` from the config dataclasses and
+   the JSON output — they are threaded through but never used (the SDK call inherits the
+   ambient model). Real tiered model selection is a separate future enhancement.
+
+### Testing
+
+Add a unit test that exercises the **real** extraction path (today `tests/test_judge.py`
+mocks `query_llm` wholesale, which is why this slipped through): feed fabricated
+`AssistantMessage` / `ResultMessage` objects and assert (a) valid JSON → real sub-scores,
+(b) empty / errored result → "unmeasured", never `0.5`.
+
+### Out of scope
+
+Wiring real Haiku/Sonnet tier selection; the reporter's specific z.ai configuration
+(the extraction fix makes any ambient-configured model work).
+
+---
+
+## #598 — Cedar `in`-on-String in review-agent-governance policy
+
+### Assessment
+
+`plugins/review-agent-governance/policies/review-agent-governance.cedar` (shipped on
+`main` via PR #495) has 5 `forbid` rules using `context.<attr> in [string literals]`
+plus a terminal blanket `permit`. Under **standard Cedar**, `in` requires an entity LHS,
+so `context.command_pattern in [...]` is a type error and the erroring `forbid` is
+silently discarded — which is the disclosure's claim (issue #598, upstream
+`cedar-policy/cedar#2428`).
+
+**However**, the plugin is evaluated at runtime by `npx protect-mcp@0.5.5 evaluate`
+(`hooks/hooks.json`), not vanilla Cedar, and protect-mcp's own shipped regression test
+(`plugins/protect-mcp/test/run-tests.sh`, Test 3) *expects* the identical
+`in [string-set]` idiom to **deny** (exit 2). That strongly implies protect-mcp treats
+`in [string-set]` as set membership, making this a **likely false positive** for the
+real engine — but this rests on an inference; protect-mcp was not executed during
+analysis. The `.contains()` rewrite is correct, validator-clean Cedar either way
+(`["a","b"].contains(context.x)` validates; confirmed via Context7).
+
+### Plan
+
+1. **Live verification first** — run `npx protect-mcp@0.5.5 evaluate` against the policy
+   with a known deny-case (e.g. `command_pattern="gh pr merge"`) and a permit-case to
+   confirm whether the gates fire under the real engine. If the sandbox blocks
+   network/npx, surface the exact command for the maintainer to run via `!`. **This
+   result gates the severity wording** in the reply (informational vs. high).
+2. **Rewrite** all 5 `forbid` rules: `context.x in [list]` → `[list].contains(context.x)`.
+3. **Add a `.cedarschema`** typing the context attributes (`command_pattern`,
+   `target_branch`, `path_starts_with`, `method`, `url_host`) as `String`, so
+   `cedar validate` turns this class of mistake into a load-time error. *Caveat:*
+   protect-mcp may not consume the schema at runtime; its value is for `cedar validate`,
+   documentation, and future-proofing.
+4. **Permanent round-trip test** — a deny/permit test mirroring protect-mcp's
+   `run-tests.sh`, gated on `npx` availability (skips gracefully when absent, like the
+   existing smoke tests). Covers `review-agent-governance.cedar`, which has zero coverage
+   today.
+5. **Reply to the reporter** (responsible disclosure): acknowledge + credit, explain the
+   engine distinction (their test used `cedar-policy 4.8.2`; the plugin runs
+   `protect-mcp@0.5.5`), state the verified result, and note the `.contains()` hardening
+   plus the `cedar-policy/cedar#2428` reference.
+
+### Out of scope
+
+protect-mcp's own fixtures/docs that use the same idiom; a repo-wide cedar lint.
+
+---
+
+## Triage closes (no code)
+
+| Issue | Action | Comment substance |
+|---|---|---|
+| **#579** manifest conflicts | Close (fixed) | Resolved by format-modernization commit `4820385`; current marketplace has no `strict`/component arrays. Update the marketplace / unpin from 1.0.1/1.2.x. |
+| **#580** shell-scripting paths | Close (fixed) | Same modernization; shell-scripting is now 1.2.3 with auto-discovery, skills load fine. Update to latest. |
+| **#570** skill-forge | Close (superseded) | Converted to PR #577 (trimmed 3-skill version); tracking moves there. |
+| **#595** operating-kit | Close (superseded) | Converted to PR #596; tracking moves there. |
+
+---
+
+## Rollout
+
+- All code work lands on branch `fix/issues-591-598` → PR, not direct to `main`.
+- Gates before merge: `make validate STRICT=1`, `make garden`, `make test` (the new
+  judge extraction test runs here), plus `make generate-all` drift check (no harness
+  artifacts change, so drift should be clean).
+- Issue closes and the #598 reply are posted only after the maintainer approves (they
+  are outward-facing).
+
+## Risks / open items
+
+- **#598 severity** is unresolved until the live protect-mcp run; the reply wording
+  branches on it.
+- The `.cedarschema` may be advisory-only if protect-mcp doesn't load it — acceptable
+  (documentation + `cedar validate` value), flagged honestly in the reply.
+- The new Cedar round-trip test requires `npx`/network; it must skip gracefully in CI
+  rather than hard-fail when unavailable.

--- a/docs/superpowers/specs/2026-06-25-open-issue-resolution-design.md
+++ b/docs/superpowers/specs/2026-06-25-open-issue-resolution-design.md
@@ -114,32 +114,36 @@ so `context.command_pattern in [...]` is a type error and the erroring `forbid` 
 silently discarded — which is the disclosure's claim (issue #598, upstream
 `cedar-policy/cedar#2428`).
 
-**However**, the plugin is evaluated at runtime by `npx protect-mcp@0.5.5 evaluate`
-(`hooks/hooks.json`), not vanilla Cedar, and protect-mcp's own shipped regression test
-(`plugins/protect-mcp/test/run-tests.sh`, Test 3) *expects* the identical
-`in [string-set]` idiom to **deny** (exit 2). That strongly implies protect-mcp treats
-`in [string-set]` as set membership, making this a **likely false positive** for the
-real engine — but this rests on an inference; protect-mcp was not executed during
-analysis. The `.contains()` rewrite is correct, validator-clean Cedar either way
+An initial hypothesis was that the plugin's runtime (protect-mcp) might treat
+`in [string-set]` as set membership, making the disclosure a false positive. **Live
+verification (2026-06-25) refuted that** and confirmed the disclosure is essentially
+**correct**: `protect-mcp@0.5.5` evaluates Cedar via the real engine (WASM), which
+discards `in`-on-String forbids exactly as standard Cedar does. The verification also
+surfaced a **separate, larger defect** — `protect-mcp@0.5.5` has no `evaluate`/`sign`
+subcommands at all (its CLI is `serve` / `init-hooks` / `simulate` / `--cedar`), so the
+plugin's `hooks/hooks.json` (and protect-mcp's own `test/run-tests.sh`, which both invoke
+`evaluate`) don't run as shipped. That broken-hook integration is tracked as its own
+issue. The `.contains()` rewrite is correct, validator-clean Cedar regardless
 (`["a","b"].contains(context.x)` validates; confirmed via Context7).
 
 ### Plan
 
-1. **Live verification first** — run `npx protect-mcp@0.5.5 evaluate` against the policy
-   with a known deny-case (e.g. `command_pattern="gh pr merge"`) and a permit-case to
-   confirm whether the gates fire under the real engine. If the sandbox blocks
-   network/npx, surface the exact command for the maintainer to run via `!`. **This
-   result gates the severity wording** in the reply (informational vs. high).
+1. **Live verification first** — attempt to evaluate the policy with the real engine.
+   *Outcome:* `protect-mcp@0.5.5` has no `evaluate` subcommand, so the policy can't be
+   exercised that way; the disclosure is confirmed essentially correct (real Cedar
+   discards `in`-on-String), and the broken-hook integration is filed separately. The
+   reply credits the reporter rather than calling it a false positive.
 2. **Rewrite** all 5 `forbid` rules: `context.x in [list]` → `[list].contains(context.x)`.
 3. **Add a `.cedarschema`** typing the context attributes (`command_pattern`,
    `target_branch`, `path_starts_with`, `method`, `url_host`) as `String`, so
    `cedar validate` turns this class of mistake into a load-time error. *Caveat:*
    protect-mcp may not consume the schema at runtime; its value is for `cedar validate`,
    documentation, and future-proofing.
-4. **Permanent round-trip test** — a deny/permit test mirroring protect-mcp's
-   `run-tests.sh`, gated on `npx` availability (skips gracefully when absent, like the
-   existing smoke tests). Covers `review-agent-governance.cedar`, which has zero coverage
-   today.
+4. **Permanent regression test** — a `test/run-tests.sh` that does NOT depend on
+   `protect-mcp evaluate` (it doesn't exist): Part A always greps the policy for the
+   `in`-on-String pattern (catching a regression), and Part B runs `cedar validate`
+   against the schema when the `cedar` CLI is present (else skips). Covers
+   `review-agent-governance.cedar`, which had zero coverage.
 5. **Reply to the reporter** (responsible disclosure): acknowledge + credit, explain the
    engine distinction (their test used `cedar-policy 4.8.2`; the plugin runs
    `protect-mcp@0.5.5`), state the verified result, and note the `.contains()` hardening

--- a/plugins/plugin-eval/src/plugin_eval/cli.py
+++ b/plugins/plugin-eval/src/plugin_eval/cli.py
@@ -35,7 +35,6 @@ def _run_score(
     output: str,
     verbose: bool,
     concurrency: int,
-    auth: str,
     threshold: float | None,
 ) -> int:
     """Core scoring logic; returns exit code."""
@@ -48,7 +47,6 @@ def _run_score(
         output_format=output,
         verbose=verbose,
         concurrency=concurrency,
-        auth=auth,
     )
     engine = EvalEngine(config)
 
@@ -96,13 +94,12 @@ def score(
     output: str = typer.Option("markdown", help="Output format: json|markdown|html"),  # noqa: B008
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output"),  # noqa: B008
     concurrency: int = typer.Option(4, help="Max concurrent LLM calls"),  # noqa: B008
-    auth: str = typer.Option("max", help="Auth mode: max|api-key"),  # noqa: B008
     threshold: float | None = typer.Option(  # noqa: B008
         None, help="Minimum score threshold; exit code 1 if below"
     ),
 ) -> None:
     """Evaluate a plugin or skill directory and report its quality score."""
-    exit_code = _run_score(path, depth, output, verbose, concurrency, auth, threshold)
+    exit_code = _run_score(path, depth, output, verbose, concurrency, threshold)
     if exit_code != 0:
         raise typer.Exit(code=exit_code)
 
@@ -113,11 +110,10 @@ def certify(
     output: str = typer.Option("markdown", help="Output format: json|markdown|html"),  # noqa: B008
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output"),  # noqa: B008
     concurrency: int = typer.Option(4, help="Max concurrent LLM calls"),  # noqa: B008
-    auth: str = typer.Option("max", help="Auth mode: max|api-key"),  # noqa: B008
     threshold: float | None = typer.Option(None, help="Minimum score threshold"),  # noqa: B008
 ) -> None:
     """Certify a plugin or skill (runs at deep depth)."""
-    exit_code = _run_score(path, Depth.DEEP, output, verbose, concurrency, auth, threshold)
+    exit_code = _run_score(path, Depth.DEEP, output, verbose, concurrency, threshold)
     if exit_code != 0:
         raise typer.Exit(code=exit_code)
 

--- a/plugins/plugin-eval/src/plugin_eval/cli.py
+++ b/plugins/plugin-eval/src/plugin_eval/cli.py
@@ -77,6 +77,17 @@ def _run_score(
         # Default: markdown
         typer.echo(reporter.to_markdown(result))
 
+    judge_layer = next((lr for lr in result.layers if lr.layer == "judge"), None)
+    if judge_layer is not None:
+        unmeasured = judge_layer.metadata.get("unmeasured") or []
+        if unmeasured:
+            stderr_console.print(
+                f"[yellow]warning:[/yellow] LLM judge could not measure "
+                f"{', '.join(unmeasured)}; composite computed from the remaining "
+                f"layers. Check that claude-agent-sdk is installed and a model is "
+                f"configured (run with --verbose for details)."
+            )
+
     if (
         threshold is not None
         and result.composite is not None

--- a/plugins/plugin-eval/src/plugin_eval/engine.py
+++ b/plugins/plugin-eval/src/plugin_eval/engine.py
@@ -83,7 +83,6 @@ class EvalEngine:
 
             judge_config = JudgeConfig(
                 judges=self.config.judges,
-                auth=self.config.auth,
                 concurrency=self.config.concurrency,
             )
             judge = JudgeAnalyzer(judge_config)
@@ -98,7 +97,6 @@ class EvalEngine:
                 mc_config = MonteCarloConfig(
                     n_runs=n_runs,
                     concurrency=self.config.concurrency,
-                    auth=self.config.auth,
                 )
                 mc = MonteCarloAnalyzer(mc_config)
 

--- a/plugins/plugin-eval/src/plugin_eval/layers/_sdk.py
+++ b/plugins/plugin-eval/src/plugin_eval/layers/_sdk.py
@@ -44,3 +44,18 @@ def collect_sdk_output(messages: list) -> SdkOutput:
             if isinstance(message.usage, dict):
                 usage = message.usage
     return SdkOutput(text=text, result=result, errored=errored, usage=usage)
+
+
+def usage_total_tokens(usage: dict[str, Any] | None) -> int:
+    """Total token count from an SDK usage dict.
+
+    The SDK's `usage` exposes separate `*_tokens` fields (input/output/cache),
+    not a single `total_tokens`. Prefer an explicit `total_tokens` if a future
+    SDK provides one, otherwise sum the component `*_tokens` fields.
+    """
+    if not usage:
+        return 0
+    total = usage.get("total_tokens")
+    if isinstance(total, int):
+        return total
+    return sum(n for k, n in usage.items() if k.endswith("_tokens") and isinstance(n, int))

--- a/plugins/plugin-eval/src/plugin_eval/layers/_sdk.py
+++ b/plugins/plugin-eval/src/plugin_eval/layers/_sdk.py
@@ -1,0 +1,46 @@
+"""Shared helper for reading Claude Agent SDK message streams.
+
+Both the judge and Monte Carlo layers consume the same `query()` message stream
+(assistant text blocks + a terminal result message). This centralizes that
+walk so the two layers can't drift on how SDK message types are handled.
+"""
+
+from __future__ import annotations
+
+from typing import Any, NamedTuple
+
+
+class SdkOutput(NamedTuple):
+    """Extracted view of one SDK message stream."""
+
+    text: str  # concatenated assistant TextBlock text
+    result: str | None  # ResultMessage.result, if present (fallback text)
+    errored: bool  # a ResultMessage reported is_error
+    usage: dict[str, Any] | None  # ResultMessage.usage, if it was a dict
+
+
+def collect_sdk_output(messages: list) -> SdkOutput:
+    """Walk SDK messages → assistant text, result fallback, error flag, usage."""
+    from claude_agent_sdk import (  # type: ignore[import-untyped]
+        AssistantMessage,
+        ResultMessage,
+        TextBlock,
+    )
+
+    text = ""
+    result: str | None = None
+    errored = False
+    usage: dict[str, Any] | None = None
+    for message in messages:
+        if isinstance(message, AssistantMessage):
+            for block in message.content:
+                if isinstance(block, TextBlock):
+                    text += block.text
+        elif isinstance(message, ResultMessage):
+            if message.is_error:
+                errored = True
+            if message.result:
+                result = message.result
+            if isinstance(message.usage, dict):
+                usage = message.usage
+    return SdkOutput(text=text, result=result, errored=errored, usage=usage)

--- a/plugins/plugin-eval/src/plugin_eval/layers/judge.py
+++ b/plugins/plugin-eval/src/plugin_eval/layers/judge.py
@@ -136,6 +136,14 @@ async def query_llm(prompt: str, system: str = "", model: str = "claude-sonnet-4
 # ---------------------------------------------------------------------------
 
 
+def _measured_score(result: dict, key: str) -> float | None:
+    """Return the numeric score for an assessment, or None if it was unmeasured."""
+    if result.get("unmeasured"):
+        return None
+    val = result.get(key)
+    return float(val) if isinstance(val, (int, float)) else None
+
+
 @dataclass
 class JudgeConfig:
     judges: int = 1
@@ -170,27 +178,25 @@ class JudgeAnalyzer:
             self.assess_scope(skill),
         )
 
-        # Weighted composite: triggering 0.30, orchestration 0.30, output 0.25, scope 0.15
-        score = (
-            triggering.get("f1", 0.5) * 0.30
-            + orchestration.get("score", 0.5) * 0.30
-            + output_quality.get("score", 0.5) * 0.25
-            + scope.get("score", 0.5) * 0.15
-        )
-        score = max(0.0, min(1.0, score))
-
-        sub_scores: dict[str, float] = {
-            "triggering_accuracy": triggering.get("f1", 0.5),
-            "orchestration_fitness": orchestration.get("score", 0.5),
-            "output_quality": output_quality.get("score", 0.5),
-            "scope_calibration": scope.get("score", 0.5),
+        raw_scores: dict[str, float | None] = {
+            "triggering_accuracy": _measured_score(triggering, "f1"),
+            "orchestration_fitness": _measured_score(orchestration, "score"),
+            "output_quality": _measured_score(output_quality, "score"),
+            "scope_calibration": _measured_score(scope, "score"),
         }
+        sub_scores: dict[str, float] = {k: v for k, v in raw_scores.items() if v is not None}
+        unmeasured = sorted(k for k, v in raw_scores.items() if v is None)
+
+        # Layer score is display-only; the composite engine blends per-dimension
+        # sub_scores (omitted keys are excluded). Use the mean of measured dims.
+        score = sum(sub_scores.values()) / len(sub_scores) if sub_scores else 0.0
 
         metadata: dict = {
             "triggering": triggering,
             "orchestration": orchestration,
             "output_quality": output_quality,
             "scope": scope,
+            "unmeasured": unmeasured,
         }
 
         return LayerResult(

--- a/plugins/plugin-eval/src/plugin_eval/layers/judge.py
+++ b/plugins/plugin-eval/src/plugin_eval/layers/judge.py
@@ -147,9 +147,7 @@ def _measured_score(result: dict, key: str) -> float | None:
 @dataclass
 class JudgeConfig:
     judges: int = 1
-    auth: str = "max"
     concurrency: int = 4
-    model_tier: str = "auto"
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/plugin-eval/src/plugin_eval/layers/judge.py
+++ b/plugins/plugin-eval/src/plugin_eval/layers/judge.py
@@ -52,50 +52,79 @@ def _resolve_model(tier: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _extract_and_parse(messages: list) -> dict:
+    """Pull assistant text from SDK messages and parse JSON.
+
+    Returns the parsed dict on success, or an {"unmeasured": True, ...} marker
+    when the run errored, produced no text, or returned non-JSON.
+    """
+    from claude_agent_sdk import (  # type: ignore[import-untyped]
+        AssistantMessage,
+        ResultMessage,
+        TextBlock,
+    )
+
+    text = ""
+    fallback = ""
+    errored = False
+    for message in messages:
+        if isinstance(message, AssistantMessage):
+            for block in message.content:
+                if isinstance(block, TextBlock):
+                    text += block.text
+        elif isinstance(message, ResultMessage):
+            if message.is_error:
+                errored = True
+            if message.result:
+                fallback = message.result
+
+    raw = text or fallback
+    if errored:
+        return {"unmeasured": True, "error": "judge LLM call returned an error result"}
+    if not raw.strip():
+        return {"unmeasured": True, "error": "judge LLM returned no text"}
+
+    stripped = raw.strip()
+    fence_match = re.search(r"```(?:json)?\s*([\s\S]+?)\s*```", stripped)
+    if fence_match:
+        stripped = fence_match.group(1).strip()
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        return {"unmeasured": True, "error": "judge response was not valid JSON", "raw": raw}
+
+
 async def query_llm(prompt: str, system: str = "", model: str = "claude-sonnet-4-6") -> dict:
     """Call Claude via the Agent SDK and return a parsed JSON dict.
 
-    Raises RuntimeError if claude-agent-sdk is not installed.
+    Degrades to an {"unmeasured": True, ...} marker (never raises) when the SDK
+    is missing or the call fails, so the judge layer can be skipped instead of
+    crashing the whole evaluation.
     """
     try:
         from claude_agent_sdk import (  # type: ignore[import-untyped]
             ClaudeAgentOptions,
-            ResultMessage,
             query,
         )
-    except ImportError as exc:
-        raise RuntimeError(
-            "claude-agent-sdk is required for LLM judge. Install with: uv sync --extra llm"
-        ) from exc
+    except ImportError:
+        return {
+            "unmeasured": True,
+            "error": "claude-agent-sdk not installed (uv sync --extra llm)",
+        }
 
-    full_prompt = prompt
-    if system:
-        full_prompt = f"{system}\n\n{prompt}"
-
-    result_text = ""
-    async for message in query(
-        prompt=full_prompt,
-        options=ClaudeAgentOptions(
-            model=model,
-            allowed_tools=[],
-        ),
-    ):
-        if isinstance(message, ResultMessage):
-            # ResultMessage contains the final text
-            for block in getattr(message, "content", []):
-                if hasattr(block, "text"):
-                    result_text += block.text
-
-    # Try to parse JSON — handles raw JSON or JSON inside a markdown code block
-    stripped = result_text.strip()
-    fence_match = re.search(r"```(?:json)?\s*([\s\S]+?)\s*```", stripped)
-    if fence_match:
-        stripped = fence_match.group(1).strip()
-
+    full_prompt = f"{system}\n\n{prompt}" if system else prompt
     try:
-        return json.loads(stripped)
-    except json.JSONDecodeError:
-        return {"raw": result_text, "score": 0.5}
+        messages = [
+            message
+            async for message in query(
+                prompt=full_prompt,
+                options=ClaudeAgentOptions(model=model, allowed_tools=[]),
+            )
+        ]
+    except Exception as exc:  # noqa: BLE001 — judge is best-effort; degrade to unmeasured
+        return {"unmeasured": True, "error": f"judge LLM call failed: {exc}"}
+
+    return _extract_and_parse(messages)
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/plugin-eval/src/plugin_eval/layers/judge.py
+++ b/plugins/plugin-eval/src/plugin_eval/layers/judge.py
@@ -7,6 +7,7 @@ import json
 import re
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from plugin_eval.layers._sdk import collect_sdk_output
 from plugin_eval.models import LayerResult
@@ -60,7 +61,8 @@ def _extract_and_parse(messages: list) -> dict:
     when the run errored, produced no text, or returned non-JSON.
     """
     output = collect_sdk_output(messages)
-    raw = output.text or (output.result or "")
+    text = output.text.strip()
+    raw = text or (output.result or "")
     if output.errored:
         return {
             "unmeasured": True,
@@ -118,9 +120,13 @@ async def query_llm(prompt: str, system: str = "", model: str = "claude-sonnet-4
 # ---------------------------------------------------------------------------
 
 
-def _measured_score(result: dict, key: str) -> float | None:
-    """Return the numeric score for an assessment, or None if it was unmeasured."""
-    if result.get("unmeasured"):
+def _measured_score(result: Any, key: str) -> float | None:
+    """Return the numeric score for an assessment, or None if it was unmeasured.
+
+    Tolerates non-dict JSON (e.g. a list or bare string) by treating it as
+    unmeasured rather than raising.
+    """
+    if not isinstance(result, dict) or result.get("unmeasured"):
         return None
     val = result.get(key)
     return float(val) if isinstance(val, (int, float)) else None

--- a/plugins/plugin-eval/src/plugin_eval/layers/judge.py
+++ b/plugins/plugin-eval/src/plugin_eval/layers/judge.py
@@ -8,6 +8,7 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
+from plugin_eval.layers._sdk import collect_sdk_output
 from plugin_eval.models import LayerResult
 from plugin_eval.parser import ParsedSkill, parse_skill
 
@@ -58,28 +59,9 @@ def _extract_and_parse(messages: list) -> dict:
     Returns the parsed dict on success, or an {"unmeasured": True, ...} marker
     when the run errored, produced no text, or returned non-JSON.
     """
-    from claude_agent_sdk import (  # type: ignore[import-untyped]
-        AssistantMessage,
-        ResultMessage,
-        TextBlock,
-    )
-
-    text = ""
-    fallback = ""
-    errored = False
-    for message in messages:
-        if isinstance(message, AssistantMessage):
-            for block in message.content:
-                if isinstance(block, TextBlock):
-                    text += block.text
-        elif isinstance(message, ResultMessage):
-            if message.is_error:
-                errored = True
-            if message.result:
-                fallback = message.result
-
-    raw = text or fallback
-    if errored:
+    output = collect_sdk_output(messages)
+    raw = output.text or (output.result or "")
+    if output.errored:
         return {
             "unmeasured": True,
             "error": "judge LLM call returned an error result",

--- a/plugins/plugin-eval/src/plugin_eval/layers/judge.py
+++ b/plugins/plugin-eval/src/plugin_eval/layers/judge.py
@@ -80,7 +80,11 @@ def _extract_and_parse(messages: list) -> dict:
 
     raw = text or fallback
     if errored:
-        return {"unmeasured": True, "error": "judge LLM call returned an error result"}
+        return {
+            "unmeasured": True,
+            "error": "judge LLM call returned an error result",
+            **({"raw": raw} if raw else {}),
+        }
     if not raw.strip():
         return {"unmeasured": True, "error": "judge LLM returned no text"}
 

--- a/plugins/plugin-eval/src/plugin_eval/layers/monte_carlo.py
+++ b/plugins/plugin-eval/src/plugin_eval/layers/monte_carlo.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
+from plugin_eval.layers._sdk import collect_sdk_output
 from plugin_eval.models import LayerResult
 from plugin_eval.parser import ParsedSkill, parse_skill
 from plugin_eval.stats import (
@@ -51,34 +52,16 @@ class MonteCarloConfig:
 
 def _simresult_from_messages(messages: list, prompt: str, duration_ms: int) -> SimResult:
     """Build a SimResult from SDK messages (assistant text => activation + quality)."""
-    from claude_agent_sdk import (  # type: ignore[import-untyped]
-        AssistantMessage,
-        ResultMessage,
-        TextBlock,
-    )
-
-    text = ""
-    tokens = 0
-    errored = False
-    for message in messages:
-        if isinstance(message, AssistantMessage):
-            for block in message.content:
-                if isinstance(block, TextBlock):
-                    text += block.text
-        elif isinstance(message, ResultMessage):
-            if message.is_error:
-                errored = True
-            if isinstance(message.usage, dict):
-                tokens = message.usage.get("total_tokens", tokens)
-
-    activated = bool(text)
-    quality_score = min(1.0, len(text) / 500) if activated else 0.0
+    output = collect_sdk_output(messages)
+    tokens = output.usage.get("total_tokens", 0) if output.usage else 0
+    activated = bool(output.text)
+    quality_score = min(1.0, len(output.text) / 500) if activated else 0.0
     return SimResult(
         activated=activated,
         quality_score=quality_score,
         tokens=tokens,
         duration_ms=duration_ms,
-        errored=errored,
+        errored=output.errored,
         prompt=prompt,
     )
 

--- a/plugins/plugin-eval/src/plugin_eval/layers/monte_carlo.py
+++ b/plugins/plugin-eval/src/plugin_eval/layers/monte_carlo.py
@@ -50,14 +50,47 @@ class MonteCarloConfig:
 # ---------------------------------------------------------------------------
 
 
-async def run_simulation(skill_content: str, prompt: str, auth: str) -> SimResult:
+def _simresult_from_messages(messages: list, prompt: str, duration_ms: int) -> SimResult:
+    """Build a SimResult from SDK messages (assistant text => activation + quality)."""
+    from claude_agent_sdk import (  # type: ignore[import-untyped]
+        AssistantMessage,
+        ResultMessage,
+        TextBlock,
+    )
+
+    text = ""
+    tokens = 0
+    errored = False
+    for message in messages:
+        if isinstance(message, AssistantMessage):
+            for block in message.content:
+                if isinstance(block, TextBlock):
+                    text += block.text
+        elif isinstance(message, ResultMessage):
+            if message.is_error:
+                errored = True
+            if isinstance(message.usage, dict):
+                tokens = message.usage.get("total_tokens", tokens)
+
+    activated = bool(text)
+    quality_score = min(1.0, len(text) / 500) if activated else 0.0
+    return SimResult(
+        activated=activated,
+        quality_score=quality_score,
+        tokens=tokens,
+        duration_ms=duration_ms,
+        errored=errored,
+        prompt=prompt,
+    )
+
+
+async def run_simulation(skill_content: str, prompt: str) -> SimResult:
     """Run a single simulation via Agent SDK. Returns SimResult. On error, errored=True."""
     try:
         import time
 
         from claude_agent_sdk import (  # type: ignore[import-untyped]
             ClaudeAgentOptions,
-            ResultMessage,
             query,
         )
 
@@ -65,42 +98,17 @@ async def run_simulation(skill_content: str, prompt: str, auth: str) -> SimResul
             f"You are evaluating a skill. Apply the skill if appropriate.\n\n"
             f"{skill_content}\n\n{prompt}"
         )
-
-        result_text = ""
-        activated = False
-        tokens = 0
-
         start = time.monotonic()
-
-        async for message in query(
-            prompt=full_prompt,
-            options=ClaudeAgentOptions(
-                allowed_tools=[],
-            ),
-        ):
-            if isinstance(message, ResultMessage):
-                for block in getattr(message, "content", []):
-                    if hasattr(block, "text"):
-                        result_text += block.text
-                        activated = True
-                usage = getattr(message, "usage", None)
-                if usage:
-                    tokens = getattr(usage, "total_tokens", 0)
-
+        messages = [
+            message
+            async for message in query(
+                prompt=full_prompt,
+                options=ClaudeAgentOptions(allowed_tools=[]),
+            )
+        ]
         duration_ms = int((time.monotonic() - start) * 1000)
-
-        # Estimate quality score from response length and coherence heuristic
-        quality_score = min(1.0, len(result_text) / 500) if activated else 0.0
-
-        return SimResult(
-            activated=activated,
-            quality_score=quality_score,
-            tokens=tokens,
-            duration_ms=duration_ms,
-            prompt=prompt,
-        )
-
-    except Exception:
+        return _simresult_from_messages(messages, prompt, duration_ms)
+    except Exception:  # noqa: BLE001 — a failed run is recorded as errored, not fatal
         return SimResult(
             activated=False,
             quality_score=0.0,
@@ -245,7 +253,7 @@ class MonteCarloAnalyzer:
         async def run_one(prompt: str) -> SimResult:
             nonlocal completed
             async with self._sem:
-                result = await run_simulation(skill_content, prompt, self.config.auth)
+                result = await run_simulation(skill_content, prompt)
                 completed += 1
                 if self.config.progress_callback:
                     self.config.progress_callback(completed, total)

--- a/plugins/plugin-eval/src/plugin_eval/layers/monte_carlo.py
+++ b/plugins/plugin-eval/src/plugin_eval/layers/monte_carlo.py
@@ -8,7 +8,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
-from plugin_eval.layers._sdk import collect_sdk_output
+from plugin_eval.layers._sdk import collect_sdk_output, usage_total_tokens
 from plugin_eval.models import LayerResult
 from plugin_eval.parser import ParsedSkill, parse_skill
 from plugin_eval.stats import (
@@ -53,9 +53,10 @@ class MonteCarloConfig:
 def _simresult_from_messages(messages: list, prompt: str, duration_ms: int) -> SimResult:
     """Build a SimResult from SDK messages (assistant text => activation + quality)."""
     output = collect_sdk_output(messages)
-    tokens = output.usage.get("total_tokens", 0) if output.usage else 0
-    activated = bool(output.text)
-    quality_score = min(1.0, len(output.text) / 500) if activated else 0.0
+    tokens = usage_total_tokens(output.usage)
+    raw = output.text.strip() or (output.result or "").strip()
+    activated = bool(raw)
+    quality_score = min(1.0, len(raw) / 500) if activated else 0.0
     return SimResult(
         activated=activated,
         quality_score=quality_score,

--- a/plugins/plugin-eval/src/plugin_eval/layers/monte_carlo.py
+++ b/plugins/plugin-eval/src/plugin_eval/layers/monte_carlo.py
@@ -40,7 +40,6 @@ class MonteCarloConfig:
 
     n_runs: int = 50
     concurrency: int = 4
-    auth: str = "max"
     seed: int = 42
     progress_callback: Callable[[int, int], None] | None = None
 

--- a/plugins/plugin-eval/src/plugin_eval/models.py
+++ b/plugins/plugin-eval/src/plugin_eval/models.py
@@ -36,11 +36,9 @@ class Depth(StrEnum):
 class EvalConfig(BaseModel):
     depth: Depth = Depth.STANDARD
     concurrency: int = Field(default=4, ge=1, le=20)
-    model_tier: str = "auto"
     output_format: str = "json"
     verbose: bool = False
     corpus_path: str | None = None
-    auth: str = "max"
     judges: int = Field(default=1, ge=1, le=5)
     monte_carlo_n: int | None = None
 

--- a/plugins/plugin-eval/tests/test_cli.py
+++ b/plugins/plugin-eval/tests/test_cli.py
@@ -5,7 +5,11 @@ from typer.testing import CliRunner
 
 from plugin_eval.cli import app
 from plugin_eval.models import (
-    CompositeResult, Depth, EvalConfig, LayerResult, PluginEvalResult,
+    CompositeResult,
+    Depth,
+    EvalConfig,
+    LayerResult,
+    PluginEvalResult,
 )
 
 runner = CliRunner()
@@ -51,9 +55,7 @@ class TestCLI:
         assert "plugin-level" in result.stderr.lower()
         assert "deep" in result.stderr.lower()
 
-    def test_plugin_eval_at_quick_depth_does_not_warn(
-        self, sample_plugin_dir: Path
-    ) -> None:
+    def test_plugin_eval_at_quick_depth_does_not_warn(self, sample_plugin_dir: Path) -> None:
         """No warning when the requested depth is already static-only."""
         result = runner.invoke(
             app,
@@ -70,16 +72,18 @@ def test_score_warns_when_judge_unmeasured(sample_skill_dir):
         config=EvalConfig(depth=Depth.STANDARD),
         layers=[
             LayerResult(layer="static", score=0.8, sub_scores={}),
-            LayerResult(layer="judge", score=0.0, sub_scores={},
-                        metadata={"unmeasured": ["triggering_accuracy", "output_quality"]}),
+            LayerResult(
+                layer="judge",
+                score=0.0,
+                sub_scores={},
+                metadata={"unmeasured": ["triggering_accuracy", "output_quality"]},
+            ),
         ],
         composite=CompositeResult(score=60.0),
     )
     with patch("plugin_eval.cli.EvalEngine") as Eng:
         Eng.return_value.evaluate_skill.return_value = fake
-        result = CliRunner().invoke(
-            app, ["score", str(sample_skill_dir), "--output", "json"]
-        )
+        result = CliRunner().invoke(app, ["score", str(sample_skill_dir), "--output", "json"])
     assert result.exit_code == 0
     assert "judge" in result.stderr.lower()
     assert "unmeasured" in result.stderr.lower() or "could not" in result.stderr.lower()

--- a/plugins/plugin-eval/tests/test_cli.py
+++ b/plugins/plugin-eval/tests/test_cli.py
@@ -57,3 +57,31 @@ class TestCLI:
         )
         assert result.exit_code == 0
         assert "warning" not in result.stderr.lower()
+
+
+from unittest.mock import patch
+from plugin_eval.models import (
+    CompositeResult, Depth, EvalConfig, LayerResult, PluginEvalResult,
+)
+
+
+def test_score_warns_when_judge_unmeasured(sample_skill_dir, tmp_path):
+    fake = PluginEvalResult(
+        plugin_path=str(sample_skill_dir),
+        timestamp="t",
+        config=EvalConfig(depth=Depth.STANDARD),
+        layers=[
+            LayerResult(layer="static", score=0.8, sub_scores={}),
+            LayerResult(layer="judge", score=0.0, sub_scores={},
+                        metadata={"unmeasured": ["triggering_accuracy", "output_quality"]}),
+        ],
+        composite=CompositeResult(score=60.0),
+    )
+    with patch("plugin_eval.cli.EvalEngine") as Eng:
+        Eng.return_value.evaluate_skill.return_value = fake
+        result = CliRunner().invoke(
+            app, ["score", str(sample_skill_dir), "--output", "json"]
+        )
+    assert result.exit_code == 0
+    assert "judge" in result.stderr.lower()
+    assert "unmeasured" in result.stderr.lower() or "could not" in result.stderr.lower()

--- a/plugins/plugin-eval/tests/test_cli.py
+++ b/plugins/plugin-eval/tests/test_cli.py
@@ -1,8 +1,12 @@
 from pathlib import Path
+from unittest.mock import patch
 
 from typer.testing import CliRunner
 
 from plugin_eval.cli import app
+from plugin_eval.models import (
+    CompositeResult, Depth, EvalConfig, LayerResult, PluginEvalResult,
+)
 
 runner = CliRunner()
 
@@ -59,13 +63,7 @@ class TestCLI:
         assert "warning" not in result.stderr.lower()
 
 
-from unittest.mock import patch
-from plugin_eval.models import (
-    CompositeResult, Depth, EvalConfig, LayerResult, PluginEvalResult,
-)
-
-
-def test_score_warns_when_judge_unmeasured(sample_skill_dir, tmp_path):
+def test_score_warns_when_judge_unmeasured(sample_skill_dir):
     fake = PluginEvalResult(
         plugin_path=str(sample_skill_dir),
         timestamp="t",

--- a/plugins/plugin-eval/tests/test_judge.py
+++ b/plugins/plugin-eval/tests/test_judge.py
@@ -137,3 +137,4 @@ class TestUnmeasuredPropagation:
         assert set(result.sub_scores) == {"triggering_accuracy", "output_quality"}
         assert result.sub_scores["triggering_accuracy"] == 0.9
         assert set(result.metadata["unmeasured"]) == {"orchestration_fitness", "scope_calibration"}
+        assert abs(result.score - 0.85) < 1e-9

--- a/plugins/plugin-eval/tests/test_judge.py
+++ b/plugins/plugin-eval/tests/test_judge.py
@@ -59,7 +59,7 @@ class TestJudgeConfig:
     def test_default_config(self):
         config = JudgeConfig()
         assert config.judges == 1
-        assert config.auth == "max"
+        assert config.concurrency == 4
 
 
 class TestJudgeAnalyzer:

--- a/plugins/plugin-eval/tests/test_judge.py
+++ b/plugins/plugin-eval/tests/test_judge.py
@@ -49,6 +49,11 @@ class TestExtractAndParse:
         assert out["unmeasured"] is True
         assert out["raw"] == "not json at all"
 
+    def test_errored_result_with_partial_text_includes_raw(self):
+        out = _extract_and_parse([_assistant('{"f1": 0.9}'), _result(is_error=True)])
+        assert out["unmeasured"] is True
+        assert out["raw"] == '{"f1": 0.9}'
+
 
 class TestJudgeConfig:
     def test_default_config(self):

--- a/plugins/plugin-eval/tests/test_judge.py
+++ b/plugins/plugin-eval/tests/test_judge.py
@@ -2,9 +2,19 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
 
-from plugin_eval.layers.judge import JudgeAnalyzer, JudgeConfig, _extract_and_parse
+# claude-agent-sdk lives in the optional `llm` extra; skip these SDK-object tests
+# (rather than fail collection) when a dev installed only the `dev` extra.
+pytest.importorskip("claude_agent_sdk")
+
+from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock  # noqa: E402
+
+from plugin_eval.layers.judge import (  # noqa: E402
+    JudgeAnalyzer,
+    JudgeConfig,
+    _extract_and_parse,
+    _measured_score,
+)
 
 
 def _assistant(text: str) -> AssistantMessage:
@@ -138,3 +148,20 @@ class TestUnmeasuredPropagation:
         assert result.sub_scores["triggering_accuracy"] == 0.9
         assert set(result.metadata["unmeasured"]) == {"orchestration_fitness", "scope_calibration"}
         assert abs(result.score - 0.85) < 1e-9
+
+
+class TestMeasuredScoreNonDict:
+    def test_list_result_is_unmeasured(self):
+        assert _measured_score([], "f1") is None
+
+    def test_string_result_is_unmeasured(self):
+        assert _measured_score("oops", "score") is None
+
+    def test_dict_result_still_extracts(self):
+        assert _measured_score({"f1": 0.9}, "f1") == 0.9
+
+
+class TestWhitespaceFallback:
+    def test_whitespace_text_falls_back_to_result(self):
+        out = _extract_and_parse([_assistant("   \n"), _result(result='{"f1": 1.0}')])
+        assert out == {"f1": 1.0}

--- a/plugins/plugin-eval/tests/test_judge.py
+++ b/plugins/plugin-eval/tests/test_judge.py
@@ -1,9 +1,53 @@
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import pytest
+from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
 
-from plugin_eval.layers.judge import JudgeAnalyzer, JudgeConfig
+from plugin_eval.layers.judge import JudgeAnalyzer, JudgeConfig, _extract_and_parse
+
+
+def _assistant(text: str) -> AssistantMessage:
+    return AssistantMessage(content=[TextBlock(text=text)], model="claude-sonnet-4-6")
+
+
+def _result(*, is_error: bool = False, result: str | None = None) -> ResultMessage:
+    return ResultMessage(
+        subtype="success" if not is_error else "error",
+        duration_ms=1,
+        duration_api_ms=1,
+        is_error=is_error,
+        num_turns=1,
+        session_id="t",
+        result=result,
+    )
+
+
+class TestExtractAndParse:
+    def test_parses_assistant_text_json(self):
+        msgs = [_assistant('{"f1": 1.0}'), _result(result="ignored")]
+        assert _extract_and_parse(msgs) == {"f1": 1.0}
+
+    def test_parses_json_in_code_fence(self):
+        msgs = [_assistant('```json\n{"score": 0.8}\n```'), _result()]
+        assert _extract_and_parse(msgs) == {"score": 0.8}
+
+    def test_falls_back_to_result_field_when_no_assistant_text(self):
+        msgs = [_result(result='{"score": 0.7}')]
+        assert _extract_and_parse(msgs) == {"score": 0.7}
+
+    def test_errored_result_is_unmeasured(self):
+        msgs = [_result(is_error=True)]
+        out = _extract_and_parse(msgs)
+        assert out["unmeasured"] is True
+
+    def test_empty_output_is_unmeasured(self):
+        assert _extract_and_parse([_result()])["unmeasured"] is True
+
+    def test_non_json_is_unmeasured(self):
+        out = _extract_and_parse([_assistant("not json at all"), _result()])
+        assert out["unmeasured"] is True
+        assert out["raw"] == "not json at all"
 
 
 class TestJudgeConfig:

--- a/plugins/plugin-eval/tests/test_judge.py
+++ b/plugins/plugin-eval/tests/test_judge.py
@@ -105,3 +105,35 @@ class TestJudgeAnalyzer:
         result = await analyzer.analyze_skill(sample_skill_dir)
         assert result.layer == "judge"
         assert result.score > 0
+
+
+class TestUnmeasuredPropagation:
+    @pytest.mark.asyncio
+    @patch("plugin_eval.layers.judge.query_llm")
+    async def test_all_unmeasured_yields_empty_sub_scores(self, mock_query, sample_skill_dir: Path):
+        mock_query.return_value = {"unmeasured": True, "error": "no text"}
+        analyzer = JudgeAnalyzer(JudgeConfig())
+        result = await analyzer.analyze_skill(sample_skill_dir)
+        assert result.sub_scores == {}
+        assert result.score == 0.0
+        assert set(result.metadata["unmeasured"]) == {
+            "triggering_accuracy",
+            "orchestration_fitness",
+            "output_quality",
+            "scope_calibration",
+        }
+
+    @pytest.mark.asyncio
+    @patch("plugin_eval.layers.judge.query_llm")
+    async def test_partial_measurement_omits_only_failed(self, mock_query, sample_skill_dir: Path):
+        mock_query.side_effect = [
+            {"f1": 0.9, "predictions": []},  # triggering measured
+            {"unmeasured": True, "error": "x"},  # orchestration failed
+            {"score": 0.8, "simulations": []},  # output measured
+            {"unmeasured": True, "error": "x"},  # scope failed
+        ]
+        analyzer = JudgeAnalyzer(JudgeConfig())
+        result = await analyzer.analyze_skill(sample_skill_dir)
+        assert set(result.sub_scores) == {"triggering_accuracy", "output_quality"}
+        assert result.sub_scores["triggering_accuracy"] == 0.9
+        assert set(result.metadata["unmeasured"]) == {"orchestration_fitness", "scope_calibration"}

--- a/plugins/plugin-eval/tests/test_models.py
+++ b/plugins/plugin-eval/tests/test_models.py
@@ -21,7 +21,6 @@ class TestEvalConfig:
         config = EvalConfig()
         assert config.depth == Depth.STANDARD
         assert config.concurrency == 4
-        assert config.auth == "max"
 
     def test_custom_config(self):
         config = EvalConfig(depth=Depth.DEEP, concurrency=8)

--- a/plugins/plugin-eval/tests/test_monte_carlo.py
+++ b/plugins/plugin-eval/tests/test_monte_carlo.py
@@ -2,9 +2,16 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
 
-from plugin_eval.layers.monte_carlo import (
+from plugin_eval.layers._sdk import usage_total_tokens
+
+# claude-agent-sdk lives in the optional `llm` extra; skip these SDK-object tests
+# (rather than fail collection) when a dev installed only the `dev` extra.
+pytest.importorskip("claude_agent_sdk")
+
+from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock  # noqa: E402
+
+from plugin_eval.layers.monte_carlo import (  # noqa: E402
     MonteCarloAnalyzer,
     MonteCarloConfig,
     SimResult,
@@ -16,7 +23,9 @@ def _assistant(text: str) -> AssistantMessage:
     return AssistantMessage(content=[TextBlock(text=text)], model="claude-sonnet-4-6")
 
 
-def _result(*, is_error: bool = False) -> ResultMessage:
+def _result(
+    *, is_error: bool = False, result: str | None = None, usage: dict | None = None
+) -> ResultMessage:
     return ResultMessage(
         subtype="success" if not is_error else "error",
         duration_ms=1,
@@ -24,6 +33,8 @@ def _result(*, is_error: bool = False) -> ResultMessage:
         is_error=is_error,
         num_turns=1,
         session_id="t",
+        result=result,
+        usage=usage,
     )
 
 
@@ -42,6 +53,21 @@ class TestSimResultFromMessages:
     def test_errored_result_flagged(self):
         sim = _simresult_from_messages([_result(is_error=True)], "p", 10)
         assert sim.errored is True
+
+    def test_activated_via_result_fallback(self):
+        # A run that emits only a terminal ResultMessage.result (no AssistantMessage
+        # text) must still count as activated, using the shared result fallback.
+        sim = _simresult_from_messages([_result(result="x" * 250)], "p", 10)
+        assert sim.activated is True
+        assert sim.quality_score == 0.5
+
+    def test_tokens_summed_from_usage(self):
+        sim = _simresult_from_messages(
+            [_assistant("hi"), _result(usage={"input_tokens": 3, "output_tokens": 4})],
+            "p",
+            10,
+        )
+        assert sim.tokens == 7
 
 
 class TestSimResult:
@@ -83,3 +109,15 @@ class TestMonteCarloAnalyzer:
         assert stats["triggering"]["activation_rate"] == pytest.approx(0.98)
         assert stats["failure_rate"]["p_fail"] == pytest.approx(0.02)
         assert stats["output_consistency"]["cv"] < 0.15
+
+
+class TestUsageTotalTokens:
+    def test_sums_component_token_fields(self):
+        assert usage_total_tokens({"input_tokens": 10, "output_tokens": 5}) == 15
+
+    def test_prefers_explicit_total_tokens(self):
+        assert usage_total_tokens({"total_tokens": 20, "input_tokens": 1}) == 20
+
+    def test_none_and_empty_are_zero(self):
+        assert usage_total_tokens(None) == 0
+        assert usage_total_tokens({}) == 0

--- a/plugins/plugin-eval/tests/test_monte_carlo.py
+++ b/plugins/plugin-eval/tests/test_monte_carlo.py
@@ -1,10 +1,10 @@
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import pytest
+from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
 
 from plugin_eval.layers.monte_carlo import MonteCarloAnalyzer, MonteCarloConfig, SimResult
-from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
 from plugin_eval.layers.monte_carlo import _simresult_from_messages
 
 

--- a/plugins/plugin-eval/tests/test_monte_carlo.py
+++ b/plugins/plugin-eval/tests/test_monte_carlo.py
@@ -4,6 +4,36 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from plugin_eval.layers.monte_carlo import MonteCarloAnalyzer, MonteCarloConfig, SimResult
+from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
+from plugin_eval.layers.monte_carlo import _simresult_from_messages
+
+
+def _assistant(text: str) -> AssistantMessage:
+    return AssistantMessage(content=[TextBlock(text=text)], model="claude-sonnet-4-6")
+
+
+def _result(*, is_error: bool = False) -> ResultMessage:
+    return ResultMessage(
+        subtype="success" if not is_error else "error",
+        duration_ms=1, duration_api_ms=1, is_error=is_error, num_turns=1, session_id="t",
+    )
+
+
+class TestSimResultFromMessages:
+    def test_activated_when_assistant_text_present(self):
+        sim = _simresult_from_messages([_assistant("x" * 250), _result()], "p", 10)
+        assert sim.activated is True
+        assert sim.quality_score == 0.5
+        assert sim.errored is False
+
+    def test_not_activated_when_no_text(self):
+        sim = _simresult_from_messages([_result()], "p", 10)
+        assert sim.activated is False
+        assert sim.quality_score == 0.0
+
+    def test_errored_result_flagged(self):
+        sim = _simresult_from_messages([_result(is_error=True)], "p", 10)
+        assert sim.errored is True
 
 
 class TestSimResult:

--- a/plugins/plugin-eval/tests/test_monte_carlo.py
+++ b/plugins/plugin-eval/tests/test_monte_carlo.py
@@ -4,8 +4,12 @@ from unittest.mock import patch
 import pytest
 from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
 
-from plugin_eval.layers.monte_carlo import MonteCarloAnalyzer, MonteCarloConfig, SimResult
-from plugin_eval.layers.monte_carlo import _simresult_from_messages
+from plugin_eval.layers.monte_carlo import (
+    MonteCarloAnalyzer,
+    MonteCarloConfig,
+    SimResult,
+    _simresult_from_messages,
+)
 
 
 def _assistant(text: str) -> AssistantMessage:
@@ -15,7 +19,11 @@ def _assistant(text: str) -> AssistantMessage:
 def _result(*, is_error: bool = False) -> ResultMessage:
     return ResultMessage(
         subtype="success" if not is_error else "error",
-        duration_ms=1, duration_api_ms=1, is_error=is_error, num_turns=1, session_id="t",
+        duration_ms=1,
+        duration_api_ms=1,
+        is_error=is_error,
+        num_turns=1,
+        session_id="t",
     )
 
 
@@ -66,7 +74,9 @@ class TestMonteCarloAnalyzer:
             SimResult(activated=True, quality_score=0.8 + i * 0.002, tokens=2500, duration_ms=1200)
             for i in range(48)
         ] + [
-            SimResult(activated=False, quality_score=0.0, tokens=500, duration_ms=200, errored=True),
+            SimResult(
+                activated=False, quality_score=0.0, tokens=500, duration_ms=200, errored=True
+            ),
             SimResult(activated=True, quality_score=0.75, tokens=8000, duration_ms=5000),
         ]
         stats = analyzer._compute_statistics(results)

--- a/plugins/review-agent-governance/policies/review-agent-governance.cedar
+++ b/plugins/review-agent-governance/policies/review-agent-governance.cedar
@@ -42,6 +42,7 @@ forbid (
     resource
 ) when {
     ["git push", "git push --force", "git push -f"].contains(context.command_pattern) &&
+    context has target_branch &&
     ["main", "master", "release", "production"].contains(context.target_branch)
 };
 

--- a/plugins/review-agent-governance/policies/review-agent-governance.cedar
+++ b/plugins/review-agent-governance/policies/review-agent-governance.cedar
@@ -20,19 +20,9 @@ forbid (
     action == Action::"Bash",
     resource
 ) when {
-    context.command_pattern in [
-        "gh pr review",
-        "gh pr comment",
-        "gh pr close",
-        "gh pr merge",
-        "gh pr edit",
-        "gh issue comment",
-        "gh issue close",
-        "gh issue edit",
-        "gh release create",
-        "gh release edit",
-        "gh api repos"
-    ]
+    ["gh pr review", "gh pr comment", "gh pr close", "gh pr merge", "gh pr edit",
+     "gh issue comment", "gh issue close", "gh issue edit", "gh release create",
+     "gh release edit", "gh api repos"].contains(context.command_pattern)
 };
 
 // 2. Posting via GitLab / Bitbucket CLIs
@@ -41,12 +31,8 @@ forbid (
     action == Action::"Bash",
     resource
 ) when {
-    context.command_pattern in [
-        "glab mr comment",
-        "glab mr approve",
-        "glab mr merge",
-        "glab issue comment"
-    ]
+    ["glab mr comment", "glab mr approve", "glab mr merge",
+     "glab issue comment"].contains(context.command_pattern)
 };
 
 // 3. Git operations on protected branches
@@ -55,8 +41,8 @@ forbid (
     action == Action::"Bash",
     resource
 ) when {
-    context.command_pattern in ["git push", "git push --force", "git push -f"] &&
-    context.target_branch in ["main", "master", "release", "production"]
+    ["git push", "git push --force", "git push -f"].contains(context.command_pattern) &&
+    ["main", "master", "release", "production"].contains(context.target_branch)
 };
 
 // 4. Direct writes to CI / CD configuration paths. Modifying these files lets
@@ -67,13 +53,8 @@ forbid (
     action in [Action::"Write", Action::"Edit"],
     resource
 ) when {
-    context.path_starts_with in [
-        ".github/workflows/",
-        ".github/CODEOWNERS",
-        ".gitlab-ci.yml",
-        ".circleci/config.yml",
-        "buildkite/pipeline.yml"
-    ]
+    [".github/workflows/", ".github/CODEOWNERS", ".gitlab-ci.yml",
+     ".circleci/config.yml", "buildkite/pipeline.yml"].contains(context.path_starts_with)
 };
 
 // 5. WebFetch POSTs to known review / chat platforms
@@ -83,13 +64,8 @@ forbid (
     resource
 ) when {
     context.method == "POST" &&
-    context.url_host in [
-        "api.github.com",
-        "api.gitlab.com",
-        "api.bitbucket.org",
-        "hooks.slack.com",
-        "discord.com"
-    ]
+    ["api.github.com", "api.gitlab.com", "api.bitbucket.org",
+     "hooks.slack.com", "discord.com"].contains(context.url_host)
 };
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/plugins/review-agent-governance/policies/review-agent-governance.cedarschema
+++ b/plugins/review-agent-governance/policies/review-agent-governance.cedarschema
@@ -4,7 +4,7 @@ entity Resource;
 action "Bash" appliesTo {
   principal: [User],
   resource: [Resource],
-  context: { command_pattern: String, target_branch: String }
+  context: { command_pattern: String, target_branch?: String }
 };
 
 action "Write" appliesTo {

--- a/plugins/review-agent-governance/policies/review-agent-governance.cedarschema
+++ b/plugins/review-agent-governance/policies/review-agent-governance.cedarschema
@@ -1,0 +1,26 @@
+entity User;
+entity Resource;
+
+action "Bash" appliesTo {
+  principal: [User],
+  resource: [Resource],
+  context: { command_pattern: String, target_branch: String }
+};
+
+action "Write" appliesTo {
+  principal: [User],
+  resource: [Resource],
+  context: { path_starts_with: String }
+};
+
+action "Edit" appliesTo {
+  principal: [User],
+  resource: [Resource],
+  context: { path_starts_with: String }
+};
+
+action "WebFetch" appliesTo {
+  principal: [User],
+  resource: [Resource],
+  context: { method: String, url_host: String }
+};

--- a/plugins/review-agent-governance/test/README.md
+++ b/plugins/review-agent-governance/test/README.md
@@ -1,0 +1,19 @@
+# review-agent-governance policy tests
+
+Guards `policies/review-agent-governance.cedar` against the #598 `in`-on-String
+forbid bug.
+
+```bash
+./run-tests.sh   # exit 0 pass · 1 fail
+```
+
+- **Part A** (always runs, needs only `grep`): asserts the policy contains no
+  `context.<attr> in [ ... ]` forbid pattern (which Cedar silently discards) and
+  uses `[ ... ].contains(context.<attr>)` instead.
+- **Part B** (runs only if the `cedar` CLI is installed): `cedar validate` the
+  policy against `review-agent-governance.cedarschema`. With the context
+  attributes typed as `String`, `cedar validate` rejects the `in`-on-String form
+  at load time and accepts `.contains()`.
+
+Note: the shipped runtime is `protect-mcp serve` (Cedar-via-WASM); this test
+validates the policy source directly and does not depend on protect-mcp.

--- a/plugins/review-agent-governance/test/run-tests.sh
+++ b/plugins/review-agent-governance/test/run-tests.sh
@@ -5,7 +5,7 @@
 # Exit codes: 0 pass, 1 fail.
 set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$SCRIPT_DIR"
+cd "$SCRIPT_DIR" || { echo "FAIL: cannot cd to script dir: $SCRIPT_DIR"; exit 1; }
 POLICY="../policies/review-agent-governance.cedar"
 SCHEMA="../policies/review-agent-governance.cedarschema"
 
@@ -17,11 +17,13 @@ fail() { echo "FAIL: ${1:-?}"; FAIL=$((FAIL+1)); }
 
 echo "=== Part A: no in-on-String forbid pattern (always runs) ==="
 # The bug pattern is `context.<attr> in [` inside a forbid rule. The fixed form
-# is `[ ... ].contains(context.<attr>)`. Assert the bad pattern is absent.
-bad_hits=$(grep -nE 'context\.[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]+in[[:space:]]*\[' "$POLICY" 2>/dev/null)
-if [ -n "$bad_hits" ]; then
+# is `[ ... ].contains(context.<attr>)`. Flatten whitespace first so a reformat
+# that splits the expression across lines can't slip past the guard.
+attr_re='context\.[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]+in[[:space:]]*\['
+flat=$(tr '\n' ' ' <"$POLICY" | tr -s '[:space:]' ' ')
+if printf '%s' "$flat" | grep -qE "$attr_re"; then
   fail "policy still uses 'context.<attr> in [ ... ]' (the discarded-forbid bug)"
-  echo "$bad_hits"
+  grep -nE "$attr_re" "$POLICY" 2>/dev/null || echo "  (match spans multiple lines)"
 else
   pass "no in-on-String forbid pattern present"
 fi

--- a/plugins/review-agent-governance/test/run-tests.sh
+++ b/plugins/review-agent-governance/test/run-tests.sh
@@ -18,9 +18,10 @@ fail() { echo "FAIL: ${1:-?}"; FAIL=$((FAIL+1)); }
 echo "=== Part A: no in-on-String forbid pattern (always runs) ==="
 # The bug pattern is `context.<attr> in [` inside a forbid rule. The fixed form
 # is `[ ... ].contains(context.<attr>)`. Assert the bad pattern is absent.
-if grep -nE 'context\.[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]+in[[:space:]]*\[' "$POLICY" >/dev/null; then
+bad_hits=$(grep -nE 'context\.[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]+in[[:space:]]*\[' "$POLICY" 2>/dev/null)
+if [ -n "$bad_hits" ]; then
   fail "policy still uses 'context.<attr> in [ ... ]' (the discarded-forbid bug)"
-  grep -nE 'context\.[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]+in[[:space:]]*\[' "$POLICY"
+  echo "$bad_hits"
 else
   pass "no in-on-String forbid pattern present"
 fi

--- a/plugins/review-agent-governance/test/run-tests.sh
+++ b/plugins/review-agent-governance/test/run-tests.sh
@@ -9,16 +9,18 @@ cd "$SCRIPT_DIR"
 POLICY="../policies/review-agent-governance.cedar"
 SCHEMA="../policies/review-agent-governance.cedarschema"
 
+[ -f "$POLICY" ] || { echo "FAIL: policy file not found: $POLICY"; exit 1; }
+
 PASS=0; FAIL=0
-pass() { echo "PASS: $1"; PASS=$((PASS+1)); }
-fail() { echo "FAIL: $1"; FAIL=$((FAIL+1)); }
+pass() { echo "PASS: ${1:-?}"; PASS=$((PASS+1)); }
+fail() { echo "FAIL: ${1:-?}"; FAIL=$((FAIL+1)); }
 
 echo "=== Part A: no in-on-String forbid pattern (always runs) ==="
 # The bug pattern is `context.<attr> in [` inside a forbid rule. The fixed form
 # is `[ ... ].contains(context.<attr>)`. Assert the bad pattern is absent.
-if grep -nE 'context\.[a-z_]+[[:space:]]+in[[:space:]]*\[' "$POLICY" >/dev/null; then
+if grep -nE 'context\.[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]+in[[:space:]]*\[' "$POLICY" >/dev/null; then
   fail "policy still uses 'context.<attr> in [ ... ]' (the discarded-forbid bug)"
-  grep -nE 'context\.[a-z_]+[[:space:]]+in[[:space:]]*\[' "$POLICY"
+  grep -nE 'context\.[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]+in[[:space:]]*\[' "$POLICY"
 else
   pass "no in-on-String forbid pattern present"
 fi

--- a/plugins/review-agent-governance/test/run-tests.sh
+++ b/plugins/review-agent-governance/test/run-tests.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# run-tests.sh — guard review-agent-governance.cedar against the in-on-String
+# forbid bug (#598). Part A (grep) always runs; Part B (cedar validate) runs
+# only if the `cedar` CLI is installed, else SKIPs without failing.
+# Exit codes: 0 pass, 1 fail.
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+POLICY="../policies/review-agent-governance.cedar"
+SCHEMA="../policies/review-agent-governance.cedarschema"
+
+PASS=0; FAIL=0
+pass() { echo "PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL+1)); }
+
+echo "=== Part A: no in-on-String forbid pattern (always runs) ==="
+# The bug pattern is `context.<attr> in [` inside a forbid rule. The fixed form
+# is `[ ... ].contains(context.<attr>)`. Assert the bad pattern is absent.
+if grep -nE 'context\.[a-z_]+[[:space:]]+in[[:space:]]*\[' "$POLICY" >/dev/null; then
+  fail "policy still uses 'context.<attr> in [ ... ]' (the discarded-forbid bug)"
+  grep -nE 'context\.[a-z_]+[[:space:]]+in[[:space:]]*\[' "$POLICY"
+else
+  pass "no in-on-String forbid pattern present"
+fi
+# And assert the fixed idiom is actually used.
+if grep -qE '\]\.contains\(context\.' "$POLICY"; then
+  pass "policy uses [ ... ].contains(context.<attr>)"
+else
+  fail "policy does not use the expected .contains() idiom"
+fi
+
+echo "=== Part B: cedar validate against schema (if cedar CLI present) ==="
+if command -v cedar >/dev/null 2>&1; then
+  if cedar validate --policies "$POLICY" --schema "$SCHEMA"; then
+    pass "cedar validate succeeds (policy is well-typed)"
+  else
+    fail "cedar validate failed"
+  fi
+else
+  echo "SKIP: 'cedar' CLI not found — Part B skipped (Part A still gates)."
+fi
+
+echo ""; echo "Passed: $PASS, Failed: $FAIL"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

Fixes two open issues, plus surfaces a third (filed separately).

### #591 — plugin-eval LLM judge silently emitted fabricated 0.5 scores
`query_llm` (and the Monte Carlo `run_simulation`) read response text from `ResultMessage.content`, which does not exist on that `claude-agent-sdk` type — so the judge always saw empty text, JSON parsing always failed, and every dimension silently fell back to `0.5` (grade **F**) while the command exited 0. The judge carries ~72% of the rubric weight, so genuinely strong skills were reported as failing.

- Read assistant text the documented way — `AssistantMessage` → `TextBlock.text`, with `ResultMessage.result` as fallback — in both the judge and Monte Carlo layers (shared `layers/_sdk.py::collect_sdk_output`).
- Genuine measurement failures (errored / empty / unparseable, or SDK missing) now surface as **"unmeasured"** — the dimension is omitted from `sub_scores` so the composite engine recomputes static-only, and the CLI prints a clear stderr warning — instead of fabricating `0.5`.
- Removed dead `auth` / `model_tier` config that was threaded through but never used.
- Added real (non-mocked) extraction tests that exercise the actual SDK-message path that let this bug ship.

### #598 — review-agent-governance Cedar `in`-on-String silently disabled forbid rules
All 5 `forbid` rules used `context.<stringAttr> in [strings]`. In Cedar `in` requires an **entity** LHS, so this is a type error the engine discards — leaving the terminal `permit` to fire. The reporter is essentially correct (the runtime evaluates Cedar via the real engine).

- Rewrote all 5 rules to the validator-clean set form `["s1","s2"].contains(context.<attr>)` (legitimate entity-`in` on the `action` scope left untouched).
- Added a `.cedarschema` typing the context attributes as `String` so `cedar validate` catches this class of mistake at load time.
- Added a regression test (`test/run-tests.sh`): Part A (always runs) greps for the bug pattern; Part B runs `cedar validate` when the CLI is present.

### ⚠️ Separate finding surfaced while verifying #598
The plugin's `hooks/hooks.json` invokes `protect-mcp@0.5.5 evaluate` / `sign` subcommands that **do not exist** in that version (its CLI is `serve` / `init-hooks` / `simulate` / `--cedar`). So the governance gate does not run as shipped, independent of the Cedar syntax. This is a larger defect than #598 as filed and is being tracked as its own issue.

## Verification
- `make test` (plugin-eval + tools), `make validate STRICT=1`, `make garden`, and `make generate-all` drift check all pass; **122 plugin-eval tests pass**; `src/plugin_eval/` is ruff + format + ty clean.
- Cedar policy test passes (Part A); Part B skips gracefully where the `cedar` CLI is absent.

## Notes
- Relates to #591 and #598 (intentionally not auto-closing — the issue replies/closes and the new broken-hook issue are being handled separately).
- Design + plan: `docs/superpowers/specs/2026-06-25-open-issue-resolution-design.md`, `docs/superpowers/plans/2026-06-25-open-issue-resolution.md`.
- Known follow-ups (out of scope here): route the Monte Carlo layer through the same "unmeasured" omission as the judge; wire `cedar validate` into `make validate`; fix/regenerate the protect-mcp hook integration.
