### PR TITLE
fix(adapters): parse nested frontmatter mappings

### DIFF
--- a/tools/adapters/base.py
+++ b/tools/adapters/base.py
@@ -39,6 +39,7 @@ def parse_frontmatter(content: str) -> tuple[dict, str]:
     Supports:
     - scalar fields (`name: foo`)
     - inline lists (`tools: [a, b]`) and block lists (key: \\n  - a\\n  - b)
+    - one-level mappings (`metadata: \\n  version: 1.0.0`)
     - YAML block scalar indicators `>` and `|` (folded/literal multi-line strings)
     - 2-space continuation of scalar values
     """
@@ -100,6 +101,14 @@ def parse_frontmatter(content: str) -> tuple[dict, str]:
             if text:
                 existing = fields.get(current_key) or ""
                 fields[current_key] = (existing + " " + text).strip() if existing else text
+        elif (
+            current_key
+            and isinstance(fields.get(current_key), dict)
+            and line.startswith(("  ", "\t"))
+        ):
+            nested = re.match(r"^(\w[\w-]*):\s*(.*)", line.strip())
+            if nested:
+                fields[current_key][nested.group(1)] = nested.group(2).strip().strip('"').strip("'")
         elif in_list and (
             isinstance(fields.get(current_key), list)
             or (isinstance(fields.get(current_key), str) and fields[current_key] == "")
@@ -123,6 +132,13 @@ def parse_frontmatter(content: str) -> tuple[dict, str]:
                 item = stripped.strip('",[] ')
                 if item and item != "]":
                     fields[current_key].append(item)
+            elif is_indented:
+                nested = re.match(r"^(\w[\w-]*):\s*(.*)", stripped)
+                if nested:
+                    fields[current_key] = {
+                        nested.group(1): nested.group(2).strip().strip('"').strip("'")
+                    }
+                    in_list = False
         elif current_key and isinstance(fields.get(current_key), str) and line.startswith("  "):
             fields[current_key] += " " + line.strip().strip('"')
 

--- a/tools/adapters/base.py
+++ b/tools/adapters/base.py
@@ -33,6 +33,11 @@ def read_plugin_json(plugin_dir: Path) -> dict:
         return {}
 
 
+def _is_one_level_mapping_entry(line: str) -> bool:
+    """Return whether a line has exactly one frontmatter indentation level."""
+    return bool(re.match(r"^(?: {2}|\t)\S", line))
+
+
 def parse_frontmatter(content: str) -> tuple[dict, str]:
     """Return (fields, body). Tolerant YAML-ish parser; no external dep.
 
@@ -104,7 +109,7 @@ def parse_frontmatter(content: str) -> tuple[dict, str]:
         elif (
             current_key
             and isinstance(fields.get(current_key), dict)
-            and line.startswith(("  ", "\t"))
+            and _is_one_level_mapping_entry(line)
         ):
             nested = re.match(r"^(\w[\w-]*):\s*(.*)", line.strip())
             if nested:
@@ -132,7 +137,7 @@ def parse_frontmatter(content: str) -> tuple[dict, str]:
                 item = stripped.strip('",[] ')
                 if item and item != "]":
                     fields[current_key].append(item)
-            elif is_indented:
+            elif _is_one_level_mapping_entry(line):
                 nested = re.match(r"^(\w[\w-]*):\s*(.*)", stripped)
                 if nested:
                     fields[current_key] = {

--- a/tools/tests/test_adapters.py
+++ b/tools/tests/test_adapters.py
@@ -1181,6 +1181,17 @@ class TestFrontmatterParser:
         fm, _ = parse_frontmatter("---\nname: x\ndescription: >\n  multi\n  line\n---\nbody")
         assert fm["description"] == "multi line"
 
+    def test_nested_mapping(self):
+        from tools.adapters.base import parse_frontmatter
+
+        fm, _ = parse_frontmatter(
+            "---\nmetadata:\n  version: \"1.0.0\"\n  source: https://example.com\n---\nbody"
+        )
+        assert fm["metadata"] == {
+            "version": "1.0.0",
+            "source": "https://example.com",
+        }
+
 
 class TestCapabilities:
     def test_every_adapter_id_has_capabilities_entry(self):

--- a/tools/tests/test_adapters.py
+++ b/tools/tests/test_adapters.py
@@ -1192,6 +1192,17 @@ class TestFrontmatterParser:
             "source": "https://example.com",
         }
 
