### PR TITLE
Pin protect-mcp@0.7.4 in the governance plugins (closes #601)

### DIFF
--- a/plugins/protect-mcp/hooks/hooks.json
+++ b/plugins/protect-mcp/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx protect-mcp@0.7.0 evaluate --policy \"${PROTECT_MCP_POLICY:-./protect.cedar}\" --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --fail-on-missing-policy false"
+            "command": "npx protect-mcp@0.7.4 evaluate --policy \"${PROTECT_MCP_POLICY:-./protect.cedar}\" --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --fail-on-missing-policy false"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx protect-mcp@0.7.0 sign --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --output \"$TOOL_OUTPUT\" --receipts \"${PROTECT_MCP_RECEIPTS:-./receipts/}\" --key \"${PROTECT_MCP_KEY:-./protect-mcp.key}\""
+            "command": "npx protect-mcp@0.7.4 sign --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --output \"$TOOL_OUTPUT\" --receipts \"${PROTECT_MCP_RECEIPTS:-./receipts/}\" --key \"${PROTECT_MCP_KEY:-./protect-mcp.key}\""
           }
         ]
       }

--- a/plugins/protect-mcp/hooks/hooks.json
+++ b/plugins/protect-mcp/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx protect-mcp@0.5.5 evaluate --policy \"${PROTECT_MCP_POLICY:-./protect.cedar}\" --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --fail-on-missing-policy false"
+            "command": "npx protect-mcp@0.7.0 evaluate --policy \"${PROTECT_MCP_POLICY:-./protect.cedar}\" --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --fail-on-missing-policy false"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx protect-mcp@0.5.5 sign --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --output \"$TOOL_OUTPUT\" --receipts \"${PROTECT_MCP_RECEIPTS:-./receipts/}\" --key \"${PROTECT_MCP_KEY:-./protect-mcp.key}\""
+            "command": "npx protect-mcp@0.7.0 sign --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --output \"$TOOL_OUTPUT\" --receipts \"${PROTECT_MCP_RECEIPTS:-./receipts/}\" --key \"${PROTECT_MCP_KEY:-./protect-mcp.key}\""
           }
         ]
       }

--- a/plugins/protect-mcp/test/expected/receipt-schema.json
+++ b/plugins/protect-mcp/test/expected/receipt-schema.json
@@ -1,32 +1,81 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://veritasacta.com/schemas/receipt-v1.json",
-  "title": "Veritas Acta Decision Receipt v1",
-  "description": "Expected shape of a protect-mcp-produced receipt. Mirrors draft-farley-acta-signed-receipts.",
+  "$id": "https://veritasacta.com/schemas/receipt-v2.json",
+  "title": "Veritas Acta Decision Receipt (v2 envelope)",
+  "description": "Expected shape of a protect-mcp@0.7.4 receipt. Mirrors draft-farley-acta-signed-receipts; the decision facts live in payload, signed as a unit.",
   "type": "object",
   "required": [
-    "receipt_id",
-    "receipt_version",
-    "issuer_id",
-    "event_time",
-    "tool_name",
-    "decision",
-    "public_key",
+    "v",
+    "type",
+    "algorithm",
+    "kid",
+    "issuer",
+    "issued_at",
+    "payload",
     "signature"
   ],
   "properties": {
-    "receipt_id":      { "type": "string", "pattern": "^rec_" },
-    "receipt_version": { "type": "string", "const": "1.0" },
-    "issuer_id":       { "type": "string" },
-    "event_time":      { "type": "string", "format": "date-time" },
-    "tool_name":       { "type": "string" },
-    "input_hash":      { "type": "string", "pattern": "^sha256:" },
-    "decision":        { "type": "string", "enum": ["allow", "deny"] },
-    "policy_id":       { "type": "string" },
-    "policy_digest":   { "type": "string", "pattern": "^sha256:" },
-    "parent_receipt_id": { "type": ["string", "null"] },
-    "public_key":      { "type": "string", "minLength": 32 },
-    "signature":       { "type": "string", "minLength": 32 }
+    "v": {
+      "type": "integer",
+      "const": 2
+    },
+    "type": {
+      "type": "string",
+      "enum": [
+        "decision_receipt",
+        "gateway_restraint"
+      ]
+    },
+    "algorithm": {
+      "type": "string",
+      "const": "ed25519"
+    },
+    "kid": {
+      "type": "string"
+    },
+    "issuer": {
+      "type": "string"
+    },
+    "issued_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "payload": {
+      "type": "object",
+      "required": [
+        "tool",
+        "decision"
+      ],
+      "properties": {
+        "tool": {
+          "type": "string"
+        },
+        "decision": {
+          "type": "string",
+          "enum": [
+            "allow",
+            "deny"
+          ]
+        },
+        "reason_code": {
+          "type": "string"
+        },
+        "policy_digest": {
+          "type": "string"
+        },
+        "request_id": {
+          "type": "string"
+        },
+        "spec": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "signature": {
+      "type": "string",
+      "minLength": 32
+    }
   },
   "additionalProperties": true
 }

