### PR TITLE
docs: refresh model references for Claude Sonnet 5 and Fable 5

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -232,9 +232,9 @@ Agents are assigned to specific Claude models based on task complexity and compu
 | ------- | ----------- | --------------------------------------------------------------- |
 | Fable   | 0           | Longest-horizon autonomous work (tier above Opus; see criteria) |
 | Opus    | 54          | Critical architecture, security, code review, production coding |
-| Sonnet  | 62          | Complex tasks, support with intelligence                        |
-| Haiku   | 20          | Fast operational tasks                                          |
-| Inherit | 49          | Complex tasks where the user chooses the model at runtime       |
+| Sonnet  | 66          | Complex tasks, support with intelligence                        |
+| Haiku   | 22          | Fast operational tasks                                          |
+| Inherit | 52          | Complex tasks where the user chooses the model at runtime       |
 
 ### Model Selection Criteria
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,7 +52,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 
 - Domain experts with deep knowledge
 - Organized across architecture, languages, infrastructure, quality, data/AI, documentation, business, and SEO
-- Model-optimized with three-tier strategy (Opus, Sonnet, Haiku) for performance and cost
+- Model-optimized with a five-tier strategy (Fable, Opus, Sonnet, Haiku, Inherit) for performance and cost
 
 **16 Workflow Orchestrators**
 
@@ -198,16 +198,17 @@ See [Agent Skills](./agent-skills.md) for complete details on the 158 skills.
 
 ## Model Configuration Strategy
 
-### Four-Tier Architecture
+### Five-Tier Architecture
 
-The system uses Claude Opus, Sonnet, Haiku, and Inherit assignments strategically:
+The system uses Claude Fable, Opus, Sonnet, Haiku, and Inherit assignments strategically:
 
-| Model   | Count     | Use Case                                     |
-| ------- | --------- | -------------------------------------------- |
-| Opus    | 54 agents | Critical architecture, security, code review |
-| Sonnet  | 62 agents | Complex tasks, support with intelligence     |
-| Haiku   | 20 agents | Fast operational tasks                       |
-| Inherit | 49 agents | Defers model choice to the user at runtime   |
+| Model   | Count     | Use Case                                        |
+| ------- | --------- | ----------------------------------------------- |
+| Fable   | 0 agents  | Longest-horizon autonomous work (opt-in tier)   |
+| Opus    | 54 agents | Critical architecture, security, code review    |
+| Sonnet  | 66 agents | Complex tasks, support with intelligence        |
+| Haiku   | 22 agents | Fast operational tasks                          |
+| Inherit | 52 agents | Defers model choice to the user at runtime      |
 
 ### Selection Criteria
 

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -112,18 +112,19 @@ clean naming — pick distinct names for skill/command pairs within a plugin.
 
 | Source field | Codex | Cursor | OpenCode | Gemini | Copilot |
 |---|---|---|---|---|---|---|
-| `model: fable` | `gpt-5.5` | `inherit` | `anthropic/claude-fable-5` | `gemini-2.5-pro` | `claude-opus-4.8` |
+| `model: fable` | `gpt-5.5` | `inherit` | `anthropic/claude-fable-5` | `gemini-2.5-pro` | `claude-fable-5` |
 | `model: opus` | `gpt-5.5` | `inherit` | `anthropic/claude-opus-4-8` | `gemini-2.5-pro` | `claude-opus-4.8` |
-| `model: sonnet` | `gpt-5.4-mini` | `inherit` | `anthropic/claude-sonnet-4-6` | `gemini-2.5-pro` | `claude-sonnet-4.6` |
+| `model: sonnet` | `gpt-5.4-mini` | `inherit` | `anthropic/claude-sonnet-5` | `gemini-2.5-pro` | `claude-sonnet-5` |
 | `model: haiku` | `gpt-5.4-mini` | `inherit` | `anthropic/claude-haiku-4-5` | `gemini-2.5-flash` | `claude-haiku-4.5` |
