### PR TITLE
docs: sync counts after skill-forge-essentials merge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # claude-agents — multi-harness agentic plugin marketplace
 
-Production-ready agentic-workflow building blocks: **89 plugins** (86 local + 3 external), **199 agents**, **158 skills**, **106 commands**. Native source-of-truth for Claude Code; also consumed by OpenAI Codex CLI, Cursor, OpenCode, and Gemini CLI from a single Markdown source.
+Production-ready agentic-workflow building blocks: **90 plugins** (87 local + 3 external), **199 agents**, **161 skills**, **106 commands**. Native source-of-truth for Claude Code; also consumed by OpenAI Codex CLI, Cursor, OpenCode, and Gemini CLI from a single Markdown source.
 
 This file is the canonical context file. Codex / Cursor / OpenCode read it directly. Claude Code reads it via `CLAUDE.md`, a symlink to this file. Gemini CLI reads it via `gemini-extension.json` (`contextFileName`) / `.gemini/settings.json`.
 
@@ -10,7 +10,7 @@ This file is the canonical context file. Codex / Cursor / OpenCode read it direc
 
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — top-level architectural overview (adapter framework, source-of-truth invariant, capability matrix summary)
 - **[docs/architecture.md](docs/architecture.md)** — detailed design principles
-- **[docs/plugins.md](docs/plugins.md)** — full plugin catalog (89 plugins by category)
+- **[docs/plugins.md](docs/plugins.md)** — full plugin catalog (90 plugins by category)
 - **[docs/agents.md](docs/agents.md)** — agent reference (199 agents, model tiers)
 - **[docs/agent-skills.md](docs/agent-skills.md)** — skill reference (progressive disclosure model)
 - **[docs/usage.md](docs/usage.md)** — commands, workflows, examples
@@ -52,7 +52,7 @@ Generated artifacts are **committed** so each harness installs natively from a c
 
 ## Skills (cross-harness)
 
-158 skills under `plugins/*/skills/<n>/SKILL.md` — discoverable by every harness:
+161 skills under `plugins/*/skills/<n>/SKILL.md` — discoverable by every harness:
 
 - **Claude Code**: auto-discovery via Anthropic's SKILL.md spec
 - **Codex CLI**: mirrored to `.codex/skills/<plugin>__<skill>/` (8 KB body cap; detail in `references/details.md`)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,7 +26,7 @@ claude-agents/
 ├── CONTRIBUTING.md                 # Contributor entry point
 ├── .claude-plugin/marketplace.json # Plugin registry (source of truth)
 ├── .gemini/settings.json           # Gemini CLI → AGENTS.md redirect