--- a/plugins/protect-mcp/test/fixtures/test-policy.cedar
+++ b/plugins/protect-mcp/test/fixtures/test-policy.cedar
@@ -1,37 +1,58 @@
 // Test Cedar policy for protect-mcp hook round-trip tests.
+// Written for the entity shape protect-mcp >= 0.7.0 actually evaluates:
+//   principal Agent::"<id>", action Action::"MCP::Tool::call",
+//   resource Tool::"<toolName>", with the tool input at context.input.
+// (0.5.5's evaluator did not evaluate Cedar correctly, so the old
+// Action::"Read"-shaped policy only appeared to work.)
 // Not a production example. See ../../agents/policy-enforcer.md for real-world policies.
 
-// Allow all read-oriented tools.
+// Allow read-oriented tools.
 permit (
     principal,
-    action in [Action::"Read", Action::"Glob", Action::"Grep", Action::"WebSearch"],
+    action == Action::"MCP::Tool::call",
     resource
-);
+) when {
+    resource == Tool::"Read" || resource == Tool::"Glob" ||
+    resource == Tool::"Grep" || resource == Tool::"WebSearch"
+};
 
-// Allow safe Bash commands only.
+// Allow Bash only for safe command prefixes.
 permit (
     principal,
-    action == Action::"Bash",
-    resource
+    action == Action::"MCP::Tool::call",
+    resource == Tool::"Bash"
 ) when {
-    context.command_pattern in ["git", "npm", "ls", "cat", "echo", "pwd", "test", "node"]
+    context has input && context.input has command &&
+    (context.input.command like "git*" ||
+     context.input.command like "npm*" ||
+     context.input.command like "ls*" ||
+     context.input.command like "cat*" ||
+     context.input.command like "echo*" ||
+     context.input.command like "pwd*" ||
+     context.input.command like "node*")
 };
 
-// Explicit deny on destructive commands, even if permit would match elsewhere.
-// Cedar deny is authoritative.
+// Explicit deny on destructive commands, even if a permit matches elsewhere.
+// Cedar forbid is authoritative.
 forbid (
     principal,
-    action == Action::"Bash",
-    resource
+    action == Action::"MCP::Tool::call",
+    resource == Tool::"Bash"
 ) when {
-    context.command_pattern in ["rm -rf", "dd", "mkfs", "shred", ":(){ :|:& };:"]
+    context has input && context.input has command &&
+    (context.input.command like "*rm -rf*" ||
+     context.input.command like "dd *" ||
+     context.input.command like "*mkfs*" ||
+     context.input.command like "*shred*")
 };
 
-// Writes are denied unscoped. A real policy would permit writes when
-// context.path_starts_with is safe. The tests exercise the unscoped
-// form so we can verify deny is enforced.
+// Writes are denied unscoped. A real policy would permit writes when the
+// target path is safe. The tests exercise the unscoped form so we can
+// verify deny is enforced.
 forbid (
     principal,
-    action in [Action::"Write", Action::"Edit"],
+    action == Action::"MCP::Tool::call",
     resource
-);
+) when {
+    resource == Tool::"Write" || resource == Tool::"Edit"
+};

