### PR TITLE
docs: sync counts to 92 plugins after #582 + #614

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # claude-agents — multi-harness agentic plugin marketplace
 
-Production-ready agentic-workflow building blocks: **91 plugins** (88 local + 3 external), **199 agents**, **162 skills**, **106 commands**. Native source-of-truth for Claude Code; also consumed by OpenAI Codex CLI, Cursor, OpenCode, and Gemini CLI from a single Markdown source.
+Production-ready agentic-workflow building blocks: **92 plugins** (88 local + 4 external), **199 agents**, **162 skills**, **106 commands**. Native source-of-truth for Claude Code; also consumed by OpenAI Codex CLI, Cursor, OpenCode, and Gemini CLI from a single Markdown source.
 
 This file is the canonical context file. Codex / Cursor / OpenCode read it directly. Claude Code reads it via `CLAUDE.md`, a symlink to this file. Gemini CLI reads it via `gemini-extension.json` (`contextFileName`) / `.gemini/settings.json`.
 
@@ -10,7 +10,7 @@ This file is the canonical context file. Codex / Cursor / OpenCode read it direc
 
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — top-level architectural overview (adapter framework, source-of-truth invariant, capability matrix summary)
 - **[docs/architecture.md](docs/architecture.md)** — detailed design principles
-- **[docs/plugins.md](docs/plugins.md)** — full plugin catalog (91 plugins by category)
+- **[docs/plugins.md](docs/plugins.md)** — full plugin catalog (92 plugins by category)
 - **[docs/agents.md](docs/agents.md)** — agent reference (199 agents, model tiers)
 - **[docs/agent-skills.md](docs/agent-skills.md)** — skill reference (progressive disclosure model)
 - **[docs/usage.md](docs/usage.md)** — commands, workflows, examples

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,7 +36,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 
 ### Plugin Distribution
 
-- **91 marketplace plugins** (88 local + 3 external via git-subdir) optimized for specific use cases
+- **92 marketplace plugins** (88 local + 4 external via git-subdir) optimized for specific use cases
 - **26 clear categories** with 1-10 plugins each for easy discovery
 - Organized by domain:
   - **Development**: 6 plugins (debugging, backend, frontend, UI, multi-platform, essentials)
@@ -81,7 +81,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 ```
 claude-agents/
 ├── .claude-plugin/
-│   └── marketplace.json          # Marketplace catalog (91 plugins)
+│   └── marketplace.json          # Marketplace catalog (92 plugins)
 ├── plugins/                       # Isolated plugin directories
 │   ├── python-development/
 │   │   ├── agents/               # Python language agents
@@ -393,5 +393,5 @@ Feature Development Workflow:
 
 - [Agent Skills](./agent-skills.md) - Modular knowledge packages
 - [Agent Reference](./agents.md) - Complete agent catalog
-- [Plugin Reference](./plugins.md) - All 91 marketplace plugins
+- [Plugin Reference](./plugins.md) - All 92 marketplace plugins
 - [Usage Guide](./usage.md) - Commands and workflows

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -363,7 +363,7 @@ plugins/python-development/
 /plugin marketplace add wshobson/agents
 ```
 
-This makes all 91 marketplace plugins available for installation, but **does not load any agents or tools** into your context.
+This makes all 92 marketplace plugins available for installation, but **does not load any agents or tools** into your context.
 
 ### Step 2: Install Specific Plugins
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -391,5 +391,5 @@ See [Agent Skills](./agent-skills.md) for details on the 158 specialized skills.
 
 - [Agent Skills](./agent-skills.md) - Specialized knowledge packages
 - [Agent Reference](./agents.md) - Complete agent catalog
-- [Plugin Reference](./plugins.md) - All 90 marketplace plugins
+- [Plugin Reference](./plugins.md) - All 92 marketplace plugins
 - [Architecture](./architecture.md) - Design principles


### PR DESCRIPTION
Reconciles plugin-count references across the docs after the hermes-tweet (#582) and ciagent (#614) merges. Each of those PRs updated only a subset of count strings; this brings the remainder to **92 plugins (88 local + 4 external)**.

Files: `AGENTS.md` (==`CLAUDE.md` symlink), `docs/architecture.md`, `docs/plugins.md`, `docs/usage.md`. Agents (199), skills (162), commands (106) unchanged.

Gates (local): `make validate STRICT=1` OK · `make garden` 0 errors · `make test` 449 passed · `make smoke-test` 7 passed.

Note: `docs/round-trip-results.md` still says `155 skills` — long-standing drift predating this batch; left untouched to keep this PR surgical.