-| `model: inherit` | `gpt-5.5` | `inherit` | `anthropic/claude-sonnet-4-6` | `gemini-2.5-pro` | `claude-sonnet-4.6` |
+| `model: inherit` | `gpt-5.5` | `inherit` | `anthropic/claude-sonnet-5` | `gemini-2.5-pro` | `claude-sonnet-5` |
 
 The adapter handles mapping. The `BARE_MODEL_ALIAS` lint is informational — it just notes
 that the mapping is implicit. If you want explicit, use `inherit`.
 
 Mapping targets live in `tools/adapters/capabilities.py` (`MODEL_ALIASES`) and track each
-harness's published catalog (last verified June 2026). Copilot CLI serves Claude models
-natively, so its aliases map Claude → Claude using Copilot's dotted IDs. Gemini stays on
+harness's published catalog (last verified July 2026). Copilot CLI serves Claude models
+natively — including Fable 5 and Sonnet 5 since late June 2026 — so its aliases map
+Claude → Claude using Copilot's IDs (dotted for minor-versioned models). Gemini stays on
 the GA `gemini-2.5-*` family because Gemini 3.x ships only access-gated `-preview` IDs.
 
 `fable` (Claude Fable 5) is the tier above `opus`, reserved for the longest-horizon

--- a/plugins/llm-application-dev/README.md
+++ b/plugins/llm-application-dev/README.md
@@ -5,7 +5,7 @@ Build production-ready LLM applications, advanced RAG systems, and intelligent a
 ## Version 2.0.0 Highlights
 
 - **LangGraph Integration**: Updated from deprecated LangChain patterns to LangGraph StateGraph workflows
-- **Modern Model Support**: Claude Opus 4.7/Sonnet 4.6/Haiku 4.5 and GPT-5.4/GPT-5-mini
+- **Modern Model Support**: Claude Opus 4.8/Sonnet 5/Haiku 4.5 and GPT-5.4/GPT-5-mini
 - **Voyage AI Embeddings**: Recommended embedding models for Claude applications
 - **Structured Outputs**: Pydantic-based structured output patterns
 

--- a/plugins/llm-application-dev/agents/ai-engineer.md
+++ b/plugins/llm-application-dev/agents/ai-engineer.md
@@ -15,7 +15,7 @@ Expert AI engineer specializing in LLM application development, RAG systems, and
 ### LLM Integration & Model Management
 
 - OpenAI GPT-5.4/GPT-5-mini with function calling and structured outputs
-- Anthropic Claude Opus 4.7, Claude Sonnet 4.6, Claude Haiku 4.5 with tool use and computer use
+- Anthropic Claude Opus 4.8, Claude Sonnet 5, Claude Haiku 4.5 with tool use and computer use
 - Open-source models: Llama 3.3, Mixtral 8x22B, Qwen 2.5, DeepSeek-V3
 - Local deployment with Ollama, vLLM, TGI (Text Generation Inference)
 - Model serving with TorchServe, MLflow, BentoML for production deployment

--- a/plugins/llm-application-dev/agents/prompt-engineer.md
+++ b/plugins/llm-application-dev/agents/prompt-engineer.md
@@ -58,7 +58,7 @@ Expert prompt engineer specializing in advanced prompting methodologies and LLM 
 - Multi-turn conversation management
 - Image and multimodal prompt engineering
 
-#### Anthropic Claude (Claude Opus 4.7, Sonnet 4.6, Haiku 4.5)
+#### Anthropic Claude (Claude Opus 4.8, Sonnet 5, Haiku 4.5)
 
 - Constitutional AI alignment with Claude's training
 - Tool use optimization for complex workflows

--- a/plugins/llm-application-dev/commands/langchain-agent.md
+++ b/plugins/llm-application-dev/commands/langchain-agent.md
@@ -37,7 +37,7 @@ class AgentState(TypedDict):
 
 ### Model & Embeddings
 
-- **Primary LLM**: Claude Sonnet 4.6 (`claude-sonnet-4-6`)
+- **Primary LLM**: Claude Sonnet 5 (`claude-sonnet-5`)
 - **Embeddings**: Voyage AI (`voyage-3-large`) - officially recommended by Anthropic for Claude
 - **Specialized**: `voyage-code-3` (code), `voyage-finance-2` (finance), `voyage-law-2` (legal)
 