--- a/plugins/protect-mcp/test/run-tests.sh
+++ b/plugins/protect-mcp/test/run-tests.sh
@@ -55,7 +55,7 @@ extract() { python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d
 echo ""
 echo "=== Test 1: PreToolUse permit on Read ==="
 INPUT=fixtures/pretool-allow-read.json
-npx --yes protect-mcp@0.5.5 evaluate \
+npx --yes protect-mcp@0.7.4 evaluate \
     --policy fixtures/test-policy.cedar \
     --tool "$(extract "$INPUT" tool_name)" \
     --input "$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1]))["tool_input"]))' "$INPUT")" \
@@ -66,7 +66,7 @@ check_exit $? 0 "Read is permitted by test-policy.cedar"
 echo ""
 echo "=== Test 2: PreToolUse permit on Bash git ==="
 INPUT=fixtures/pretool-allow-bash-safe.json
-npx --yes protect-mcp@0.5.5 evaluate \
+npx --yes protect-mcp@0.7.4 evaluate \
     --policy fixtures/test-policy.cedar \
     --tool "$(extract "$INPUT" tool_name)" \
     --input "$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1]))["tool_input"]))' "$INPUT")" \
@@ -77,7 +77,7 @@ check_exit $? 0 "Bash 'git status' is permitted"
 echo ""
 echo "=== Test 3: PreToolUse forbid on Bash rm -rf ==="
 INPUT=fixtures/pretool-deny-bash-destructive.json
-npx --yes protect-mcp@0.5.5 evaluate \
+npx --yes protect-mcp@0.7.4 evaluate \
     --policy fixtures/test-policy.cedar \
     --tool "$(extract "$INPUT" tool_name)" \
     --input "$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1]))["tool_input"]))' "$INPUT")" \
@@ -88,7 +88,7 @@ check_exit $? 2 "Bash 'rm -rf /' is denied with exit 2"
 echo ""
 echo "=== Test 4: PreToolUse forbid on Write ==="
 INPUT=fixtures/pretool-deny-write.json
-npx --yes protect-mcp@0.5.5 evaluate \
+npx --yes protect-mcp@0.7.4 evaluate \
     --policy fixtures/test-policy.cedar \
     --tool "$(extract "$INPUT" tool_name)" \
     --input "$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1]))["tool_input"]))' "$INPUT")" \
@@ -98,9 +98,10 @@ check_exit $? 2 "Write is denied with exit 2"
 # --- Test 5: PostToolUse produces a receipt ---------------------------------
 echo ""
 echo "=== Test 5: PostToolUse sign produces a receipt ==="
-KEY="$WORKDIR/test.key"
-npx --yes protect-mcp@0.5.5 keygen --out "$KEY" >/dev/null 2>&1 || \
-    echo "note: keygen subcommand not available; falling back to default key generation inside sign"
+# protect-mcp >= 0.7.0 has no keygen subcommand; init generates keys/gateway.json under --dir.
+npx --yes protect-mcp@0.7.4 init --dir "$WORKDIR" >/dev/null 2>&1
+KEY="$WORKDIR/keys/gateway.json"
+PUBKEY="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["publicKey"])' "$KEY" 2>/dev/null || true)"
 
 INPUT=fixtures/posttool-signing-input.json
 TOOL_NAME="$(extract "$INPUT" tool_name)"
@@ -110,9 +111,16 @@ TOOL_OUTPUT_JSON="$(python3 -c 'import json,sys; print(json.dumps(json.load(open
 SIGN_ARGS=(--tool "$TOOL_NAME" --input "$TOOL_INPUT_JSON" --output "$TOOL_OUTPUT_JSON" --receipts "$RECEIPTS_DIR/")
 [ -f "$KEY" ] && SIGN_ARGS+=(--key "$KEY")
 
-npx --yes protect-mcp@0.5.5 sign "${SIGN_ARGS[@]}" >/dev/null 2>&1
+npx --yes protect-mcp@0.7.4 sign "${SIGN_ARGS[@]}" >/dev/null 2>&1
 SIGN_RC=$?
-RECEIPT_FILE="$(ls "$RECEIPTS_DIR"/*.json 2>/dev/null | head -n1 || true)"
+# protect-mcp >= 0.7.0 appends receipts to receipts.jsonl in the --receipts dir (one JSON per
+# line) rather than one file per receipt; extract the newest line as a
+# standalone document for the schema/verify/tamper tests below.
+RECEIPT_FILE=""
+if [ -s "$RECEIPTS_DIR/receipts.jsonl" ]; then
+    RECEIPT_FILE="$WORKDIR/receipt-latest.json"
+    tail -n 1 "$RECEIPTS_DIR/receipts.jsonl" > "$RECEIPT_FILE"
+fi
 
 if [ "$SIGN_RC" -eq 0 ] && [ -n "$RECEIPT_FILE" ] && [ -f "$RECEIPT_FILE" ]; then
     pass "Receipt produced at $(basename "$RECEIPT_FILE")"
@@ -131,10 +139,10 @@ s = json.load(open(sys.argv[2]))
 missing = [f for f in s["required"] if f not in r]
 if missing:
     print(f"missing required fields: {missing}"); sys.exit(1)
-if r.get("receipt_version") != "1.0":
-    print(f"wrong version: {r.get('receipt_version')}"); sys.exit(1)
-if r.get("decision") not in ("allow","deny"):
-    print(f"invalid decision: {r.get('decision')}"); sys.exit(1)
+if r.get("v") != 2:
+    print(f"wrong envelope version: {r.get('v')}"); sys.exit(1)
+if r.get("payload", {}).get("decision") not in ("allow","deny"):
+    print(f"invalid decision: {r.get('payload',{}).get('decision')}"); sys.exit(1)
 sys.exit(0)
 PY
     check_exit $? 0 "Receipt conforms to expected schema"
@@ -146,7 +154,7 @@ fi
 echo ""
 echo "=== Test 7: Offline verification with @veritasacta/verify ==="
 if [ -n "$RECEIPT_FILE" ]; then
-    npx --yes @veritasacta/verify@0.3.0 "$RECEIPT_FILE" >/dev/null 2>&1
+    npx --yes @veritasacta/verify@0.9.2 "$RECEIPT_FILE" --key "$PUBKEY" >/dev/null 2>&1
     check_exit $? 0 "Valid receipt verifies with exit 0"
 else
     fail "No receipt available to verify"
@@ -160,11 +168,11 @@ if [ -n "$RECEIPT_FILE" ]; then
     python3 -c '
 import json, sys
 r = json.load(open(sys.argv[1]))
-# Flip the decision (a signed field). Signature will no longer validate.
-r["decision"] = "deny" if r.get("decision") == "allow" else "allow"
+# Flip the decision (a signed payload field). Signature will no longer validate.
+r["payload"]["decision"] = "deny" if r["payload"].get("decision") == "allow" else "allow"
 json.dump(r, open(sys.argv[2], "w"))
 ' "$RECEIPT_FILE" "$TAMPERED"
-    npx --yes @veritasacta/verify@0.3.0 "$TAMPERED" >/dev/null 2>&1
+    npx --yes @veritasacta/verify@0.9.2 "$TAMPERED" --key "$PUBKEY" >/dev/null 2>&1
     check_exit $? 1 "Tampered receipt rejected with exit 1"
 else
     fail "No receipt available to tamper with"

--- a/plugins/review-agent-governance/hooks/hooks.json
+++ b/plugins/review-agent-governance/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if [ -f \"${REVIEW_APPROVAL_FLAG:-./.review-approved}\" ]; then exit 0; fi; npx protect-mcp@0.5.5 evaluate --policy \"${REVIEW_GOVERNANCE_POLICY:-./review-governance.cedar}\" --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --fail-on-missing-policy false"
+            "command": "if [ -f \"${REVIEW_APPROVAL_FLAG:-./.review-approved}\" ]; then exit 0; fi; npx protect-mcp@0.7.0 evaluate --policy \"${REVIEW_GOVERNANCE_POLICY:-./review-governance.cedar}\" --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --fail-on-missing-policy false"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx protect-mcp@0.5.5 sign --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --output \"$TOOL_OUTPUT\" --receipts \"${REVIEW_GOVERNANCE_RECEIPTS:-./review-receipts/}\" --key \"${REVIEW_GOVERNANCE_KEY:-./review-governance.key}\""
+            "command": "npx protect-mcp@0.7.0 sign --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --output \"$TOOL_OUTPUT\" --receipts \"${REVIEW_GOVERNANCE_RECEIPTS:-./review-receipts/}\" --key \"${REVIEW_GOVERNANCE_KEY:-./review-governance.key}\""
           }
         ]
       }

