### PR TITLE
Add ciagent — pytest-native regression testing for AI agents (external, testing)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1095,6 +1095,23 @@
       "category": "testing"
     },
     {
+      "name": "ciagent",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/suniel12/ciagent.git",
+        "path": "plugins/ciagent"
+      },
+      "description": "Pytest-native regression testing for the AI agent being built — the onboard skill records golden baselines and generates a test spec; the check skill runs trace-diff regression, multi-run stability with verdict-flip attribution, and LLM-judge audits after every agent change.",
+      "version": "0.10.0",
+      "author": {
+        "name": "Sunil Pandey",
+        "url": "https://github.com/suniel12"
+      },
+      "homepage": "https://github.com/suniel12/ciagent",
+      "license": "Apache-2.0",
+      "category": "testing"
+    },
+    {
       "name": "protect-mcp",
       "source": "./plugins/protect-mcp",
       "description": "Cedar policy enforcement + Ed25519 signed receipts for every Claude Code tool call. First cryptographic governance plugin \u2014 decisions are policy-gated before they run and every decision produces a tamper-evident receipt verifiable offline.",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agentic Plugin Marketplace
 
-> Production-ready agentic workflow building blocks: **91 plugins**, **199 agents**,
+> Production-ready agentic workflow building blocks: **92 plugins**, **199 agents**,
 > **162 skills**, **106 commands** — built for Claude Code and consumed natively by
 > OpenAI Codex CLI, Cursor, OpenCode, Gemini CLI, and GitHub Copilot from a single Markdown source.
 
@@ -19,7 +19,7 @@ Pick your harness:
 
 ```bash
 /plugin marketplace add wshobson/agents
-/plugin install python-development          # or any of 91 plugins
+/plugin install python-development          # or any of 92 plugins
 ```
 
 [→ Full Claude Code setup, troubleshooting, and plugin catalog](docs/usage.md)
@@ -47,7 +47,7 @@ Setup details and per-harness gotchas: [docs/harnesses.md](docs/harnesses.md). G
 
 | | Count | What it is |
 |---|---:|---|
-| **Plugins** | 91 | Granular, single-purpose installable units (88 local + 3 external via git-subdir) |
+| **Plugins** | 92 | Granular, single-purpose installable units (88 local + 4 external via git-subdir) |
 | **Agents** | 199 | Domain experts (architecture, languages, infra, security, data, ML, docs, business, SEO) |
 | **Skills** | 162 | Modular knowledge packages with progressive disclosure (load when activated) |
 | **Commands** | 106 | Slash commands: scaffolding, security scans, test gen, infrastructure setup |
@@ -125,7 +125,7 @@ uv run plugin-eval certify path/to/skill
 
 Detail lives in `docs/`. Read in this order:
 
-- **[docs/plugins.md](docs/plugins.md)** — full catalog of all 91 plugins
+- **[docs/plugins.md](docs/plugins.md)** — full catalog of all 92 plugins
 - **[docs/agents.md](docs/agents.md)** — all 199 agents by category
 - **[docs/agent-skills.md](docs/agent-skills.md)** — 162 skills with progressive disclosure
 - **[docs/usage.md](docs/usage.md)** — commands, workflows, examples

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,6 +1,6 @@
 # Complete Plugin Reference
 
-Browse all **91 marketplace plugins** organized by category: 88 local plugins plus 3 externally hosted `git-subdir` entries (`pensyve`, `qa-orchestra`, `storymap-skill`).
+Browse all **92 marketplace plugins** organized by category: 88 local plugins plus 4 externally hosted `git-subdir` entries (`pensyve`, `qa-orchestra`, `storymap-skill`, `ciagent`).
 
 ## Quick Start - Essential Plugins
 
@@ -141,12 +141,13 @@ Next.js, React + Vite, and Node.js project setup with pnpm and TypeScript best p
 | **ship-mate**                | Story-file to reviewed, tested PR workflow orchestration                       | `/plugin install ship-mate`                |
 | **storymap-skill**           | User story mapping (Jeff Patton) with WSJF/RICE/MoSCoW prioritization — external plugin | `/plugin install storymap-skill`           |
 
-### ✅ Testing (2 plugins)
+### ✅ Testing (3 plugins)
 
 | Plugin             | Description                                                                          | Install                          |
 | ------------------ | ------------------------------------------------------------------------------------ | -------------------------------- |
 | **unit-testing**   | Automated unit test generation (Python/JavaScript)                                   | `/plugin install unit-testing`   |
 | **qa-orchestra**   | Multi-agent QA toolkit (10 agents, Chrome MCP live validation, stack-agnostic) — external plugin | `/plugin install qa-orchestra`   |
+| **ciagent**        | Pytest-native regression testing for AI agents (golden-trace diffing, stability runs with flip attribution, LLM-judge audit) — external plugin | `/plugin install ciagent`        |
 
 ### 🔍 Quality (4 plugins)
 


### PR DESCRIPTION
Adds **ciagent** as an external `git-subdir` plugin in the **testing** category, following the qa-orchestra/storymap-skill precedent.

**What it does:** two skills that let a coding agent regression-test the AI agent it is building. `onboard` sets CIAgent up in a repo (writes the runner, records golden baselines, generates a test spec, with a cost gate before live recording). `check` runs the right check after any agent change — trace-diff regression, multi-run stability with verdict-flip attribution (agent-variance vs judge-flake), or an LLM-judge audit — and reads the results honestly.

**Disclosure (per CONTRIBUTING):** this plugin wraps the `ciagent` PyPI package (Apache-2.0, free, no paid tier or telemetry), and I maintain both the plugin and the package. Also disclosed in the plugin README.

**Checks:** `make validate STRICT=1` — OK across 5 harnesses. `make garden STRICT=1` — 0 errors; the 10 SKILL_OVER_CODEX_CAP warnings are pre-existing on files this PR doesn't touch. Docs counts updated (89→90, externals 3→4) in README.md and docs/plugins.md.