@@ -158,7 +158,7 @@ from langsmith.evaluation import evaluate
 # Run evaluation suite
 eval_config = RunEvalConfig(
     evaluators=["qa", "context_qa", "cot_qa"],
-    eval_llm=ChatAnthropic(model="claude-sonnet-4-6")
+    eval_llm=ChatAnthropic(model="claude-sonnet-5")
 )
 
 results = await evaluate(
@@ -209,7 +209,7 @@ async def call_with_retry():
 
 ## Implementation Checklist
 
-- [ ] Initialize LLM with Claude Sonnet 4.6
+- [ ] Initialize LLM with Claude Sonnet 5
 - [ ] Setup Voyage AI embeddings (voyage-3-large)
 - [ ] Create tools with async support and error handling
 - [ ] Implement memory system (choose type based on use case)

--- a/plugins/llm-application-dev/skills/langchain-architecture/SKILL.md
+++ b/plugins/llm-application-dev/skills/langchain-architecture/SKILL.md
@@ -115,8 +115,8 @@ from langchain_core.tools import tool
 import ast
 import operator
 
-# Initialize LLM (Claude Sonnet 4.6 recommended)
-llm = ChatAnthropic(model="claude-sonnet-4-6", temperature=0)
+# Initialize LLM (Claude Sonnet 5 recommended)
+llm = ChatAnthropic(model="claude-sonnet-5")
 
 # Define tools with Pydantic schemas
 @tool

--- a/plugins/llm-application-dev/skills/langchain-architecture/references/details.md
+++ b/plugins/llm-application-dev/skills/langchain-architecture/references/details.md
@@ -19,7 +19,7 @@ class RAGState(TypedDict):
     answer: str
 
 # Initialize components
-llm = ChatAnthropic(model="claude-sonnet-4-6")
+llm = ChatAnthropic(model="claude-sonnet-5")
 embeddings = VoyageAIEmbeddings(model="voyage-3-large")
 vectorstore = PineconeVectorStore(index_name="docs", embedding=embeddings)
 retriever = vectorstore.as_retriever(search_kwargs={"k": 4})
@@ -307,7 +307,7 @@ os.environ["LANGCHAIN_API_KEY"] = "your-api-key"
 os.environ["LANGCHAIN_PROJECT"] = "my-project"
 
 # All LangChain/LangGraph operations are automatically traced
-llm = ChatAnthropic(model="claude-sonnet-4-6")
+llm = ChatAnthropic(model="claude-sonnet-5")
 ```
 
 ### Custom Callback Handler
@@ -348,7 +348,7 @@ result = await agent.ainvoke(
 ```python
 from langchain_anthropic import ChatAnthropic
 
-llm = ChatAnthropic(model="claude-sonnet-4-6", streaming=True)
+llm = ChatAnthropic(model="claude-sonnet-5", streaming=True)
 
 # Stream tokens
 async for chunk in llm.astream("Tell me a story"):

--- a/plugins/llm-application-dev/skills/llm-evaluation/references/details.md
+++ b/plugins/llm-application-dev/skills/llm-evaluation/references/details.md
@@ -144,7 +144,7 @@ Provide ratings in JSON format:
 }}"""
 
     message = client.messages.create(
-        model="claude-sonnet-4-6",
+        model="claude-sonnet-5",
         max_tokens=500,
         system=system,
         messages=[{"role": "user", "content": prompt}]
@@ -190,7 +190,7 @@ Answer with JSON:
 }}"""
 
     message = client.messages.create(
-        model="claude-sonnet-4-6",
+        model="claude-sonnet-5",
         max_tokens=500,
         messages=[{"role": "user", "content": prompt}]
     )