--- a/plugins/review-agent-governance/hooks/hooks.json
+++ b/plugins/review-agent-governance/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if [ -f \"${REVIEW_APPROVAL_FLAG:-./.review-approved}\" ]; then exit 0; fi; npx protect-mcp@0.7.0 evaluate --policy \"${REVIEW_GOVERNANCE_POLICY:-./review-governance.cedar}\" --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --fail-on-missing-policy false"
+            "command": "if [ -f \"${REVIEW_APPROVAL_FLAG:-./.review-approved}\" ]; then exit 0; fi; npx protect-mcp@0.7.4 evaluate --policy \"${REVIEW_GOVERNANCE_POLICY:-./review-governance.cedar}\" --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --fail-on-missing-policy false"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx protect-mcp@0.7.0 sign --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --output \"$TOOL_OUTPUT\" --receipts \"${REVIEW_GOVERNANCE_RECEIPTS:-./review-receipts/}\" --key \"${REVIEW_GOVERNANCE_KEY:-./review-governance.key}\""
+            "command": "npx protect-mcp@0.7.4 sign --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --output \"$TOOL_OUTPUT\" --receipts \"${REVIEW_GOVERNANCE_RECEIPTS:-./review-receipts/}\" --key \"${REVIEW_GOVERNANCE_KEY:-./review-governance.key}\""
           }
         ]
       }

