### PR TITLE
docs: sync counts after operating-kit merge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ Top-level `skills/` is Gemini output; do not use it for OpenCode installs.
 
 ## Subagents (cross-harness)
 
-194 subagents under `plugins/*/agents/<name>.md`. Per-harness transpilation:
+199 subagents under `plugins/*/agents/<name>.md`. Per-harness transpilation:
 
 - **Codex**: `.codex/agents/<plugin>__<agent>.toml` (drop `tools:`, map model alias to the GPT-5.x family, infer `sandbox_mode`)
 - **OpenCode**: `.opencode/agents/<plugin>__<agent>.md` with `mode: subagent` + `permission:` block (locked agents — those with source `tools: []` — get deny-everything except base `skill`/`task`)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,7 +26,7 @@ claude-agents/
 ├── CONTRIBUTING.md                 # Contributor entry point
 ├── .claude-plugin/marketplace.json # Plugin registry (source of truth)
 ├── .gemini/settings.json           # Gemini CLI → AGENTS.md redirect
-├── plugins/                        # SOURCE OF TRUTH (85 local plugins; 3 externals in marketplace)
+├── plugins/                        # SOURCE OF TRUTH (86 local plugins; 3 externals in marketplace)
 │   └── <name>/
 │       ├── .claude-plugin/plugin.json
 │       ├── agents/*.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agentic Plugin Marketplace
 
-> Production-ready agentic workflow building blocks: **88 plugins**, **194 agents**,
+> Production-ready agentic workflow building blocks: **89 plugins**, **199 agents**,
 > **158 skills**, **106 commands** — built for Claude Code and consumed natively by
 > OpenAI Codex CLI, Cursor, OpenCode, Gemini CLI, and GitHub Copilot from a single Markdown source.
 
@@ -19,7 +19,7 @@ Pick your harness:
 
 ```bash
 /plugin marketplace add wshobson/agents
-/plugin install python-development          # or any of 88 plugins
+/plugin install python-development          # or any of 89 plugins
 ```
 
 [→ Full Claude Code setup, troubleshooting, and plugin catalog](docs/usage.md)
@@ -47,8 +47,8 @@ Setup details and per-harness gotchas: [docs/harnesses.md](docs/harnesses.md). G
 
 | | Count | What it is |
 |---|---:|---|
-| **Plugins** | 88 | Granular, single-purpose installable units (85 local + 3 external via git-subdir) |
-| **Agents** | 194 | Domain experts (architecture, languages, infra, security, data, ML, docs, business, SEO) |
+| **Plugins** | 89 | Granular, single-purpose installable units (86 local + 3 external via git-subdir) |
+| **Agents** | 199 | Domain experts (architecture, languages, infra, security, data, ML, docs, business, SEO) |
 | **Skills** | 158 | Modular knowledge packages with progressive disclosure (load when activated) |
 | **Commands** | 106 | Slash commands: scaffolding, security scans, test gen, infrastructure setup |
 | **Orchestrators** | 16 | Multi-agent coordination workflows (full-stack, security, ML, incident response) |
@@ -125,8 +125,8 @@ uv run plugin-eval certify path/to/skill
 
 Detail lives in `docs/`. Read in this order:
 
-- **[docs/plugins.md](docs/plugins.md)** — full catalog of all 88 plugins
-- **[docs/agents.md](docs/agents.md)** — all 194 agents by category
+- **[docs/plugins.md](docs/plugins.md)** — full catalog of all 89 plugins
+- **[docs/agents.md](docs/agents.md)** — all 199 agents by category
 - **[docs/agent-skills.md](docs/agent-skills.md)** — 158 skills with progressive disclosure
 - **[docs/usage.md](docs/usage.md)** — commands, workflows, examples
 - **[docs/architecture.md](docs/architecture.md)** — design principles

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,6 +1,6 @@
 # Agent Reference
 
-Complete reference for all **194 local specialized AI agents** organized by category with model assignments.
+Complete reference for all **199 local specialized AI agents** organized by category with model assignments.
 
 ## Agent Categories
 
@@ -232,8 +232,8 @@ Agents are assigned to specific Claude models based on task complexity and compu
 | ------- | ----------- | --------------------------------------------------------------- |
 | Fable   | 0           | Longest-horizon autonomous work (tier above Opus; see criteria) |
 | Opus    | 54          | Critical architecture, security, code review, production coding |
-| Sonnet  | 66          | Complex tasks, support with intelligence                        |
-| Haiku   | 22          | Fast operational tasks                                          |
+| Sonnet  | 68          | Complex tasks, support with intelligence                        |
+| Haiku   | 25          | Fast operational tasks                                          |
 | Inherit | 52          | Complex tasks where the user chooses the model at runtime       |
 
 ### Model Selection Criteria

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,7 +36,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 
 ### Plugin Distribution
 
-- **88 marketplace plugins** (85 local + 3 external via git-subdir) optimized for specific use cases
+- **89 marketplace plugins** (86 local + 3 external via git-subdir) optimized for specific use cases
 - **26 clear categories** with 1-10 plugins each for easy discovery
 - Organized by domain:
   - **Development**: 6 plugins (debugging, backend, frontend, UI, multi-platform, essentials)
@@ -48,7 +48,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 
 ### Component Breakdown
 
-**194 Local Specialized Agents**
+**199 Local Specialized Agents**
 
 - Domain experts with deep knowledge
 - Organized across architecture, languages, infrastructure, quality, data/AI, documentation, business, and SEO
@@ -81,7 +81,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 ```
 claude-agents/
 ├── .claude-plugin/
-│   └── marketplace.json          # Marketplace catalog (88 plugins)
+│   └── marketplace.json          # Marketplace catalog (89 plugins)
 ├── plugins/                       # Isolated plugin directories
 │   ├── python-development/
 │   │   ├── agents/               # Python language agents
@@ -206,8 +206,8 @@ The system uses Claude Fable, Opus, Sonnet, Haiku, and Inherit assignments strat
 | ------- | --------- | ----------------------------------------------- |
 | Fable   | 0 agents  | Longest-horizon autonomous work (opt-in tier)   |
 | Opus    | 54 agents | Critical architecture, security, code review    |
-| Sonnet  | 66 agents | Complex tasks, support with intelligence        |
-| Haiku   | 22 agents | Fast operational tasks                          |
+| Sonnet  | 68 agents | Complex tasks, support with intelligence        |
+| Haiku   | 25 agents | Fast operational tasks                          |
 | Inherit | 52 agents | Defers model choice to the user at runtime      |
 
 ### Selection Criteria
@@ -263,7 +263,7 @@ code-reviewer (Sonnet) validates architecture
 ### Component Coverage
 
 - **100% agent coverage** - all plugins include at least one agent
-- **100% component availability** - all 194 local agents accessible across plugins
+- **100% component availability** - all 199 local agents accessible across plugins
 - **Efficient distribution** - 5.5 components per plugin average
 
 ### Discoverability
@@ -393,5 +393,5 @@ Feature Development Workflow:
 
 - [Agent Skills](./agent-skills.md) - Modular knowledge packages
 - [Agent Reference](./agents.md) - Complete agent catalog
-- [Plugin Reference](./plugins.md) - All 88 marketplace plugins
+- [Plugin Reference](./plugins.md) - All 89 marketplace plugins
 - [Usage Guide](./usage.md) - Commands and workflows


### PR DESCRIPTION
Post-merge count sync for #596: README.md, ARCHITECTURE.md, AGENTS.md (line 67), docs/agents.md, and docs/architecture.md now reflect 89 plugins (86 local + 3 external), 199 agents, and the updated model-tier distribution (Opus 54 / Sonnet 68 / Haiku 25 / Inherit 52), all verified against the filesystem. Gates: validate STRICT=1 OK, garden 0 errors, markdownlint clean.