### PR TITLE
fix: cross-cutting process fixes from open-PR/issue audit

### DIFF
--- a/.cursor/rules/000-project-conventions.mdc
+++ b/.cursor/rules/000-project-conventions.mdc
@@ -16,7 +16,7 @@ artifacts (`.codex/`, `.cursor-plugin/`, `.opencode/`, `commands/`) are generate
 ## Never
 
 - Never commit secrets or hardcode credentials.
-- Never modify `.claude-plugin/marketplace.json` from inside a plugin PR — it's the registry.
+- Never hand-edit generated registries (`.agents/plugins/marketplace.json`, `.cursor-plugin/`) — plugin PRs register the plugin in `.claude-plugin/marketplace.json`, then run `make generate-all` (see CONTRIBUTING.md).
 - Never run destructive git operations (force-push, reset --hard, branch -D) without explicit ask.
 
 See `docs/authoring.md` for the portable-content style guide.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ Top-level `skills/` is Gemini output; do not use it for OpenCode installs.
 
 ## Subagents (cross-harness)
 
-192 subagents under `plugins/*/agents/<name>.md`. Per-harness transpilation:
+194 subagents under `plugins/*/agents/<name>.md`. Per-harness transpilation:
 
 - **Codex**: `.codex/agents/<plugin>__<agent>.toml` (drop `tools:`, map model alias to the GPT-5.x family, infer `sandbox_mode`)
 - **OpenCode**: `.opencode/agents/<plugin>__<agent>.md` with `mode: subagent` + `permission:` block (locked agents — those with source `tools: []` — get deny-everything except base `skill`/`task`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,15 @@ Markdown source.
 
 Full frontmatter conventions in [`docs/authoring.md`](docs/authoring.md).
 
+## Commercial content and disclosure
+
+- Plugin content must not funnel users to paid products, affiliate programs, or
+  revenue-sharing services. Submissions whose primary purpose is promotion are
+  closed as spam.
+- If a plugin wraps a third-party API, package, or service that you own or
+  maintain, disclose that relationship in the PR description and the plugin
+  README.
+
 ## Quality gates
 
 Every PR runs these on CI (`.github/workflows/`); run them locally before pushing:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,7 +48,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 
 ### Component Breakdown
 
-**192 Local Specialized Agents**
+**194 Local Specialized Agents**
 
 - Domain experts with deep knowledge
 - Organized across architecture, languages, infrastructure, quality, data/AI, documentation, business, and SEO
@@ -60,7 +60,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 - Complex operations like full-stack development, security hardening, ML pipelines, incident response
 - Pre-configured agent workflows
 
-**102 Local Commands**
+**106 Local Commands**
 
 - Optimized utilities including:
   - Project scaffolding (Python, TypeScript, Rust)
@@ -69,11 +69,11 @@ This marketplace follows industry best practices with a focus on granularity, co
   - Component scaffolding (React, React Native)
   - Infrastructure setup (Terraform, Kubernetes)
 
-**156 Local Agent Skills**
+**158 Local Agent Skills**
 
 - Modular knowledge packages
 - Progressive disclosure architecture
-- Domain-specific expertise across 41 plugins
+- Domain-specific expertise across 44 plugins
 - Spec-compliant (Anthropic Agent Skills Specification)
 
 ## Repository Structure

--- a/plugins/protect-mcp/README.md
+++ b/plugins/protect-mcp/README.md
@@ -149,7 +149,7 @@ Use the `receipt-verifier` agent for help interpreting verification failures.
 
 ## Related
 
-- **npm**: [protect-mcp](https://www.npmjs.com/package/protect-mcp) — 10K+ monthly downloads
+- **npm**: [protect-mcp](https://www.npmjs.com/package/protect-mcp)
 - **Verification CLI**: [@veritasacta/verify](https://www.npmjs.com/package/@veritasacta/verify)
 - **Cedar integration**: Contributor to [cedar-policy/cedar-for-agents](https://github.com/cedar-policy/cedar-for-agents) (PR #64 merged)
 - **Microsoft AGT**: Integrated in [microsoft/agent-governance-toolkit](https://github.com/microsoft/agent-governance-toolkit) (PR #667 merged)

--- a/plugins/protect-mcp/skills/protect-mcp-setup/SKILL.md
+++ b/plugins/protect-mcp/skills/protect-mcp-setup/SKILL.md
@@ -200,7 +200,7 @@ Each receipt is a JSON file with this structure:
 
 ## Related
 
-- **npm**: [protect-mcp](https://www.npmjs.com/package/protect-mcp) (v0.5.5, 10K+ monthly downloads)
+- **npm**: [protect-mcp](https://www.npmjs.com/package/protect-mcp)
 - **Verify CLI**: [@veritasacta/verify](https://www.npmjs.com/package/@veritasacta/verify)
 - **Source**: [github.com/ScopeBlind/scopeblind-gateway](https://github.com/ScopeBlind/scopeblind-gateway)
 - **Protocol**: [veritasacta.com](https://veritasacta.com)

--- a/tools/adapters/cursor_rules/000-project-conventions.mdc
+++ b/tools/adapters/cursor_rules/000-project-conventions.mdc
@@ -16,7 +16,7 @@ artifacts (`.codex/`, `.cursor-plugin/`, `.opencode/`, `commands/`) are generate
 ## Never
 
 - Never commit secrets or hardcode credentials.
-- Never modify `.claude-plugin/marketplace.json` from inside a plugin PR — it's the registry.
+- Never hand-edit generated registries (`.agents/plugins/marketplace.json`, `.cursor-plugin/`) — plugin PRs register the plugin in `.claude-plugin/marketplace.json`, then run `make generate-all` (see CONTRIBUTING.md).
 - Never run destructive git operations (force-push, reset --hard, branch -D) without explicit ask.
 
 See `docs/authoring.md` for the portable-content style guide.


### PR DESCRIPTION
Process fixes surfaced by a full audit of open PRs and issues (2026-07-07).

## Changes

- **Align the cursor-rules registry rule with CONTRIBUTING.md** — the rule "Never modify `.claude-plugin/marketplace.json` from inside a plugin PR" contradicted CONTRIBUTING.md step 3 and actual practice, causing CodeRabbit revert/re-add churn on #577, #582, #596, and #606. Fixed at the source template (`tools/adapters/cursor_rules/`) and regenerated.
- **Fix stale component counts** in `docs/architecture.md` (192→194 agents, 102→106 commands, 156→158 skills, 41→44 skill-bearing plugins) and `AGENTS.md` (192→194 subagents). Verified against the filesystem.
- **Add commercial content and disclosure policy to CONTRIBUTING.md** — no funnels to paid products/affiliate programs; wrapped self-owned services must be disclosed. Prompted by two spam submissions closed today (#605, #606) and the disclosure question on #582.
- **Remove unverified "10K+ monthly downloads" claim from protect-mcp docs** (npm reports ~3.2K/month; README keeps its live shields.io badge) and the stale v0.5.5 reference in the setup skill's Related links (see #601).

## Verification

- `make validate STRICT=1` — OK across 5 harnesses
- `make garden` — 0 errors (10 pre-existing SKILL_OVER_CODEX_CAP warnings, untouched)
- `make generate-all` — zero drift after regeneration
- `make test` — 443 passed, 3 skipped
- `markdownlint-cli2` on all changed Markdown — 0 errors