--- a/plugins/review-agent-governance/skills/review-agent-setup/SKILL.md
+++ b/plugins/review-agent-governance/skills/review-agent-setup/SKILL.md
@@ -159,7 +159,7 @@ If both plugins are installed, run them side by side:
         "hooks": [
           {
             "type": "command",
-            "command": "npx protect-mcp@0.5.5 evaluate --policy ./protect.cedar --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --fail-on-missing-policy false"
+            "command": "npx protect-mcp@0.7.4 evaluate --policy ./protect.cedar --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --fail-on-missing-policy false"
           }
         ]
       },
@@ -168,7 +168,7 @@ If both plugins are installed, run them side by side:
         "hooks": [
           {
             "type": "command",
-            "command": "if [ -f ./.review-approved ]; then exit 0; fi; npx protect-mcp@0.5.5 evaluate --policy ./review-governance.cedar --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --fail-on-missing-policy false"
+            "command": "if [ -f ./.review-approved ]; then exit 0; fi; npx protect-mcp@0.7.4 evaluate --policy ./review-governance.cedar --tool \"$TOOL_NAME\" --input \"$TOOL_INPUT\" --fail-on-missing-policy false"
           }
         ]
       }


### PR DESCRIPTION
Both governance plugins invoke `protect-mcp evaluate` (PreToolUse) and `protect-mcp sign` (PostToolUse), but pinned `protect-mcp@0.5.5`, which predates those verbs. That is issue #601: the hooks call subcommands that did not exist in the pinned version. This bumps the pin in both `plugins/review-agent-governance/hooks/hooks.json` and `plugins/protect-mcp/hooks/hooks.json`, so the verbs resolve and the hooks run as written.

The pin is `0.7.4` (originally proposed as 0.7.0): `evaluate` passes the tool input through to Cedar as `context.input` from 0.7.4, which any command-scoping policy (including this repo's test policy) needs, and 0.7.4 also carries the per-host `--format` hook adapters. The 0.7.x line is a security release series: the Cedar gate fails closed on any evaluation error, evaluates Cedar correctly against cedar-wasm 4.x, and refuses to arm unless a startup self-test proves a known-forbidden vector is denied.

Review follow-ups (second commit):

- `plugins/protect-mcp/test/run-tests.sh`: pins updated in all 6 places; `keygen` (removed in 0.7.0) replaced with `init --dir`; receipts are read from `receipts.jsonl` (0.7.0+ appends one JSON per line); the offline verify step pins the current `@veritasacta/verify` and passes the signer public key explicitly (v2 receipts do not embed it).
- `fixtures/test-policy.cedar`: rewritten in the entity shape protect-mcp actually evaluates (`action == Action::"MCP::Tool::call"`, the tool as `resource`, input at `context.input`). The old `Action::"Read"` shape only appeared to work under 0.5.5's broken evaluator; under real fail-closed evaluation nothing matched and every allow test denied.
- `expected/receipt-schema.json`: updated to the v2 receipt envelope.
- `SKILL.md` copy-paste examples bumped in both plugins. The remaining `0.5.5` strings under `docs/superpowers/` are dated investigation records where 0.5.5 is historically accurate, so they were left as written.

Test suite: 8/8 locally via `plugins/protect-mcp/test/run-tests.sh`.

Note on the PostToolUse `sign` step: it is best-effort and never blocks a tool. If no signing key is configured it records an honest unsigned receipt line rather than failing. To produce signed receipts, run `protect-mcp init` once and point `--key` at `keys/gateway.json`.

Disclosure: I maintain protect-mcp upstream and originally authored these plugins, per the disclosure policy added in #611.