-├── plugins/                        # SOURCE OF TRUTH (86 local plugins; 3 externals in marketplace)
+├── plugins/                        # SOURCE OF TRUTH (87 local plugins; 3 externals in marketplace)
 │   └── <name>/
 │       ├── .claude-plugin/plugin.json
 │       ├── agents/*.md

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Agentic Plugin Marketplace
 
-> Production-ready agentic workflow building blocks: **89 plugins**, **199 agents**,
-> **158 skills**, **106 commands** — built for Claude Code and consumed natively by
+> Production-ready agentic workflow building blocks: **90 plugins**, **199 agents**,
+> **161 skills**, **106 commands** — built for Claude Code and consumed natively by
 > OpenAI Codex CLI, Cursor, OpenCode, Gemini CLI, and GitHub Copilot from a single Markdown source.
 
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-native-blueviolet)](#claude-code) [![Codex CLI](https://img.shields.io/badge/Codex%20CLI-supported-black)](docs/harnesses.md) [![Cursor](https://img.shields.io/badge/Cursor-supported-purple)](docs/harnesses.md) [![OpenCode](https://img.shields.io/badge/OpenCode-supported-green)](docs/harnesses.md) [![Gemini CLI](https://img.shields.io/badge/Gemini%20CLI-supported-blue)](GEMINI.md) [![Copilot](https://img.shields.io/badge/Copilot-supported-lightgrey)](docs/harnesses.md)
@@ -19,7 +19,7 @@ Pick your harness:
 
 ```bash
 /plugin marketplace add wshobson/agents
-/plugin install python-development          # or any of 89 plugins
+/plugin install python-development          # or any of 90 plugins
 ```
 
 [→ Full Claude Code setup, troubleshooting, and plugin catalog](docs/usage.md)
@@ -47,9 +47,9 @@ Setup details and per-harness gotchas: [docs/harnesses.md](docs/harnesses.md). G
 
 | | Count | What it is |
 |---|---:|---|
-| **Plugins** | 89 | Granular, single-purpose installable units (86 local + 3 external via git-subdir) |
+| **Plugins** | 90 | Granular, single-purpose installable units (87 local + 3 external via git-subdir) |
 | **Agents** | 199 | Domain experts (architecture, languages, infra, security, data, ML, docs, business, SEO) |
-| **Skills** | 158 | Modular knowledge packages with progressive disclosure (load when activated) |
+| **Skills** | 161 | Modular knowledge packages with progressive disclosure (load when activated) |
 | **Commands** | 106 | Slash commands: scaffolding, security scans, test gen, infrastructure setup |
 | **Orchestrators** | 16 | Multi-agent coordination workflows (full-stack, security, ML, incident response) |
 
@@ -125,9 +125,9 @@ uv run plugin-eval certify path/to/skill
 
 Detail lives in `docs/`. Read in this order:
 
-- **[docs/plugins.md](docs/plugins.md)** — full catalog of all 89 plugins
+- **[docs/plugins.md](docs/plugins.md)** — full catalog of all 90 plugins
 - **[docs/agents.md](docs/agents.md)** — all 199 agents by category
-- **[docs/agent-skills.md](docs/agent-skills.md)** — 158 skills with progressive disclosure
+- **[docs/agent-skills.md](docs/agent-skills.md)** — 161 skills with progressive disclosure
 - **[docs/usage.md](docs/usage.md)** — commands, workflows, examples
 - **[docs/architecture.md](docs/architecture.md)** — design principles
 - **[docs/harnesses.md](docs/harnesses.md)** — cross-harness capability matrix

--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -1,6 +1,6 @@
 # Agent Skills
 
-Agent Skills are modular packages that extend Claude's capabilities with specialized domain knowledge, following Anthropic's [Agent Skills Specification](https://github.com/anthropics/skills/blob/main/agent_skills_spec.md). This plugin ecosystem includes **158 local specialized skills** across 44 plugins, enabling progressive disclosure and efficient token usage.
+Agent Skills are modular packages that extend Claude's capabilities with specialized domain knowledge, following Anthropic's [Agent Skills Specification](https://github.com/anthropics/skills/blob/main/agent_skills_spec.md). This plugin ecosystem includes **161 local specialized skills** across 45 plugins, enabling progressive disclosure and efficient token usage.
 
 ## Overview
 
@@ -392,7 +392,7 @@ fastapi-templates skill → Supplies production-ready templates
 
 ## Specification Compliance
 
-All 158 skills follow the [Agent Skills Specification](https://agentskills.io/specification):
+All 161 skills follow the [Agent Skills Specification](https://agentskills.io/specification):
 
 - ✓ Required `name` field (hyphen-case)
 - ✓ Required `description` field with "Use when" clause

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,7 +36,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 
 ### Plugin Distribution
 
-- **89 marketplace plugins** (86 local + 3 external via git-subdir) optimized for specific use cases
+- **90 marketplace plugins** (87 local + 3 external via git-subdir) optimized for specific use cases
 - **26 clear categories** with 1-10 plugins each for easy discovery
 - Organized by domain:
   - **Development**: 6 plugins (debugging, backend, frontend, UI, multi-platform, essentials)
@@ -69,11 +69,11 @@ This marketplace follows industry best practices with a focus on granularity, co
   - Component scaffolding (React, React Native)
   - Infrastructure setup (Terraform, Kubernetes)
 
-**158 Local Agent Skills**
+**161 Local Agent Skills**
 
 - Modular knowledge packages
 - Progressive disclosure architecture
-- Domain-specific expertise across 44 plugins
+- Domain-specific expertise across 45 plugins
 - Spec-compliant (Anthropic Agent Skills Specification)
 
 ## Repository Structure
@@ -81,7 +81,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 ```
 claude-agents/
 ├── .claude-plugin/
-│   └── marketplace.json          # Marketplace catalog (89 plugins)
+│   └── marketplace.json          # Marketplace catalog (90 plugins)
 ├── plugins/                       # Isolated plugin directories
 │   ├── python-development/
 │   │   ├── agents/               # Python language agents
@@ -194,7 +194,7 @@ description: What the skill does. Use when [trigger]. # Required: < 1024 chars
 - **Composability**: Mix and match skills across workflows
 - **Maintainability**: Isolated updates don't affect other skills
 
-See [Agent Skills](./agent-skills.md) for complete details on the 158 skills.
+See [Agent Skills](./agent-skills.md) for complete details on the 161 skills.
 
 ## Model Configuration Strategy
 
@@ -393,5 +393,5 @@ Feature Development Workflow:
 
 - [Agent Skills](./agent-skills.md) - Modular knowledge packages
 - [Agent Reference](./agents.md) - Complete agent catalog
-- [Plugin Reference](./plugins.md) - All 89 marketplace plugins
+- [Plugin Reference](./plugins.md) - All 90 marketplace plugins
 - [Usage Guide](./usage.md) - Commands and workflows

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,6 +1,6 @@
 # Complete Plugin Reference
 
-Browse all **89 marketplace plugins** organized by category: 86 local plugins plus 3 externally hosted `git-subdir` entries (`pensyve`, `qa-orchestra`, `storymap-skill`).
+Browse all **90 marketplace plugins** organized by category: 87 local plugins plus 3 externally hosted `git-subdir` entries (`pensyve`, `qa-orchestra`, `storymap-skill`).
 
 ## Quick Start - Essential Plugins
 
@@ -362,7 +362,7 @@ plugins/python-development/
 /plugin marketplace add wshobson/agents
 ```
 
-This makes all 89 marketplace plugins available for installation, but **does not load any agents or tools** into your context.
+This makes all 90 marketplace plugins available for installation, but **does not load any agents or tools** into your context.
 
 ### Step 2: Install Specific Plugins
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -391,5 +391,5 @@ See [Agent Skills](./agent-skills.md) for details on the 158 specialized skills.
 
 - [Agent Skills](./agent-skills.md) - Specialized knowledge packages
 - [Agent Reference](./agents.md) - Complete agent catalog
-- [Plugin Reference](./plugins.md) - All 88 marketplace plugins
+- [Plugin Reference](./plugins.md) - All 90 marketplace plugins
 - [Architecture](./architecture.md) - Design principles


### PR DESCRIPTION
Post-merge count sync for #577: 90 plugins (87 local + 3 external), 161 skills across 45 plugins, verified against the filesystem. Includes the docs/usage.md and docs/plugins.md lines that previous syncs missed. Gates: validate STRICT=1 OK, garden 0 errors, markdownlint clean.