### PR TITLE
Add agent preflight plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -26,6 +26,18 @@
       "category": "Coding"
     },
     {
+      "name": "agent-preflight",
+      "source": {
+        "source": "local",
+        "path": "./plugins/agent-preflight"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_USE"
+      },
+      "category": "Coding"
+    },
+    {
       "name": "agent-teams",
       "source": {
         "source": "local",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -33,6 +33,17 @@
       "license": "MIT"
     },
     {
+      "name": "agent-preflight",
+      "source": "./plugins/agent-preflight",
+      "version": "1.0.0",
+      "description": "Preflight checks and receipts before AI agents modify real repositories",
+      "author": {
+        "name": "Wealth Hunter",
+        "email": ""
+      },
+      "license": "MIT"
+    },
+    {
       "name": "agent-teams",
       "source": "./plugins/agent-teams",
       "version": "1.0.3",

--- a/.cursor-plugin/plugins/agent-preflight.json
+++ b/.cursor-plugin/plugins/agent-preflight.json
@@ -1,0 +1,11 @@
+{
+  "name": "agent-preflight",
+  "displayName": "Agent Preflight",
+  "version": "1.0.0",
+  "description": "Preflight checks and receipts before AI agents modify real repositories",
+  "author": {
+    "name": "Wealth Hunter",
+    "email": ""
+  },
+  "license": "MIT"
+}

--- a/plugins/agent-preflight/.claude-plugin/plugin.json
+++ b/plugins/agent-preflight/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "agent-preflight",
+  "version": "1.0.0",
+  "description": "Preflight checks and receipts before AI agents modify real repositories",
+  "author": {
+    "name": "Wealth Hunter",
+    "url": "https://github.com/el-zachariah"
+  },
+  "license": "MIT"
+}

--- a/plugins/agent-preflight/.codex-plugin/plugin.json
+++ b/plugins/agent-preflight/.codex-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "agent-preflight",
+  "version": "1.0.0",
+  "description": "Preflight checks and receipts before AI agents modify real repositories",
+  "skills": "./skills/",
+  "author": {
+    "name": "Wealth Hunter",
+    "url": "https://github.com/el-zachariah"
+  },
+  "license": "MIT",
+  "interface": {
+    "displayName": "Agent Preflight",
+    "shortDescription": "Preflight checks and receipts before AI agents modify real repositories",
+    "category": "Coding"
+  }
+}

--- a/plugins/agent-preflight/README.md
+++ b/plugins/agent-preflight/README.md
@@ -1,0 +1,9 @@
+# Agent Preflight
+
+A free Claude Code plugin command for producing an AI-agent safety receipt before agentic coding work mutates a repository.
+
+## Command
+
+- `/agent-preflight` — checks repository state, likely edit scope, risk flags, validation path, and rollback plan before edits begin.
+
+This listing points to the free starter pack rather than a paid offer so the marketplace entry stays useful and non-spammy.

--- a/plugins/agent-preflight/commands/agent-preflight.md
+++ b/plugins/agent-preflight/commands/agent-preflight.md
@@ -1,0 +1,55 @@
+---
+description: Use when preparing to let an AI coding agent modify a repository; produce a preflight safety receipt before changes begin.
+argument-hint: "optional target path, branch, or risk focus"
+---
+
+# Agent Preflight Safety Receipt
+
+Use this command when a developer, maintainer, or small team wants a quick safety receipt before Claude Code, Codex, Cursor, or another AI coding agent edits a real repository.
+
+## Context
+
+$ARGUMENTS
+
+## Instructions
+
+1. Confirm repository state.
+   - Identify the current branch and whether there are uncommitted changes.
+   - Refuse to proceed silently if user work is dirty; report the exact files first.
+   - Note the latest commit SHA or state that no Git repository is present.
+
+2. Map the blast radius.
+   - List the files or directories the requested agent work is likely to touch.
+   - Flag sensitive areas such as payment code, deployment config, credentials, migrations, CI, auth, security policy, or production data paths.
+   - If the work touches a sensitive area, name the risk and ask for explicit confirmation before mutation.
+
+3. Find the cheapest validation path.
+   - Detect available test, lint, typecheck, build, or smoke commands from package scripts, Makefile targets, project docs, or obvious framework conventions.
+   - Prefer the smallest command that proves the requested change.
+   - If no validator is available, state that clearly and suggest one low-friction check.
+
+4. Produce the preflight receipt.
+   - Summarize: repo/branch, dirty-state result, risky files, intended edit scope, validation command, rollback plan, and any human approval needed.
+   - Keep the receipt copyable into a PR, issue, or handoff note.
+   - Do not modify files until the user approves the receipt.
+
+## Output
+
+Return a concise receipt in this format:
+
+```text
+Agent preflight receipt
+Repo/branch:
+Dirty state:
+Likely edit scope:
+Risk flags:
+Validation command:
+Rollback plan:
+Human approval needed:
+Recommended next step:
+```
+
+## Related free resource
+
+For a fuller standalone starter pack with sample hooks, checklists, and receipt templates, see:
+https://github.com/el-zachariah/ai-agent-safety-starter-pack


### PR DESCRIPTION
## Summary
- adds a free `agent-preflight` Claude Code plugin command for producing a repo safety receipt before AI-agent edits
- registers it in the marketplace with the public free starter-pack repository as homepage
- keeps the listing non-commercial and focused on preflight trust/validation workflows

## Validation
- make generate-all
- make validate