### PR TITLE
Add software graph analysis skill

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -388,7 +388,7 @@
       "name": "developer-essentials",
       "source": "./plugins/developer-essentials",
       "version": "1.0.4",
-      "description": "Essential developer skills including Git workflows, SQL optimization, error handling, code review, E2E testing, authentication, debugging, and monorepo management",
+      "description": "Essential developer skills including Git workflows, SQL optimization, error handling, code review, E2E testing, authentication, debugging, monorepo management, and software graph analysis",
       "author": {
         "name": "Seth Hobson",
         "email": "seth@major7apps.com"

--- a/.cursor-plugin/plugins/developer-essentials.json
+++ b/.cursor-plugin/plugins/developer-essentials.json
@@ -2,7 +2,7 @@
   "name": "developer-essentials",
   "displayName": "Developer Essentials",
   "version": "1.0.4",
-  "description": "Essential developer skills including Git workflows, SQL optimization, error handling, code review, E2E testing, authentication, debugging, and monorepo management",
+  "description": "Essential developer skills including Git workflows, SQL optimization, error handling, code review, E2E testing, authentication, debugging, monorepo management, and software graph analysis",
   "author": {
     "name": "Seth Hobson",
     "email": "seth@major7apps.com"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Agentic Plugin Marketplace
 
 > Production-ready agentic workflow building blocks: **92 plugins**, **199 agents**,
-> **162 skills**, **106 commands** — built for Claude Code and consumed natively by
+> **163 skills**, **106 commands** — built for Claude Code and consumed natively by
 > OpenAI Codex CLI, Cursor, OpenCode, Gemini CLI, and GitHub Copilot from a single Markdown source.
 
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-native-blueviolet)](#claude-code) [![Codex CLI](https://img.shields.io/badge/Codex%20CLI-supported-black)](docs/harnesses.md) [![Cursor](https://img.shields.io/badge/Cursor-supported-purple)](docs/harnesses.md) [![OpenCode](https://img.shields.io/badge/OpenCode-supported-green)](docs/harnesses.md) [![Gemini CLI](https://img.shields.io/badge/Gemini%20CLI-supported-blue)](GEMINI.md) [![Copilot](https://img.shields.io/badge/Copilot-supported-lightgrey)](docs/harnesses.md)
@@ -49,7 +49,7 @@ Setup details and per-harness gotchas: [docs/harnesses.md](docs/harnesses.md). G
 |---|---:|---|
 | **Plugins** | 92 | Granular, single-purpose installable units (88 local + 4 external via git-subdir) |
 | **Agents** | 199 | Domain experts (architecture, languages, infra, security, data, ML, docs, business, SEO) |
-| **Skills** | 162 | Modular knowledge packages with progressive disclosure (load when activated) |
+| **Skills** | 163 | Modular knowledge packages with progressive disclosure (load when activated) |
 | **Commands** | 106 | Slash commands: scaffolding, security scans, test gen, infrastructure setup |
 | **Orchestrators** | 16 | Multi-agent coordination workflows (full-stack, security, ML, incident response) |
 
@@ -127,7 +127,7 @@ Detail lives in `docs/`. Read in this order:
 
 - **[docs/plugins.md](docs/plugins.md)** — full catalog of all 92 plugins
 - **[docs/agents.md](docs/agents.md)** — all 199 agents by category
-- **[docs/agent-skills.md](docs/agent-skills.md)** — 162 skills with progressive disclosure
+- **[docs/agent-skills.md](docs/agent-skills.md)** — 163 skills with progressive disclosure
 - **[docs/usage.md](docs/usage.md)** — commands, workflows, examples
 - **[docs/architecture.md](docs/architecture.md)** — design principles
 - **[docs/harnesses.md](docs/harnesses.md)** — cross-harness capability matrix

--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -1,6 +1,6 @@
 # Agent Skills
 
-Agent Skills are modular packages that extend Claude's capabilities with specialized domain knowledge, following Anthropic's [Agent Skills Specification](https://github.com/anthropics/skills/blob/main/agent_skills_spec.md). This plugin ecosystem includes **162 local specialized skills** across 46 plugins, enabling progressive disclosure and efficient token usage.
+Agent Skills are modular packages that extend Claude's capabilities with specialized domain knowledge, following Anthropic's [Agent Skills Specification](https://github.com/anthropics/skills/blob/main/agent_skills_spec.md). This plugin ecosystem includes **163 local specialized skills** across 46 plugins, enabling progressive disclosure and efficient token usage.
 
 ## Overview
 
@@ -48,7 +48,7 @@ Skills provide Claude with deep expertise in specific domains without loading ev
 | **projection-patterns**             | Build efficient projections from event streams for read-optimized views                               |
 | **saga-orchestration**              | Design distributed sagas with compensation logic and failure handling                                 |
 
-### Developer Essentials (11 skills)
+### Developer Essentials (12 skills)
 
 | Skill                            | Description                                                                                     |
 | -------------------------------- | ----------------------------------------------------------------------------------------------- |
@@ -63,6 +63,7 @@ Skills provide Claude with deep expertise in specific domains without loading ev
 | **nx-workspace-patterns**        | Configure Nx workspaces with computation caching and affected commands                          |
 | **turborepo-caching**            | Optimize Turborepo builds with remote caching and pipeline configuration                        |
 | **bazel-build-optimization**     | Design Bazel builds with hermetic actions and remote execution                                  |
+| **software-graph-analysis**      | Use Ontoly's deterministic Software Graph for architecture, request tracing, dependency impact, and configuration lookup |
 
 ### Blockchain & Web3 (4 skills)
 
@@ -392,7 +393,7 @@ fastapi-templates skill → Supplies production-ready templates
 
 ## Specification Compliance
 
-All 162 skills follow the [Agent Skills Specification](https://agentskills.io/specification):
+All 163 skills follow the [Agent Skills Specification](https://agentskills.io/specification):
 
 - ✓ Required `name` field (hyphen-case)
 - ✓ Required `description` field with "Use when" clause

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -117,7 +117,7 @@ Next.js, React + Vite, and Node.js project setup with pnpm and TypeScript best p
 | **frontend-mobile-development** | Frontend UI and mobile development                           | `/plugin install frontend-mobile-development` |
 | **ui-design**                   | UI/UX design for mobile (iOS, Android, React Native) and web | `/plugin install ui-design`                   |
 | **multi-platform-apps**         | Cross-platform app coordination (web/iOS/Android)            | `/plugin install multi-platform-apps`         |
-| **developer-essentials**        | Essential Git, SQL, code review, auth, debugging, and monorepo skills | `/plugin install developer-essentials`        |
+| **developer-essentials**        | Essential Git, SQL, code review, auth, debugging, monorepo, and software graph skills | `/plugin install developer-essentials`        |
 
 ### 📚 Documentation (4 plugins)
 
@@ -406,7 +406,7 @@ Each installed plugin loads **only its specific agents and commands** into Claud
 
 ## See Also
 
-- [Agent Skills](./agent-skills.md) - 158 specialized skills across plugins
+- [Agent Skills](./agent-skills.md) - 163 specialized skills across plugins
 - [Agent Reference](./agents.md) - Complete agent catalog
 - [Usage Guide](./usage.md) - Commands and workflows
 - [Architecture](./architecture.md) - Design principles

--- a/plugins/developer-essentials/.claude-plugin/plugin.json
+++ b/plugins/developer-essentials/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "developer-essentials",
   "version": "1.0.4",
-  "description": "Essential developer skills including Git workflows, SQL optimization, error handling, code review, E2E testing, authentication, debugging, and monorepo management",
+  "description": "Essential developer skills including Git workflows, SQL optimization, error handling, code review, E2E testing, authentication, debugging, monorepo management, and software graph analysis",
   "author": {
     "name": "Seth Hobson",
     "email": "seth@major7apps.com"

--- a/plugins/developer-essentials/.codex-plugin/plugin.json
+++ b/plugins/developer-essentials/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "developer-essentials",
   "version": "1.0.4",
-  "description": "Essential developer skills including Git workflows, SQL optimization, error handling, code review, E2E testing, authentication, debugging, and monorepo management",
+  "description": "Essential developer skills including Git workflows, SQL optimization, error handling, code review, E2E testing, authentication, debugging, monorepo management, and software graph analysis",
   "skills": "./skills/",
   "author": {
     "name": "Seth Hobson",

--- a/plugins/developer-essentials/skills/software-graph-analysis/SKILL.md
+++ b/plugins/developer-essentials/skills/software-graph-analysis/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: software-graph-analysis
+description: Use when repository understanding should come from Ontoly's deterministic Software Graph, MCP capabilities, validation reports, request tracing, dependency impact analysis, architecture review, or configuration lookup before source-file search.
+---
+
+# Software Graph Analysis
+
+Use Ontoly's Software Graph as deterministic evidence for codebase understanding before falling back to source-file search.
+
+## When to Use This Skill
+
+- The repository contains `.ontoly/`, `SoftwareGraph.json`, diagnostics, graph validation reports, or Ontoly MCP configuration.
+- The user asks for architecture review, request tracing, dependency impact, framework analysis, configuration lookup, route ownership, service ownership, or codebase onboarding.
+- The user mentions Ontoly, Software Graph, semantic graph, graph hash, graph validation, or MCP graph capabilities.
+- A refactor needs evidence about what depends on a package, module, service, route, or environment variable.
+
+## Core Workflow
+
+1. **Check graph availability.** Look for `.ontoly/`, `SoftwareGraph.json`, `diagnostics.json`, validation reports, semantic evaluation output, graph hash, or MCP configuration.
+2. **Build when appropriate.** If no graph exists and local analysis is acceptable, run `ontoly build .`.
+3. **Validate graph health.** Review diagnostics, semantic coverage, trust or quality score, framework detection, graph hash, repository path, and generation timestamp.
+4. **Query Ontoly first.** Prefer Ontoly CLI or MCP capabilities for graph-answerable questions before searching source files.
+5. **Answer with evidence.** Cite node IDs, edge types, file paths, source locations, diagnostics, and confidence derived from graph evidence.
+6. **Fallback narrowly.** Search files only when the graph is missing, stale, incomplete, ambiguous, or the user explicitly requests source verification.
+
+## Capability Map
+
+| User Intent | Ontoly Capability |
+| --- | --- |
+| Repository architecture | `ExplainArchitecture` |
+| Dependency tree | `FindDependencies` |
+| Refactor blast radius | `ImpactAnalysis` |
+| Request or route flow | `TraceExecution` |
+| Configuration usage | `FindConfigurationUsage` |
+| Framework concepts | `FrameworkReport` |
+| Dead or unreachable code | `FindDeadCode` |
+
+## Evidence Rules
+
+- High confidence requires a matching node, relationship edge, and source location.
+- Medium confidence is acceptable when the matching node exists but one relationship or source location is incomplete.
+- Low confidence means only partial graph evidence exists and source verification may be needed.
+- `NOT_FOUND` is better than an invented graph fact.
+
+## Response Pattern
+
+```text
+AuthController handles authentication.
+
+Evidence:
+- node: class:src/auth/auth.controller.ts:AuthController
+- route edges: HANDLES POST /login and POST /logout
+- dependency edges: USES AuthService and JwtService
+
+Confidence: high, because controller, route, and dependency edges have source locations.
+```
+
+## Avoid
+
+- Searching the repository first when graph evidence exists.
+- Treating graph size or node count as semantic correctness.
+- Guessing confidence without graph evidence.
+- Hiding stale graph or validation warnings.
+- Inventing missing services, routes, modules, dependencies, or configuration usage.
+


### PR DESCRIPTION
## Summary\n- adds a developer-essentials skill for Ontoly Software Graph analysis\n- updates developer-essentials plugin metadata and docs counts\n- regenerates committed Cursor marketplace artifacts\n\n## Validation\n- make generate-all\n- make validate\n- make garden (0 errors; existing SKILL_OVER_CODEX_CAP warnings only)\n- git diff --check