@@ -236,7 +236,7 @@ Respond in JSON:
 }}"""
 
     message = client.messages.create(
-        model="claude-sonnet-4-6",
+        model="claude-sonnet-5",
         max_tokens=500,
         messages=[{"role": "user", "content": prompt}]
     )
@@ -466,7 +466,7 @@ experiment_results = await evaluate(
     data=dataset.name,
     evaluators=evaluators,
     experiment_prefix="v1.0.0",
-    metadata={"model": "claude-sonnet-4-6", "version": "1.0.0"}
+    metadata={"model": "claude-sonnet-5", "version": "1.0.0"}
 )
 
 print(f"Mean score: {experiment_results.aggregate_metrics['qa']['mean']}")

--- a/plugins/llm-application-dev/skills/prompt-engineering-patterns/SKILL.md
+++ b/plugins/llm-application-dev/skills/prompt-engineering-patterns/SKILL.md
@@ -85,7 +85,7 @@ class SQLQuery(BaseModel):
     tables_used: list[str] = Field(description="List of tables referenced")
 
 # Initialize model with structured output
-llm = ChatAnthropic(model="claude-sonnet-4-6")
+llm = ChatAnthropic(model="claude-sonnet-5")
 structured_llm = llm.with_structured_output(SQLQuery)
 
 # Create prompt template

--- a/plugins/llm-application-dev/skills/prompt-engineering-patterns/references/details.md
+++ b/plugins/llm-application-dev/skills/prompt-engineering-patterns/references/details.md
@@ -21,7 +21,7 @@ async def analyze_sentiment(text: str) -> SentimentAnalysis:
     client = Anthropic()
 
     message = client.messages.create(
-        model="claude-sonnet-4-6",
+        model="claude-sonnet-5",
         max_tokens=500,
         messages=[{
             "role": "user",
@@ -324,7 +324,7 @@ client = Anthropic()
 
 # Use prompt caching for repeated system prompts
 response = client.messages.create(
-    model="claude-sonnet-4-6",
+    model="claude-sonnet-5",
     max_tokens=1000,
     system=[
         {

--- a/plugins/llm-application-dev/skills/rag-implementation/SKILL.md
+++ b/plugins/llm-application-dev/skills/rag-implementation/SKILL.md
@@ -85,7 +85,7 @@ class RAGState(TypedDict):
     answer: str
 
 # Initialize components
-llm = ChatAnthropic(model="claude-sonnet-4-6")
+llm = ChatAnthropic(model="claude-sonnet-5")
 embeddings = VoyageAIEmbeddings(model="voyage-3-large")
 vectorstore = PineconeVectorStore(index_name="docs", embedding=embeddings)
 retriever = vectorstore.as_retriever(search_kwargs={"k": 4})

--- a/plugins/performance-testing-review/commands/ai-review.md
+++ b/plugins/performance-testing-review/commands/ai-review.md
@@ -395,8 +395,8 @@ Return JSON array:
 """
 
         response = self.anthropic_client.messages.create(
-            model="claude-3-5-sonnet-20241022",
-            max_tokens=8000, temperature=0.2,
+            model="claude-sonnet-5",
+            max_tokens=8000,
             messages=[{"role": "user", "content": prompt}]
         )
 

--- a/plugins/plugin-eval/src/plugin_eval/layers/judge.py
+++ b/plugins/plugin-eval/src/plugin_eval/layers/judge.py
@@ -39,7 +39,7 @@ Score 1.0 — Perfectly calibrated: Minimal surface area, maximum cohesion, idea
 
 _MODEL_MAP: dict[str, str] = {
     "haiku": "claude-haiku-4-5-20251001",
-    "sonnet": "claude-sonnet-4-6",
+    "sonnet": "claude-sonnet-5",
     "opus": "claude-opus-4-8",
 }
 
@@ -82,7 +82,7 @@ def _extract_and_parse(messages: list) -> dict:
         return {"unmeasured": True, "error": "judge response was not valid JSON", "raw": raw}
 
 