+    def test_nested_mapping_rejects_deeper_indentation(self):
+        from tools.adapters.base import parse_frontmatter
+
+        fm, _ = parse_frontmatter("---\nmetadata:\n    version: 1.0.0\n---\nbody")
+        assert fm["metadata"] == ""
+
+        fm, _ = parse_frontmatter(
+            "---\nmetadata:\n  version: 1.0.0\n    source: https://example.com\n---\nbody"
+        )
+        assert fm["metadata"] == {"version": "1.0.0"}
+
 
 class TestCapabilities:
     def test_every_adapter_id_has_capabilities_entry(self):

--- a/tools/tests/test_adapters.py
+++ b/tools/tests/test_adapters.py
@@ -1185,7 +1185,7 @@ class TestFrontmatterParser:
         from tools.adapters.base import parse_frontmatter
 
         fm, _ = parse_frontmatter(
-            "---\nmetadata:\n  version: \"1.0.0\"\n  source: https://example.com\n---\nbody"
+            '---\nmetadata:\n  version: "1.0.0"\n  source: https://example.com\n---\nbody'
         )
         assert fm["metadata"] == {
             "version": "1.0.0",


### PR DESCRIPTION
# Summary

Fix the shared frontmatter parser so one-level YAML mappings remain dictionaries when generating harness artifacts. This prevents Codex from rejecting generated skills whose `metadata` was previously serialized as an empty string.

## Why

Valid source frontmatter such as:

```yaml
metadata:
  version: "1.0.0"
  source: https://example.com
```

was parsed as `metadata: ""`, which does not satisfy Codex's `SkillFrontmatterMetadata` schema. It is now preserved as the intended mapping:

```yaml
metadata:
  version: 1.0.0
  source: https://example.com
```

## Change type

- Bug fix
- No breaking API, dependency, schema, configuration, or migration changes

## Implementation

- Recognize indented `key: value` entries beneath an empty top-level frontmatter key and promote that field to a one-level dictionary.
- Preserve subsequent entries in the same mapping, including quoted values and values containing URL punctuation.
- Document the supported mapping shape and add a focused regression test for the reported metadata structure.

## Verification

- `make test`: 477 passed, 2 skipped. Both skips are OpenCode-only CLI smoke tests because OpenCode is not installed locally; CI exercises them.
- `make validate STRICT=1`: passed across all 5 harnesses.
- Native Codex prompt loading completed without the original invalid-YAML warning for `.codex/skills/social-publishing__social-publishing/SKILL.md`.
- Direct YAML parsing confirmed `metadata` is a mapping and `version` is `1.0.0`.
- `git diff --check`: passed.

## Breaking and deployment notes

- Backward compatible for existing scalar, list, and block-scalar frontmatter.
- No new dependencies, migrations, configuration changes, or deployment steps.
- Generated artifacts showed no tracked drift after regeneration.
- Mapping support is intentionally limited to one level; deeper nesting remains outside this change.

## Screenshots

Not applicable; this change affects frontmatter parsing and generated skill metadata only.

## Reviewer checklist

- [ ] Confirm the new branch activates only for indented `key: value` entries beneath an empty field.
- [ ] Confirm existing scalar, list, and block-scalar parsing order remains unchanged.
- [ ] Confirm the regression test covers multiple metadata keys, quote removal, and URL preservation.
- [ ] Confirm the generated Codex metadata shape matches `SkillFrontmatterMetadata` expectations.