-async def query_llm(prompt: str, system: str = "", model: str = "claude-sonnet-4-6") -> dict:
+async def query_llm(prompt: str, system: str = "", model: str = "claude-sonnet-5") -> dict:
     """Call Claude via the Agent SDK and return a parsed JSON dict.
 
     Degrades to an {"unmeasured": True, ...} marker (never raises) when the SDK

--- a/plugins/plugin-eval/tests/test_judge.py
+++ b/plugins/plugin-eval/tests/test_judge.py
@@ -18,7 +18,7 @@ from plugin_eval.layers.judge import (  # noqa: E402
 
 
 def _assistant(text: str) -> AssistantMessage:
-    return AssistantMessage(content=[TextBlock(text=text)], model="claude-sonnet-4-6")
+    return AssistantMessage(content=[TextBlock(text=text)], model="claude-sonnet-5")
 
 
 def _result(*, is_error: bool = False, result: str | None = None) -> ResultMessage:

--- a/plugins/plugin-eval/tests/test_monte_carlo.py
+++ b/plugins/plugin-eval/tests/test_monte_carlo.py
@@ -20,7 +20,7 @@ from plugin_eval.layers.monte_carlo import (  # noqa: E402
 
 
 def _assistant(text: str) -> AssistantMessage:
-    return AssistantMessage(content=[TextBlock(text=text)], model="claude-sonnet-4-6")
+    return AssistantMessage(content=[TextBlock(text=text)], model="claude-sonnet-5")
 
 
 def _result(

--- a/tools/adapters/capabilities.py
+++ b/tools/adapters/capabilities.py
@@ -245,10 +245,11 @@ TOOL_NAME_MAPS: dict[str, dict[str, str]] = {
 
 
 # Model alias map: bare Claude alias -> full provider-prefixed ID per harness.
-# Targets verified against each harness's published model catalog 2026-06:
+# Targets verified against each harness's published model catalog 2026-07:
 # Codex recommends gpt-5.5 (top) / gpt-5.4-mini (light tasks, subagents);
 # Copilot CLI serves Claude models natively, so aliases map Claude -> Claude
-# (no Fable in Copilot — top available Claude is Opus 4.8, dotted-ID format);
+# (Fable 5 and Sonnet 5 GA in Copilot since 2026-06-30; dotted-ID format for
+# minor-versioned models);
 # Gemini CLI's GA models remain gemini-2.5-* (3.x is preview-gated and its
 # IDs churn), so the gemini column intentionally stays on the 2.5 family.
 MODEL_ALIASES: dict[str, dict[str, str]] = {
@@ -267,11 +268,11 @@ MODEL_ALIASES: dict[str, dict[str, str]] = {
         "inherit": "gpt-5.5",
     },
     "copilot": {
-        "fable": "claude-opus-4.8",
+        "fable": "claude-fable-5",
         "opus": "claude-opus-4.8",
-        "sonnet": "claude-sonnet-4.6",
+        "sonnet": "claude-sonnet-5",
         "haiku": "claude-haiku-4.5",
-        "inherit": "claude-sonnet-4.6",
+        "inherit": "claude-sonnet-5",
     },
     "cursor": {
         "fable": "inherit",
@@ -283,9 +284,9 @@ MODEL_ALIASES: dict[str, dict[str, str]] = {
     "opencode": {
         "fable": "anthropic/claude-fable-5",
         "opus": "anthropic/claude-opus-4-8",
-        "sonnet": "anthropic/claude-sonnet-4-6",
+        "sonnet": "anthropic/claude-sonnet-5",
         "haiku": "anthropic/claude-haiku-4-5",
-        "inherit": "anthropic/claude-sonnet-4-6",
+        "inherit": "anthropic/claude-sonnet-5",
     },
     "gemini": {
         "fable": "gemini-2.5-pro",

--- a/tools/tests/test_adapters.py
+++ b/tools/tests/test_adapters.py
@@ -1014,10 +1014,10 @@ class TestCopilotAdapter:
         CopilotAdapter(output_root=output_root).emit_plugin(plugin)
 
         expected = {
-            "sonnet-agent": "claude-sonnet-4.6",
+            "sonnet-agent": "claude-sonnet-5",
             "haiku-agent": "claude-haiku-4.5",
-            "inherit-agent": "claude-sonnet-4.6",
-            "default-model": "claude-sonnet-4.6",
+            "inherit-agent": "claude-sonnet-5",
+            "default-model": "claude-sonnet-5",
         }
         for name, exp_model in expected.items():
             fm, _ = parse_frontmatter(
@@ -1099,7 +1099,7 @@ class TestCopilotAdapter:
         fm, body = parse_frontmatter(content)
         assert fm["name"] == "demo__advisory"
         assert fm["description"] == "Use when advising."
-        assert fm["model"] == "claude-sonnet-4.6"
+        assert fm["model"] == "claude-sonnet-5"
         assert "tools:" in content
 
     def test_no_tools_field(self, tmp_path: Path, output_root: Path):

--- a/tools/tests/test_validate_generated.py
+++ b/tools/tests/test_validate_generated.py
@@ -250,7 +250,7 @@ class TestOpenCodeValidator:
         agents = tmp_path / ".opencode" / "agents"
         agents.mkdir(parents=True)
         (agents / "no_mode.md").write_text(
-            "---\nname: no_mode\ndescription: Use when testing.\nmodel: anthropic/claude-sonnet-4-6\n---\n\nBody.\n"
+            "---\nname: no_mode\ndescription: Use when testing.\nmodel: anthropic/claude-sonnet-5\n---\n\nBody.\n"
         )
 
         report = Report()
@@ -275,7 +275,7 @@ class TestOpenCodeValidator:
         agents.mkdir(parents=True)
         (agents / "bad_perm.md").write_text(
             "---\nname: bad_perm\ndescription: Use when testing.\nmode: subagent\n"
-            "model: anthropic/claude-sonnet-4-6\npermission:\n  fly_drone: allow\n---\n\nBody.\n"
+            "model: anthropic/claude-sonnet-5\npermission:\n  fly_drone: allow\n---\n\nBody.\n"
         )
 
         report = Report()
@@ -295,7 +295,7 @@ class TestOpenCodeValidator:
         agents.mkdir(parents=True)
         (agents / "nested.md").write_text(
             "---\nname: nested\ndescription: Use when nested.\nmode: subagent\n"
-            "model: anthropic/claude-sonnet-4-6\n"
+            "model: anthropic/claude-sonnet-5\n"
             "metadata:\n  permission:\n    fly_drone: allow\n"
             "---\n\nBody.\n"
         )
@@ -311,7 +311,7 @@ class TestOpenCodeValidator:
         agents.mkdir(parents=True)
         (agents / "bad_value.md").write_text(
             "---\nname: bad_value\ndescription: Use when testing.\nmode: subagent\n"
-            "model: anthropic/claude-sonnet-4-6\npermission:\n  read: maybe\n---\n\nBody.\n"
+            "model: anthropic/claude-sonnet-5\npermission:\n  read: maybe\n---\n\nBody.\n"
         )
 
         report = Report()


### PR DESCRIPTION
Model-reference refresh following the public releases of Claude Fable 5 / Mythos 5 (June 9, 2026) and Claude Sonnet 5 (GA in GitHub Copilot June 30, 2026).

## Changes

- **Adapter model maps** (`tools/adapters/capabilities.py`): `sonnet`/`inherit` aliases now target Claude Sonnet 5 (`claude-sonnet-5` in Copilot, `anthropic/claude-sonnet-5` in OpenCode). Copilot's `fable` alias maps to `claude-fable-5` instead of falling back to Opus 4.8 — GitHub's supported-models docs now list both Fable 5 and Sonnet 5. Catalog verification date bumped to 2026-07.
- **plugin-eval judge**: sonnet tier resolves to `claude-sonnet-5` (opus/haiku mappings already current).
- **Docs**: model alias table in `docs/authoring.md` updated; tier tables in `docs/agents.md` and `docs/architecture.md` corrected to actual frontmatter counts (Opus 54 / Sonnet 66 / Haiku 22 / Inherit 52, verified against `plugins/*/agents/*.md`); architecture.md's "Four-Tier" section now reflects the five-tier strategy including Fable.
- **Plugin content**: `llm-application-dev` examples move from `claude-sonnet-4-6` → `claude-sonnet-5` and Opus 4.7 → 4.8; `performance-testing-review`'s ai-review command replaces the **retired** `claude-3-5-sonnet-20241022` (404s since Oct 2025). `temperature` arguments were dropped from migrated examples since Sonnet 5 rejects non-default sampling parameters.

Fable 5 tier documentation (docs/agents.md, docs/authoring.md, README) was already current and is unchanged.

## Verification

- `make validate STRICT=1` — OK across 5 harnesses
- `make garden` — 0 errors (10 pre-existing warnings)
- `make generate-all` — regenerated cleanly
- `make test` — 443 passed, 3 skipped (includes updated adapter/judge expectations)
- `ruff check` / `ruff format --check` — clean on CI scope and changed test files
- markdownlint — changed docs clean (2 pre-existing findings in a plugin skill are outside CI's lint scope)
- Zero `sonnet-4-6` references remain in source (generated dirs and historical plan docs excluded)
