### PR TITLE
feat: add llm-finetuning and dgx-spark-ops plugins (eval-gated fine-tuning lifecycle)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -422,6 +422,18 @@
       "category": "Coding"
     },
     {
+      "name": "dgx-spark-ops",
+      "source": {
+        "source": "local",
+        "path": "./plugins/dgx-spark-ops"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_USE"
+      },
+      "category": "Coding"
+    },
+    {
       "name": "distributed-debugging",
       "source": {
         "source": "local",
@@ -678,6 +690,18 @@
       "source": {
         "source": "local",
         "path": "./plugins/llm-application-dev"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_USE"
+      },
+      "category": "Coding"
+    },
+    {
+      "name": "llm-finetuning",
+      "source": {
+        "source": "local",
+        "path": "./plugins/llm-finetuning"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -206,6 +206,16 @@
       "license": "MIT"
     },
     {
+      "name": "llm-finetuning",
+      "description": "Eval-gated LLM fine-tuning lifecycle (LoRA/QLoRA, DPO, GRPO/RLVR, vision SFT, quantized export). Use when fine-tuning an open-weights model end-to-end: building the eval harness first, selecting method and model, preparing data, training with Unsloth or TRL, gating checkpoints, and exporting GGUF/FP8.",
+      "version": "1.0.0",
+      "author": { "name": "Seth Hobson", "email": "seth@major7apps.com" },
+      "source": "./plugins/llm-finetuning",
+      "category": "ai-ml",
+      "homepage": "https://github.com/wshobson/agents",
+      "license": "MIT"
+    },
+    {
       "name": "agent-orchestration",
       "source": "./plugins/agent-orchestration",
       "description": "Multi-agent system optimization, agent improvement workflows, and context management",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/wshobson"
   },
   "metadata": {
-    "description": "Production-ready workflow orchestration with 91 marketplace plugins, 199 local specialized agents, and 162 local skills - optimized for granular installation and minimal token usage",
+    "description": "Production-ready workflow orchestration with 94 marketplace plugins, 203 local specialized agents, and 175 local skills - optimized for granular installation and minimal token usage",
     "version": "1.7.1"
   },
   "plugins": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -947,6 +947,16 @@
       "category": "development"
     },
     {
+      "name": "dgx-spark-ops",
+      "description": "NVIDIA DGX Spark (GB10) environment operations. Use when setting up, preflighting, or debugging ML workloads on DGX Spark or aarch64 Blackwell hardware — CUDA-13 wheel/ABI checks, unified-memory OOM ladders, thermal monitoring.",
+      "version": "1.0.0",
+      "author": { "name": "Seth Hobson", "email": "seth@major7apps.com" },
+      "source": "./plugins/dgx-spark-ops",
+      "category": "ai-ml",
+      "homepage": "https://github.com/wshobson/agents",
+      "license": "MIT"
+    },
+    {
       "name": "reverse-engineering",
       "source": "./plugins/reverse-engineering",
       "description": "Binary reverse engineering, malware analysis, firmware security, and software protection research for authorized security research, CTF competitions, and defensive security",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -396,6 +396,17 @@
       "license": "MIT"
     },
     {
+      "name": "dgx-spark-ops",
+      "source": "./plugins/dgx-spark-ops",
+      "version": "1.0.0",
+      "description": "NVIDIA DGX Spark (GB10 Grace Blackwell) environment operations: aarch64/CUDA-13 stack setup, training gotcha preflights, and unified-memory/thermal management for local ML workloads",
+      "author": {
+        "name": "Seth Hobson",
+        "email": "seth@major7apps.com"
+      },
+      "license": "MIT"
+    },
+    {
       "name": "distributed-debugging",
       "source": "./plugins/distributed-debugging",
       "version": "1.2.1",
@@ -634,6 +645,17 @@
       "source": "./plugins/llm-application-dev",
       "version": "2.0.6",
       "description": "LLM application development with LangGraph, RAG systems, vector search, and AI agent architectures for Claude 4.6 and GPT-5.4",
+      "author": {
+        "name": "Seth Hobson",
+        "email": "seth@major7apps.com"
+      },
+      "license": "MIT"
+    },
+    {
+      "name": "llm-finetuning",
+      "source": "./plugins/llm-finetuning",
+      "version": "1.0.0",
+      "description": "Eval-gated LLM fine-tuning lifecycle: LoRA/QLoRA SFT, preference optimization (DPO/ORPO/KTO), GRPO/RLVR, vision SFT, and quantized export \u2014 Unsloth-first with TRL fallback, no eval harness means no fine-tune",
       "author": {
         "name": "Seth Hobson",
         "email": "seth@major7apps.com"

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/wshobson"
   },
   "metadata": {
-    "description": "Production-ready workflow orchestration with 91 marketplace plugins, 199 local specialized agents, and 162 local skills - optimized for granular installation and minimal token usage",
+    "description": "Production-ready workflow orchestration with 94 marketplace plugins, 203 local specialized agents, and 175 local skills - optimized for granular installation and minimal token usage",
     "version": "1.7.1"
   },
   "plugins": [

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-code-workflows",
   "displayName": "Claude Code Workflows",
   "version": "1.7.1",
-  "description": "Production-ready workflow orchestration with 91 marketplace plugins, 199 local specialized agents, and 162 local skills - optimized for granular installation and minimal token usage",
+  "description": "Production-ready workflow orchestration with 94 marketplace plugins, 203 local specialized agents, and 175 local skills - optimized for granular installation and minimal token usage",
   "author": {
     "name": "Seth Hobson",
     "email": "seth@major7apps.com"

--- a/.cursor-plugin/plugins/dgx-spark-ops.json
+++ b/.cursor-plugin/plugins/dgx-spark-ops.json
@@ -1,0 +1,11 @@
+{
+  "name": "dgx-spark-ops",
+  "displayName": "Dgx Spark Ops",
+  "version": "1.0.0",
+  "description": "NVIDIA DGX Spark (GB10 Grace Blackwell) environment operations: aarch64/CUDA-13 stack setup, training gotcha preflights, and unified-memory/thermal management for local ML workloads",
+  "author": {
+    "name": "Seth Hobson",
+    "email": "seth@major7apps.com"
+  },
+  "license": "MIT"
+}

--- a/.cursor-plugin/plugins/llm-finetuning.json
+++ b/.cursor-plugin/plugins/llm-finetuning.json
@@ -1,0 +1,11 @@
+{
+  "name": "llm-finetuning",
+  "displayName": "Llm Finetuning",
+  "version": "1.0.0",
+  "description": "Eval-gated LLM fine-tuning lifecycle: LoRA/QLoRA SFT, preference optimization (DPO/ORPO/KTO), GRPO/RLVR, vision SFT, and quantized export \u2014 Unsloth-first with TRL fallback, no eval harness means no fine-tune",
+  "author": {
+    "name": "Seth Hobson",
+    "email": "seth@major7apps.com"
+  },
+  "license": "MIT"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # claude-agents — multi-harness agentic plugin marketplace
 
-Production-ready agentic-workflow building blocks: **92 plugins** (88 local + 4 external), **199 agents**, **162 skills**, **106 commands**. Native source-of-truth for Claude Code; also consumed by OpenAI Codex CLI, Cursor, OpenCode, and Gemini CLI from a single Markdown source.
+Production-ready agentic-workflow building blocks: **94 plugins** (90 local + 4 external), **203 agents**, **175 skills**, **109 commands**. Native source-of-truth for Claude Code; also consumed by OpenAI Codex CLI, Cursor, OpenCode, and Gemini CLI from a single Markdown source.
 
 This file is the canonical context file. Codex / Cursor / OpenCode read it directly. Claude Code reads it via `CLAUDE.md`, a symlink to this file. Gemini CLI reads it via `gemini-extension.json` (`contextFileName`) / `.gemini/settings.json`.
 
@@ -10,8 +10,8 @@ This file is the canonical context file. Codex / Cursor / OpenCode read it direc
 
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — top-level architectural overview (adapter framework, source-of-truth invariant, capability matrix summary)
 - **[docs/architecture.md](docs/architecture.md)** — detailed design principles
-- **[docs/plugins.md](docs/plugins.md)** — full plugin catalog (92 plugins by category)
-- **[docs/agents.md](docs/agents.md)** — agent reference (199 agents, model tiers)
+- **[docs/plugins.md](docs/plugins.md)** — full plugin catalog (94 plugins by category)
+- **[docs/agents.md](docs/agents.md)** — agent reference (203 agents, model tiers)
 - **[docs/agent-skills.md](docs/agent-skills.md)** — skill reference (progressive disclosure model)
 - **[docs/usage.md](docs/usage.md)** — commands, workflows, examples
 - **[docs/authoring.md](docs/authoring.md)** — portable-content style guide (read before adding plugins)
@@ -52,7 +52,7 @@ Generated artifacts are **committed** so each harness installs natively from a c
 
 ## Skills (cross-harness)
 
-162 skills under `plugins/*/skills/<n>/SKILL.md` — discoverable by every harness:
+175 skills under `plugins/*/skills/<n>/SKILL.md` — discoverable by every harness:
 
 - **Claude Code**: auto-discovery via Anthropic's SKILL.md spec
 - **Codex CLI**: mirrored to `.codex/skills/<plugin>__<skill>/` (8 KB body cap; detail in `references/details.md`)
@@ -64,7 +64,7 @@ Top-level `skills/` is Gemini output; do not use it for OpenCode installs.
 
 ## Subagents (cross-harness)
 
-199 subagents under `plugins/*/agents/<name>.md`. Per-harness transpilation:
+203 subagents under `plugins/*/agents/<name>.md`. Per-harness transpilation:
 
 - **Codex**: `.codex/agents/<plugin>__<agent>.toml` (drop `tools:`, map model alias to the GPT-5.x family, infer `sandbox_mode`)
 - **OpenCode**: `.opencode/agents/<plugin>__<agent>.md` with `mode: subagent` + `permission:` block (locked agents — those with source `tools: []` — get deny-everything except base `skill`/`task`)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Agentic Plugin Marketplace
 
-> Production-ready agentic workflow building blocks: **92 plugins**, **199 agents**,
-> **162 skills**, **106 commands** — built for Claude Code and consumed natively by
+> Production-ready agentic workflow building blocks: **94 plugins**, **203 agents**,
+> **175 skills**, **109 commands** — built for Claude Code and consumed natively by
 > OpenAI Codex CLI, Cursor, OpenCode, Gemini CLI, and GitHub Copilot from a single Markdown source.
 
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-native-blueviolet)](#claude-code) [![Codex CLI](https://img.shields.io/badge/Codex%20CLI-supported-black)](docs/harnesses.md) [![Cursor](https://img.shields.io/badge/Cursor-supported-purple)](docs/harnesses.md) [![OpenCode](https://img.shields.io/badge/OpenCode-supported-green)](docs/harnesses.md) [![Gemini CLI](https://img.shields.io/badge/Gemini%20CLI-supported-blue)](GEMINI.md) [![Copilot](https://img.shields.io/badge/Copilot-supported-lightgrey)](docs/harnesses.md)
@@ -19,7 +19,7 @@ Pick your harness:
 
 ```bash
 /plugin marketplace add wshobson/agents
-/plugin install python-development          # or any of 92 plugins
+/plugin install python-development          # or any of 94 plugins
 ```
 
 [→ Full Claude Code setup, troubleshooting, and plugin catalog](docs/usage.md)
@@ -47,10 +47,10 @@ Setup details and per-harness gotchas: [docs/harnesses.md](docs/harnesses.md). G
 
 | | Count | What it is |
 |---|---:|---|
-| **Plugins** | 92 | Granular, single-purpose installable units (88 local + 4 external via git-subdir) |
-| **Agents** | 199 | Domain experts (architecture, languages, infra, security, data, ML, docs, business, SEO) |
-| **Skills** | 162 | Modular knowledge packages with progressive disclosure (load when activated) |
-| **Commands** | 106 | Slash commands: scaffolding, security scans, test gen, infrastructure setup |
+| **Plugins** | 94 | Granular, single-purpose installable units (90 local + 4 external via git-subdir) |
+| **Agents** | 203 | Domain experts (architecture, languages, infra, security, data, ML, docs, business, SEO) |
+| **Skills** | 175 | Modular knowledge packages with progressive disclosure (load when activated) |
+| **Commands** | 109 | Slash commands: scaffolding, security scans, test gen, infrastructure setup |
 | **Orchestrators** | 16 | Multi-agent coordination workflows (full-stack, security, ML, incident response) |
 
 Browse the catalog: [docs/plugins.md](docs/plugins.md) · [docs/agents.md](docs/agents.md) · [docs/agent-skills.md](docs/agent-skills.md)
@@ -125,9 +125,9 @@ uv run plugin-eval certify path/to/skill
 
 Detail lives in `docs/`. Read in this order:
 
-- **[docs/plugins.md](docs/plugins.md)** — full catalog of all 92 plugins
-- **[docs/agents.md](docs/agents.md)** — all 199 agents by category
-- **[docs/agent-skills.md](docs/agent-skills.md)** — 162 skills with progressive disclosure
+- **[docs/plugins.md](docs/plugins.md)** — full catalog of all 94 plugins
+- **[docs/agents.md](docs/agents.md)** — all 203 agents by category
+- **[docs/agent-skills.md](docs/agent-skills.md)** — 175 skills with progressive disclosure
 - **[docs/usage.md](docs/usage.md)** — commands, workflows, examples
 - **[docs/architecture.md](docs/architecture.md)** — design principles
 - **[docs/harnesses.md](docs/harnesses.md)** — cross-harness capability matrix

--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -1,6 +1,6 @@
 # Agent Skills
 
-Agent Skills are modular packages that extend Claude's capabilities with specialized domain knowledge, following Anthropic's [Agent Skills Specification](https://github.com/anthropics/skills/blob/main/agent_skills_spec.md). This plugin ecosystem includes **162 local specialized skills** across 46 plugins, enabling progressive disclosure and efficient token usage.
+Agent Skills are modular packages that extend Claude's capabilities with specialized domain knowledge, following Anthropic's [Agent Skills Specification](https://github.com/anthropics/skills/blob/main/agent_skills_spec.md). This plugin ecosystem includes **175 local specialized skills** across 48 plugins, enabling progressive disclosure and efficient token usage.
 
 ## Overview
 
@@ -392,7 +392,7 @@ fastapi-templates skill → Supplies production-ready templates
 
 ## Specification Compliance
 
-All 162 skills follow the [Agent Skills Specification](https://agentskills.io/specification):
+All 175 skills follow the [Agent Skills Specification](https://agentskills.io/specification):
 
 - ✓ Required `name` field (hyphen-case)
 - ✓ Required `description` field with "Use when" clause

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,6 +1,6 @@
 # Agent Reference
 
-Complete reference for all **199 local specialized AI agents** organized by category with model assignments.
+Complete reference for all **203 local specialized AI agents** organized by category with model assignments.
 
 ## Agent Categories
 
@@ -156,6 +156,10 @@ Complete reference for all **199 local specialized AI agents** organized by cate
 | [mlops-engineer](../plugins/machine-learning-ops/agents/mlops-engineer.md)                    | opus  | ML infrastructure, experiment tracking, model registries              |
 | [prompt-engineer](../plugins/llm-application-dev/agents/prompt-engineer.md)                   | opus  | LLM prompt optimization and engineering                               |
 | [vector-database-engineer](../plugins/llm-application-dev/agents/vector-database-engineer.md) | opus  | Vector databases, embeddings, similarity search, and hybrid retrieval |
+| [llm-finetuning-architect](../plugins/llm-finetuning/agents/llm-finetuning-architect.md)      | opus  | Fine-tuning strategy, method/model selection, eval-gate ownership     |
+| [llm-finetuning-training-engineer](../plugins/llm-finetuning/agents/llm-finetuning-training-engineer.md) | sonnet | Dataset prep, Unsloth training runs, artifact export         |
+| [llm-finetuning-eval-engineer](../plugins/llm-finetuning/agents/llm-finetuning-eval-engineer.md) | sonnet | Golden sets, judge calibration, checkpoint promotion verdicts     |
+| [dgx-spark-ops-engineer](../plugins/dgx-spark-ops/agents/dgx-spark-ops-engineer.md)           | sonnet | DGX Spark (GB10/aarch64/CUDA 13) environment setup and diagnostics   |
 
 ### Documentation & Technical Writing
 
@@ -231,8 +235,8 @@ Agents are assigned to specific Claude models based on task complexity and compu
 | Model   | Agent Count | Use Case                                                        |
 | ------- | ----------- | --------------------------------------------------------------- |
 | Fable   | 0           | Longest-horizon autonomous work (tier above Opus; see criteria) |
-| Opus    | 54          | Critical architecture, security, code review, production coding |
-| Sonnet  | 68          | Complex tasks, support with intelligence                        |
+| Opus    | 55          | Critical architecture, security, code review, production coding |
+| Sonnet  | 71          | Complex tasks, support with intelligence                        |
 | Haiku   | 25          | Fast operational tasks                                          |
 | Inherit | 52          | Complex tasks where the user chooses the model at runtime       |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,7 +36,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 
 ### Plugin Distribution
 
-- **92 marketplace plugins** (88 local + 4 external via git-subdir) optimized for specific use cases
+- **94 marketplace plugins** (90 local + 4 external via git-subdir) optimized for specific use cases
 - **26 clear categories** with 1-10 plugins each for easy discovery
 - Organized by domain:
   - **Development**: 6 plugins (debugging, backend, frontend, UI, multi-platform, essentials)
@@ -48,7 +48,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 
 ### Component Breakdown
 
-**199 Local Specialized Agents**
+**203 Local Specialized Agents**
 
 - Domain experts with deep knowledge
 - Organized across architecture, languages, infrastructure, quality, data/AI, documentation, business, and SEO
@@ -60,7 +60,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 - Complex operations like full-stack development, security hardening, ML pipelines, incident response
 - Pre-configured agent workflows
 
-**106 Local Commands**
+**109 Local Commands**
 
 - Optimized utilities including:
   - Project scaffolding (Python, TypeScript, Rust)
@@ -69,11 +69,11 @@ This marketplace follows industry best practices with a focus on granularity, co
   - Component scaffolding (React, React Native)
   - Infrastructure setup (Terraform, Kubernetes)
 
-**161 Local Agent Skills**
+**175 Local Agent Skills**
 
 - Modular knowledge packages
 - Progressive disclosure architecture
-- Domain-specific expertise across 45 plugins
+- Domain-specific expertise across 48 plugins
 - Spec-compliant (Anthropic Agent Skills Specification)
 
 ## Repository Structure
@@ -81,7 +81,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 ```
 claude-agents/
 ├── .claude-plugin/
-│   └── marketplace.json          # Marketplace catalog (92 plugins)
+│   └── marketplace.json          # Marketplace catalog (94 plugins)
 ├── plugins/                       # Isolated plugin directories
 │   ├── python-development/
 │   │   ├── agents/               # Python language agents
@@ -194,7 +194,7 @@ description: What the skill does. Use when [trigger]. # Required: < 1024 chars
 - **Composability**: Mix and match skills across workflows
 - **Maintainability**: Isolated updates don't affect other skills
 
-See [Agent Skills](./agent-skills.md) for complete details on the 162 skills.
+See [Agent Skills](./agent-skills.md) for complete details on the 175 skills.
 
 ## Model Configuration Strategy
 
@@ -205,8 +205,8 @@ The system uses Claude Fable, Opus, Sonnet, Haiku, and Inherit assignments strat
 | Model   | Count     | Use Case                                        |
 | ------- | --------- | ----------------------------------------------- |
 | Fable   | 0 agents  | Longest-horizon autonomous work (opt-in tier)   |
-| Opus    | 54 agents | Critical architecture, security, code review    |
-| Sonnet  | 68 agents | Complex tasks, support with intelligence        |
+| Opus    | 55 agents | Critical architecture, security, code review    |
+| Sonnet  | 71 agents | Complex tasks, support with intelligence        |
 | Haiku   | 25 agents | Fast operational tasks                          |
 | Inherit | 52 agents | Defers model choice to the user at runtime      |
 
@@ -263,7 +263,7 @@ code-reviewer (Sonnet) validates architecture
 ### Component Coverage
 
 - **100% agent coverage** - all plugins include at least one agent
-- **100% component availability** - all 199 local agents accessible across plugins
+- **100% component availability** - all 203 local agents accessible across plugins
 - **Efficient distribution** - 5.5 components per plugin average
 
 ### Discoverability
@@ -393,5 +393,5 @@ Feature Development Workflow:
 
 - [Agent Skills](./agent-skills.md) - Modular knowledge packages
 - [Agent Reference](./agents.md) - Complete agent catalog
-- [Plugin Reference](./plugins.md) - All 92 marketplace plugins
+- [Plugin Reference](./plugins.md) - All 94 marketplace plugins
 - [Usage Guide](./usage.md) - Commands and workflows

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,6 +1,6 @@
 # Complete Plugin Reference
 
-Browse all **92 marketplace plugins** organized by category: 88 local plugins plus 4 externally hosted `git-subdir` entries (`pensyve`, `qa-orchestra`, `storymap-skill`, `ciagent`).
+Browse all **94 marketplace plugins** organized by category: 90 local plugins plus 4 externally hosted `git-subdir` entries (`pensyve`, `qa-orchestra`, `storymap-skill`, `ciagent`).
 
 ## Quick Start - Essential Plugins
 
@@ -168,7 +168,7 @@ Next.js, React + Vite, and Node.js project setup with pnpm and TypeScript best p
 | **file-conversion**       | Convert files across 1,000+ format pairs   | `/plugin install file-conversion`       |
 | **team-collaboration**    | Team workflows and standup automation      | `/plugin install team-collaboration`    |
 
-### 🤖 AI & ML (5 plugins)
+### 🤖 AI & ML (7 plugins)
 
 | Plugin                   | Description                         | Install                                |
 | ------------------------ | ----------------------------------- | -------------------------------------- |
@@ -177,6 +177,8 @@ Next.js, React + Vite, and Node.js project setup with pnpm and TypeScript best p
 | **context-management**   | Context persistence and restoration | `/plugin install context-management`   |
 | **machine-learning-ops** | ML training pipelines and MLOps     | `/plugin install machine-learning-ops` |
 | **runapi-mcp**           | Media generation MCP (image, video, music, audio, LLM) across 130+ models | `/plugin install runapi-mcp`           |
+| **llm-finetuning**       | Eval-gated LLM fine-tuning lifecycle: dataset prep, LoRA/QLoRA training, and promotion gating | `/plugin install llm-finetuning`       |
+| **dgx-spark-ops**        | DGX Spark cluster setup, job scheduling, and operations monitoring | `/plugin install dgx-spark-ops`        |
 
 ### 🧠 Memory (1 external plugin)
 
@@ -363,7 +365,7 @@ plugins/python-development/
 /plugin marketplace add wshobson/agents
 ```
 
-This makes all 92 marketplace plugins available for installation, but **does not load any agents or tools** into your context.
+This makes all 94 marketplace plugins available for installation, but **does not load any agents or tools** into your context.
 
 ### Step 2: Install Specific Plugins
 
@@ -406,7 +408,7 @@ Each installed plugin loads **only its specific agents and commands** into Claud
 
 ## See Also
 
-- [Agent Skills](./agent-skills.md) - 158 specialized skills across plugins
+- [Agent Skills](./agent-skills.md) - 175 specialized skills across plugins
 - [Agent Reference](./agents.md) - Complete agent catalog
 - [Usage Guide](./usage.md) - Commands and workflows
 - [Architecture](./architecture.md) - Design principles

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -385,11 +385,11 @@ User: "Implement Kubernetes deployment with Helm"
 → Result: Production-grade K8s manifests with Helm charts
 ```
 
-See [Agent Skills](./agent-skills.md) for details on the 158 specialized skills.
+See [Agent Skills](./agent-skills.md) for details on the 175 specialized skills.
 
 ## See Also
 
 - [Agent Skills](./agent-skills.md) - Specialized knowledge packages
 - [Agent Reference](./agents.md) - Complete agent catalog
-- [Plugin Reference](./plugins.md) - All 92 marketplace plugins
+- [Plugin Reference](./plugins.md) - All 94 marketplace plugins
 - [Architecture](./architecture.md) - Design principles

--- a/plugins/dgx-spark-ops/.claude-plugin/plugin.json
+++ b/plugins/dgx-spark-ops/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "dgx-spark-ops",
+  "version": "1.0.0",
+  "description": "NVIDIA DGX Spark (GB10 Grace Blackwell) environment operations: aarch64/CUDA-13 stack setup, training gotcha preflights, and unified-memory/thermal management for local ML workloads",
+  "author": {
+    "name": "Seth Hobson",
+    "email": "seth@major7apps.com"
+  },
+  "license": "MIT"
+}

--- a/plugins/dgx-spark-ops/.codex-plugin/plugin.json
+++ b/plugins/dgx-spark-ops/.codex-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "dgx-spark-ops",
+  "version": "1.0.0",
+  "description": "NVIDIA DGX Spark (GB10 Grace Blackwell) environment operations: aarch64/CUDA-13 stack setup, training gotcha preflights, and unified-memory/thermal management for local ML workloads",
+  "skills": "./skills/",
+  "author": {
+    "name": "Seth Hobson",
+    "email": "seth@major7apps.com"
+  },
+  "license": "MIT",
+  "interface": {
+    "displayName": "Dgx Spark Ops",
+    "shortDescription": "NVIDIA DGX Spark (GB10 Grace Blackwell) environment operations: aarch64/CUDA-13 stack setup, training gotcha\u2026",
+    "category": "Coding"
+  }
+}

--- a/plugins/dgx-spark-ops/agents/dgx-spark-ops-engineer.md
+++ b/plugins/dgx-spark-ops/agents/dgx-spark-ops-engineer.md
@@ -5,9 +5,9 @@ model: sonnet
 ---
 
 You are the DGX Spark ops engineer: an environment doctor for GB10
-(Grace Blackwell, SM121, 128GB unified memory, aarch64, CUDA 13)
-hardware. You diagnose before you prescribe — every verdict you give
-is backed by a specific check, never a guess.
+(Grace Blackwell, aarch64, CUDA 13) hardware. You diagnose before
+you prescribe — every verdict you give is backed by a specific
+check, never a guess.
 
 ## Purpose
 
@@ -25,8 +25,8 @@ facts themselves rather than restating them from memory.
   container vs. bare-pip posture, and per-component status against
   the component matrix in `spark-environment-setup`.
 - **ABI triage**: recognize the CUDA 12/13 wheel-ABI symptom pattern
-  (undefined symbol, first-`.cuda()` segfault, silent CPU fallback)
-  and trace it to a root cause rather than a guess.
+  per the ABI Rule in `spark-environment-setup` and trace it to a
+  root cause rather than a guess.
 - **Gotcha preflight**: run and interpret the G1–G10 checks defined
   in `spark-training-gotchas`, including the automated subset in its
   `assets/preflight.sh`.
@@ -61,8 +61,9 @@ earlier step already explains the symptom.
    (weights + optimizer + gradients + activations, plus the model-load
    transient peak) and compare it against `free -g` headroom, not
    `nvidia-smi`. Flag any plan that lands within a thin margin of the
-   budget, and note the closest sizing anchor (70B QLoRA, 27B LoRA,
-   9B full FT) rather than trusting the raw estimate alone.
+   budget, and note the closest sizing anchor per the Anchors table
+   in `spark-memory-thermal-ops`'s worksheets rather than trusting
+   the raw estimate alone.
 
 4. **Emit `env-report.json`.** Write the report to the working
    directory using the full check vocabulary — `pass`, `fail`,
@@ -97,8 +98,9 @@ earlier step already explains the symptom.
   package mutations, consistent with the container-first rule.
 - Treats `nvidia-smi` headroom numbers as untrustworthy for unified
   memory; always cross-checks against `free -g` before sizing a run.
-- Distinguishes thermal throttling (sustained ~100W plateau) from a
-  real configuration bug before recommending any tuning change.
+- Distinguishes thermal throttling — a sustained power plateau at
+  the G4 threshold (see `spark-training-gotchas`) — from a real
+  configuration bug before recommending any tuning change.
 - States the verdict plainly (`ready` / `ready-with-warnings` /
   `blocked`) and lets the caller decide whether to proceed — does not
   silently downgrade a workload's plan on its own authority.

--- a/plugins/dgx-spark-ops/agents/dgx-spark-ops-engineer.md
+++ b/plugins/dgx-spark-ops/agents/dgx-spark-ops-engineer.md
@@ -66,10 +66,14 @@ earlier step already explains the symptom.
    the raw estimate alone.
 
 4. **Emit `env-report.json`.** Write the report to the working
-   directory using the full check vocabulary — `pass`, `fail`,
-   `warn: <detail>`, `skip: <reason>`, or `info: <reading>` per
-   G-number — matching `preflight.sh`'s own PASS/FAIL/WARN/SKIP/INFO
-   output contract:
+   directory by default — this skill has no `runs/` concept of its
+   own — unless the invocation names a different path (a caller such
+   as `/finetune` that owns a `runs/<date>-<slug>/` directory
+   supersedes this default and names the path explicitly; follow that
+   instruction instead of the working directory). Use the full check
+   vocabulary — `pass`, `fail`, `warn: <detail>`, `skip: <reason>`, or
+   `info: <reading>` per G-number — matching `preflight.sh`'s own
+   PASS/FAIL/WARN/SKIP/INFO output contract:
 
    ```json
    {

--- a/plugins/dgx-spark-ops/agents/dgx-spark-ops-engineer.md
+++ b/plugins/dgx-spark-ops/agents/dgx-spark-ops-engineer.md
@@ -1,0 +1,104 @@
+---
+name: dgx-spark-ops-engineer
+description: NVIDIA DGX Spark environment doctor for GB10/aarch64/CUDA-13 systems. Diagnoses and fixes ML stack setup, unified-memory, and thermal issues. Use PROACTIVELY when preparing or debugging any training or inference workload on DGX Spark hardware.
+model: sonnet
+---
+
+You are the DGX Spark ops engineer: an environment doctor for GB10
+(Grace Blackwell, SM121, 128GB unified memory, aarch64, CUDA 13)
+hardware. You diagnose before you prescribe — every verdict you give
+is backed by a specific check, never a guess.
+
+## Purpose
+
+Verify that a DGX Spark box is actually ready for a training or
+inference workload, not just plausibly ready. You sit between "the
+user wants to run something" and "the run actually starts cleanly" —
+catching ABI mismatches, memory headroom shortfalls, and thermal
+risk before they cost hours of wasted compute. You own diagnosis and
+remediation guidance; you defer to the three Spark skills for the
+facts themselves rather than restating them from memory.
+
+## Capabilities
+
+- **Stack verification**: confirm the installed PyTorch/CUDA build,
+  container vs. bare-pip posture, and per-component status against
+  the component matrix in `spark-environment-setup`.
+- **ABI triage**: recognize the CUDA 12/13 wheel-ABI symptom pattern
+  (undefined symbol, first-`.cuda()` segfault, silent CPU fallback)
+  and trace it to a root cause rather than a guess.
+- **Gotcha preflight**: run and interpret the G1–G10 checks defined
+  in `spark-training-gotchas`, including the automated subset in its
+  `assets/preflight.sh`.
+- **UMA memory-headroom math**: size a planned workload against
+  `free -g` headroom and the worksheets in `spark-memory-thermal-ops`,
+  not against `nvidia-smi`'s undercount.
+- **Thermal baselining**: read a temperature/power sample and judge
+  whether a plateau is the platform's sustained power cap or an
+  actual throttling risk for the planned run length.
+- **Container workflow guidance**: steer fixes toward the NGC or
+  Unsloth container images before recommending host-level mutations.
+
+## Method
+
+Work this preflight procedure in order; do not skip ahead when an
+earlier step already explains the symptom.
+
+1. **Hardware identity.** Confirm you're actually on GB10 hardware
+   before diagnosing anything else: `nvidia-smi`, `uname -m` (expect
+   `aarch64`), and the CUDA device capability (expect `(12, 1)`).
+   A mismatch here invalidates every downstream check.
+
+2. **Run the gotcha checks.** Execute `spark-training-gotchas`'
+   `assets/preflight.sh` (covers G1, G3, G4, G7, G9 automatically),
+   and evaluate the remaining gotchas (G2, G5, G6, G8, G10) against
+   the planned workload using that skill's reference material. Every
+   finding must cite its G-number — never describe a Spark-specific
+   failure without naming the gotcha it maps to.
+
+3. **Memory headroom.** Using `spark-memory-thermal-ops`' UMA
+   accounting worksheet, estimate the planned workload's footprint
+   (weights + optimizer + gradients + activations, plus the model-load
+   transient peak) and compare it against `free -g` headroom, not
+   `nvidia-smi`. Flag any plan that lands within a thin margin of the
+   budget, and note the closest sizing anchor (70B QLoRA, 27B LoRA,
+   9B full FT) rather than trusting the raw estimate alone.
+
+4. **Emit `env-report.json`.** Write the report to the working
+   directory using the full check vocabulary — `pass`, `fail`,
+   `warn: <detail>`, `skip: <reason>`, or `info: <reading>` per
+   G-number — matching `preflight.sh`'s own PASS/FAIL/WARN/SKIP/INFO
+   output contract:
+
+   ```json
+   {
+     "platform": "dgx-spark",
+     "checks": {
+       "G1": "pass",
+       "G3": "warn: 14GB page cache",
+       "G9": "info: running inside nvcr.io/nvidia/pytorch:25.11-py3"
+     },
+     "headroom_gb": 61,
+     "verdict": "ready"
+   }
+   ```
+
+   Set `verdict` to `blocked` if any check is `fail` or headroom is
+   insufficient for the planned workload, `ready-with-warnings` if
+   only `warn`/`skip` entries remain, and `ready` otherwise.
+
+## Behavioral Traits
+
+- Never retries a failed install blind — diagnoses the ABI or
+  container-posture cause first, per `spark-environment-setup`.
+- Names the gotcha (G-number) in every diagnosis; a Spark-specific
+  failure without a G-number citation is treated as incomplete.
+- Prefers container fixes (NGC or Unsloth images) over host-level
+  package mutations, consistent with the container-first rule.
+- Treats `nvidia-smi` headroom numbers as untrustworthy for unified
+  memory; always cross-checks against `free -g` before sizing a run.
+- Distinguishes thermal throttling (sustained ~100W plateau) from a
+  real configuration bug before recommending any tuning change.
+- States the verdict plainly (`ready` / `ready-with-warnings` /
+  `blocked`) and lets the caller decide whether to proceed — does not
+  silently downgrade a workload's plan on its own authority.

--- a/plugins/dgx-spark-ops/commands/spark-preflight.md
+++ b/plugins/dgx-spark-ops/commands/spark-preflight.md
@@ -1,0 +1,20 @@
+---
+description: Preflight a DGX Spark system for an ML training or inference workload and emit env-report.json
+argument-hint: "[planned workload, e.g. 'QLoRA 8B, 3 epochs, 8k context']"
+---
+
+# DGX Spark Preflight
+
+Verify this DGX Spark system is ready for: $ARGUMENTS
+
+<Task>
+subagent_type: dgx-spark-ops-engineer
+prompt: |
+  Run a full preflight for the planned workload: $ARGUMENTS
+  1. Confirm hardware identity (GB10/aarch64/CUDA 13) and stack per the spark-environment-setup skill.
+  2. Execute checks G1–G10 from the spark-training-gotchas skill; record each check's result using the check vocabulary (pass/fail/warn/skip/info).
+  3. Compute memory headroom for the workload with the spark-memory-thermal-ops worksheets.
+  4. Write env-report.json to the current directory (schema in agent instructions) and summarize verdict: ready | ready-with-warnings | blocked, with the blocking gotcha named.
+</Task>
+
+Report the verdict and any warnings to the user. If blocked, present the specific fix from the gotcha's FIX entry before suggesting anything else.

--- a/plugins/dgx-spark-ops/skills/spark-environment-setup/SKILL.md
+++ b/plugins/dgx-spark-ops/skills/spark-environment-setup/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: spark-environment-setup
+description: Set up a working ML training/inference environment on NVIDIA DGX Spark (GB10, aarch64, CUDA 13). Use when installing PyTorch/Unsloth/TRL/vLLM on DGX Spark, hitting libcudart or wheel-ABI errors on aarch64, or choosing between NGC containers and bare pip installs.
+---
+
+# Spark Environment Setup
+
+DGX Spark ships a GB10 Grace Blackwell chip: aarch64 CPU, SM121 GPU, 128GB
+unified memory, CUDA 13. This is a narrower and younger platform than a
+standard x86 CUDA 12 box, so package selection and ABI matching matter more
+than usual — the wheel ecosystem for aarch64 + CUDA 13 is still
+filling in, and the fixes below are the ones that keep coming up
+in practice.
+
+## When to Use This Skill
+
+- Setting up a fresh Spark box for training or inference for the first time.
+- Hitting an import error mentioning `libcudart`, a missing symbol, or a
+  wheel that "installed fine but won't load."
+- A framework install (PyTorch, Unsloth, TRL, vLLM, xformers) fails, hangs,
+  or silently falls back to CPU.
+- Deciding whether to use an NGC container or a bare pip environment for a
+  given run.
+- Restoring a working setup after an OS reinstall or a base-image update,
+  and needing to re-verify the stack from scratch.
+
+Each of these accepts the same general fix: match the container/wheel
+combination to CUDA 13 and SM121, don't fight the ABI. The rest of this
+skill walks through how, section by section, starting with the
+container-vs-pip decision below.
+
+## Container-First Rule
+
+Quick decision, before the detail below:
+
+- Standard training/inference work → NGC PyTorch container.
+- Unsloth-centric fine-tuning → Unsloth container.
+- Neither fits (custom system package, local IDE interpreter) → bare pip,
+  following the exact sequence further down.
+
+Default to a container. Use `nvcr.io/nvidia/pytorch:25.11-py3` as the base
+for general work, or `unsloth/unsloth:dgxspark-latest` for Unsloth-centric
+fine-tuning. Treat bare pip as the exception, reached for only when a
+container genuinely can't fit the workflow — a custom system package, an
+IDE that expects a local interpreter, and so on.
+
+Minimal invocations for each look like this (full flag rationale and
+volume mounts for `finetuning/` run dirs: `references/container-workflow.md`):
+
+```bash
+docker run --runtime=nvidia --gpus all -it --rm \
+  nvcr.io/nvidia/pytorch:25.11-py3
+```
+
+```bash
+docker run --runtime=nvidia --gpus all -it --rm \
+  unsloth/unsloth:dgxspark-latest
+```
+
+Pick the NGC image for general training/inference work, and the Unsloth
+image specifically when the run is Unsloth-centric — it ships the pinned
+Triton/xformers/transformers combination already validated for that path,
+so there's nothing extra to configure.
+
+The reason for the container-first stance is pinning, not convenience.
+Triton, xformers, and transformers versions interact narrowly with GB10's
+SM121 target and the CUDA 13 toolchain; a container locks all of them
+together against a combination that's already been validated on this
+hardware. A bare pip environment leaves that resolution to you, one broken
+import at a time.
+
+When bare pip is warranted, follow the NVIDIA playbook's install sequence
+verbatim and in order:
+
+```bash
+pip install transformers peft hf_transfer "datasets==4.3.0" "trl==0.26.1"
+pip install --no-deps unsloth unsloth_zoo bitsandbytes
+```
+
+The second command's `--no-deps` flag is not optional — letting pip
+re-resolve Unsloth's dependency tree on aarch64 is a common way to pull in
+an incompatible torch or triton build.
+
+Pull a fresh image tag when a new blessed release is announced. Rebuild
+locally from one of the two bases only when a project needs an extra
+system package layered in — not to "upgrade" a component the image
+already pins. Details on both paths: `references/container-workflow.md`.
+
+## The ABI Rule
+
+The single most common failure on Spark is a CUDA 12/13 ABI mismatch: a
+wheel built against `libcudart.so.12` loaded on a system that only has
+`libcudart.so.13`. The import usually succeeds; the failure surfaces later
+as a missing-symbol error or a segfault that doesn't obviously point at
+CUDA.
+
+Fix: pull wheels from `download.pytorch.org/whl/cu130` (the cu130-tagged
+aarch64 builds), or use one of the containers above, which already carry a
+matched build. Before chasing a stack trace that mentions a CUDA symbol,
+check which CUDA tag the installed wheel was built against:
+
+```bash
+pip show torch | grep -i version
+```
+
+If that output doesn't say `cu130` (or a container-supplied equivalent),
+the ABI mismatch is the first thing to fix, not the last.
+
+Typical symptoms of this mismatch, so it's recognizable next time:
+
+- `ImportError: undefined symbol` referencing a CUDA runtime function.
+- A segfault on the very first `.cuda()` call, with no Python traceback
+  pointing anywhere useful.
+- A wheel that installs cleanly with no warnings, then fails at import
+  time — pip's dependency resolver doesn't check CUDA ABI compatibility,
+  only package version constraints.
+- Inconsistent behavior between two otherwise-identical environments —
+  usually one has a cu130 wheel and the other a cu121/cu124 leftover from
+  an earlier install.
+
+The fix is the same regardless of which symptom shows up: match the
+wheel's CUDA tag to the system, or use a container that already does.
+
+## Component Quick Table
+
+Condensed status for the components most likely to come up. Full table
+with wheel URLs, build flags, and the sm_121 vs sm_121a distinction: see
+`references/stack-matrix.md`.
+
+| Component | Status |
+|---|---|
+| PyTorch | ✅ official cu130 aarch64 wheels |
+| bitsandbytes | ✅ works out of the box |
+| Triton | ✅ needs the `TRITON_PTXAS_PATH` parameter set |
+| flash-attn | ❌ skip — no sm_121 kernels; use PyTorch SDPA instead |
+| xformers | source build only (`TORCH_CUDA_ARCH_LIST=12.1`) |
+| vLLM | nightly wheels only |
+| TransformerEngine / NVFP4 train | container-only |
+
+Everything not in this table — Unsloth itself, Axolotl, TRL, PEFT —
+installs cleanly through the container-first path above. Only the
+components listed here need special handling, which is why they're
+called out separately instead of buried in a general dependency list.
+
+## Verification Commands
+
+Confirm the environment can actually see the GPU before running anything
+expensive:
+
+```python
+import torch
+print(torch.cuda.is_available(), torch.version.cuda)
+```
+
+This call returns two values and produces output in this exact format
+(`<bool> <cuda-version>`):
+
+```text
+True 13.0
+```
+
+If it prints `False` instead, don't assume the GPU is absent — Spark has
+known GPU-detection false negatives on bare pip installs (a
+torchcodec/driver interaction is the usual culprit). Check with the driver
+directly before spending time debugging the Python side:
+
+```bash
+nvidia-smi
+```
+
+If `nvidia-smi` shows the GPU but PyTorch still reports `False`, the
+problem is almost certainly the ABI mismatch above, not a missing driver.
+
+Run this same check right after the container starts, before installing
+any project-specific packages on top of it. That way, a failure clearly
+points at the base image rather than something layered in afterward —
+the two failure modes need different fixes, and conflating them wastes
+time.
+
+## Fast Path Recap
+
+For a repeat setup, skip straight to the order of operations:
+
+1. Pull the right container (Container-First Rule).
+2. Run it with `--runtime=nvidia --gpus all`, matching the commands above.
+3. Run the verification commands before installing anything
+   project-specific.
+4. If verification fails, check the ABI Rule first.
+5. Consult the Component Quick Table before assuming a broken framework
+   install is unique to this project.
+6. Escalate to the two companion skills linked below once the environment
+   itself is confirmed healthy.
+
+## Next Steps
+
+A verified environment is only the starting point — long training runs
+surface a different class of problem once the stack itself is working.
+
+See also: `spark-training-gotchas` for failure preflights before a
+training run, and `spark-memory-thermal-ops` for unified-memory OOMs and
+thermal throttling during long ones.

--- a/plugins/dgx-spark-ops/skills/spark-environment-setup/SKILL.md
+++ b/plugins/dgx-spark-ops/skills/spark-environment-setup/SKILL.md
@@ -105,11 +105,15 @@ stack trace that mentions a CUDA symbol, check which CUDA tag
 the installed wheel was built against:
 
 ```bash
-pip show torch | grep -i version
+python3 -c "import torch; print(torch.version.cuda)"
 ```
 
-If that output doesn't say `cu130` (or a container-supplied
-equivalent), the ABI mismatch is the first thing to fix.
+If that output doesn't start with `13`, the ABI mismatch is the
+first thing to fix. Note that NGC container builds (e.g.
+`nvcr.io/nvidia/pytorch:25.11-py3`) build torch internally
+against CUDA 13 with no `+cu130` wheel tag — `pip show torch`
+won't say `cu130` on those containers, and that absence alone is
+not a failure.
 
 Typical symptoms, so the pattern is recognizable next time:
 

--- a/plugins/dgx-spark-ops/skills/spark-environment-setup/SKILL.md
+++ b/plugins/dgx-spark-ops/skills/spark-environment-setup/SKILL.md
@@ -5,47 +5,48 @@ description: Set up a working ML training/inference environment on NVIDIA DGX Sp
 
 # Spark Environment Setup
 
-DGX Spark ships a GB10 Grace Blackwell chip: aarch64 CPU, SM121 GPU, 128GB
-unified memory, CUDA 13. This is a narrower and younger platform than a
-standard x86 CUDA 12 box, so package selection and ABI matching matter more
-than usual — the wheel ecosystem for aarch64 + CUDA 13 is still
-filling in, and the fixes below are the ones that keep coming up
-in practice.
+DGX Spark ships a GB10 Grace Blackwell chip: aarch64 CPU, SM121
+GPU, 128GB unified memory, CUDA 13. This is a narrower and
+younger platform than a standard x86 CUDA 12 box, so package
+selection and ABI matching matter more than usual — the wheel
+ecosystem for aarch64 + CUDA 13 is still filling in.
 
 ## When to Use This Skill
 
-- Setting up a fresh Spark box for training or inference for the first time.
-- Hitting an import error mentioning `libcudart`, a missing symbol, or a
-  wheel that "installed fine but won't load."
-- A framework install (PyTorch, Unsloth, TRL, vLLM, xformers) fails, hangs,
-  or silently falls back to CPU.
-- Deciding whether to use an NGC container or a bare pip environment for a
-  given run.
-- Restoring a working setup after an OS reinstall or a base-image update,
-  and needing to re-verify the stack from scratch.
+- Setting up a fresh Spark box for training or inference for
+  the first time.
+- Hitting an import error mentioning `libcudart`, a missing
+  symbol, or a wheel that "installed fine but won't load."
+- A framework install (PyTorch, Unsloth, TRL, vLLM, xformers)
+  fails, hangs, or silently falls back to CPU.
+- Deciding whether to use an NGC container or a bare pip
+  environment for a given run.
+- Restoring a working setup after an OS reinstall or a
+  base-image update, and needing to re-verify from scratch.
 
-Each of these accepts the same general fix: match the container/wheel
-combination to CUDA 13 and SM121, don't fight the ABI. The rest of this
-skill walks through how, section by section, starting with the
-container-vs-pip decision below.
+Each of these accepts the same general fix: match the
+container/wheel combination to CUDA 13 and SM121, don't fight
+the ABI. The sections below walk through how, starting with
+the container-vs-pip decision.
 
 ## Container-First Rule
 
 Quick decision, before the detail below:
 
 - Standard training/inference work → NGC PyTorch container.
-- Unsloth-centric fine-tuning → Unsloth container.
-- Neither fits (custom system package, local IDE interpreter) → bare pip,
-  following the exact sequence further down.
+- Unsloth-centric fine-tuning → Unsloth container (it ships
+  the pinned Triton/xformers/transformers combination already
+  validated for that path).
+- Neither fits (custom system package, local IDE interpreter)
+  → bare pip, following the exact sequence further down.
 
-Default to a container. Use `nvcr.io/nvidia/pytorch:25.11-py3` as the base
-for general work, or `unsloth/unsloth:dgxspark-latest` for Unsloth-centric
-fine-tuning. Treat bare pip as the exception, reached for only when a
-container genuinely can't fit the workflow — a custom system package, an
-IDE that expects a local interpreter, and so on.
+Default to a container. Use `nvcr.io/nvidia/pytorch:25.11-py3`
+as the base for general work, or
+`unsloth/unsloth:dgxspark-latest` for Unsloth-centric
+fine-tuning. Treat bare pip as the exception.
 
-Minimal invocations for each look like this (full flag rationale and
-volume mounts for `finetuning/` run dirs: `references/container-workflow.md`):
+Minimal invocations (full flag rationale and volume mounts for
+`finetuning/` run dirs: `references/container-workflow.md`):
 
 ```bash
 docker run --runtime=nvidia --gpus all -it --rm \
@@ -57,75 +58,80 @@ docker run --runtime=nvidia --gpus all -it --rm \
   unsloth/unsloth:dgxspark-latest
 ```
 
-Pick the NGC image for general training/inference work, and the Unsloth
-image specifically when the run is Unsloth-centric — it ships the pinned
-Triton/xformers/transformers combination already validated for that path,
-so there's nothing extra to configure.
+The reason for the container-first stance is pinning, not
+convenience. Triton, xformers, and transformers versions
+interact narrowly with GB10's SM121 target and the CUDA 13
+toolchain; a container locks all of them together against a
+combination already validated on this hardware. A bare pip
+environment leaves that resolution to you, one broken import
+at a time.
 
-The reason for the container-first stance is pinning, not convenience.
-Triton, xformers, and transformers versions interact narrowly with GB10's
-SM121 target and the CUDA 13 toolchain; a container locks all of them
-together against a combination that's already been validated on this
-hardware. A bare pip environment leaves that resolution to you, one broken
-import at a time.
-
-When bare pip is warranted, follow the NVIDIA playbook's install sequence
-verbatim and in order:
+When bare pip is warranted, follow the NVIDIA playbook's
+install sequence verbatim and in order:
 
 ```bash
 pip install transformers peft hf_transfer "datasets==4.3.0" "trl==0.26.1"
 pip install --no-deps unsloth unsloth_zoo bitsandbytes
 ```
 
-The second command's `--no-deps` flag is not optional — letting pip
-re-resolve Unsloth's dependency tree on aarch64 is a common way to pull in
-an incompatible torch or triton build.
+The second command's `--no-deps` flag is not optional —
+letting pip re-resolve Unsloth's dependency tree on aarch64 is
+a common way to pull in an incompatible torch or triton build.
 
-Pull a fresh image tag when a new blessed release is announced. Rebuild
-locally from one of the two bases only when a project needs an extra
-system package layered in — not to "upgrade" a component the image
-already pins. Details on both paths: `references/container-workflow.md`.
+Pull a fresh image tag when a new blessed release is
+announced. Rebuild locally from one of the two bases only when
+a project needs an extra system package layered in — not to
+"upgrade" a component the image already pins. Details on both
+paths: `references/container-workflow.md`.
+
+One more preflight: official DGX Spark playbooks have shipped
+broken before. Check recent issues on
+`github.com/NVIDIA/dgx-spark-playbooks` (and the other
+canonical resources listed in `references/stack-matrix.md`)
+before trusting a recipe verbatim for a long run.
 
 ## The ABI Rule
 
-The single most common failure on Spark is a CUDA 12/13 ABI mismatch: a
-wheel built against `libcudart.so.12` loaded on a system that only has
-`libcudart.so.13`. The import usually succeeds; the failure surfaces later
-as a missing-symbol error or a segfault that doesn't obviously point at
-CUDA.
+The single most common failure on Spark is a CUDA 12/13 ABI
+mismatch: a wheel built against `libcudart.so.12` loaded on a
+system that only has `libcudart.so.13`. The install usually
+succeeds; the failure surfaces later as a missing-symbol error
+or a segfault that doesn't obviously point at CUDA.
 
-Fix: pull wheels from `download.pytorch.org/whl/cu130` (the cu130-tagged
-aarch64 builds), or use one of the containers above, which already carry a
-matched build. Before chasing a stack trace that mentions a CUDA symbol,
-check which CUDA tag the installed wheel was built against:
+Fix: pull wheels from `download.pytorch.org/whl/cu130` (the
+cu130-tagged aarch64 builds), or use one of the containers
+above, which already carry a matched build. Before chasing a
+stack trace that mentions a CUDA symbol, check which CUDA tag
+the installed wheel was built against:
 
 ```bash
 pip show torch | grep -i version
 ```
 
-If that output doesn't say `cu130` (or a container-supplied equivalent),
-the ABI mismatch is the first thing to fix, not the last.
+If that output doesn't say `cu130` (or a container-supplied
+equivalent), the ABI mismatch is the first thing to fix.
 
-Typical symptoms of this mismatch, so it's recognizable next time:
+Typical symptoms, so the pattern is recognizable next time:
 
-- `ImportError: undefined symbol` referencing a CUDA runtime function.
-- A segfault on the very first `.cuda()` call, with no Python traceback
-  pointing anywhere useful.
-- A wheel that installs cleanly with no warnings, then fails at import
-  time — pip's dependency resolver doesn't check CUDA ABI compatibility,
-  only package version constraints.
-- Inconsistent behavior between two otherwise-identical environments —
-  usually one has a cu130 wheel and the other a cu121/cu124 leftover from
-  an earlier install.
+- `ImportError: undefined symbol` referencing a CUDA runtime
+  function.
+- A segfault on the very first `.cuda()` call, with no useful
+  Python traceback.
+- A wheel that installs cleanly, then fails at import time —
+  pip's resolver doesn't check CUDA ABI compatibility, only
+  package version constraints.
+- Two "identical" environments behaving differently — usually
+  one has a cu130 wheel and the other a cu121/cu124 leftover
+  from an earlier install.
 
-The fix is the same regardless of which symptom shows up: match the
-wheel's CUDA tag to the system, or use a container that already does.
+The fix is the same regardless of symptom: match the wheel's
+CUDA tag to the system, or use a container that already does.
 
 ## Component Quick Table
 
-Condensed status for the components most likely to come up. Full table
-with wheel URLs, build flags, and the sm_121 vs sm_121a distinction: see
-`references/stack-matrix.md`.
+Condensed status for the components most likely to come up.
+Full table with wheel URLs, build flags, and the sm_121 vs
+sm_121a distinction: see `references/stack-matrix.md`.
 
 | Component | Status |
 |---|---|
@@ -137,65 +143,59 @@ with wheel URLs, build flags, and the sm_121 vs sm_121a distinction: see
 | vLLM | nightly wheels only |
 | TransformerEngine / NVFP4 train | container-only |
 
-Everything not in this table — Unsloth itself, Axolotl, TRL, PEFT —
-installs cleanly through the container-first path above. Only the
-components listed here need special handling, which is why they're
-called out separately instead of buried in a general dependency list.
+Everything else — Unsloth itself, Axolotl, TRL, PEFT —
+installs cleanly through the container-first path above.
+LLaMA-Factory and NeMo are the exceptions: fragile on Spark as
+of this writing, so check upstream issues before depending on
+either (details in `references/stack-matrix.md`).
 
 ## Verification Commands
 
-Confirm the environment can actually see the GPU before running anything
-expensive:
+Confirm the environment can actually see the GPU before
+running anything expensive:
 
 ```python
 import torch
 print(torch.cuda.is_available(), torch.version.cuda)
 ```
 
-This call returns two values and produces output in this exact format
-(`<bool> <cuda-version>`):
+This call returns two values; the exact output format is one
+line, `<bool> <cuda-version>`:
 
 ```text
 True 13.0
 ```
 
-If it prints `False` instead, don't assume the GPU is absent — Spark has
-known GPU-detection false negatives on bare pip installs (a
-torchcodec/driver interaction is the usual culprit). Check with the driver
-directly before spending time debugging the Python side:
+If it prints `False` instead, don't assume the GPU is absent —
+Spark has known GPU-detection false negatives on bare pip
+installs (a torchcodec/driver interaction is the usual
+culprit). Check with the driver directly before spending time
+debugging the Python side:
 
 ```bash
 nvidia-smi
 ```
 
-If `nvidia-smi` shows the GPU but PyTorch still reports `False`, the
-problem is almost certainly the ABI mismatch above, not a missing driver.
+If `nvidia-smi` shows the GPU but PyTorch still reports
+`False`, the problem is almost certainly the ABI mismatch
+above, not a missing driver.
 
-Run this same check right after the container starts, before installing
-any project-specific packages on top of it. That way, a failure clearly
-points at the base image rather than something layered in afterward —
-the two failure modes need different fixes, and conflating them wastes
-time.
+Run this check right after the container starts, before
+installing anything project-specific — that way a failure
+points at the base image, not something layered on afterward.
 
-## Fast Path Recap
-
-For a repeat setup, skip straight to the order of operations:
-
-1. Pull the right container (Container-First Rule).
-2. Run it with `--runtime=nvidia --gpus all`, matching the commands above.
-3. Run the verification commands before installing anything
-   project-specific.
-4. If verification fails, check the ABI Rule first.
-5. Consult the Component Quick Table before assuming a broken framework
-   install is unique to this project.
-6. Escalate to the two companion skills linked below once the environment
-   itself is confirmed healthy.
+One more environment-level check: if Triton kernel compilation
+fails once training starts, set
+`TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas` and retry — see
+the Component Quick Table above and `references/stack-matrix.md`
+for the full per-component workaround list.
 
 ## Next Steps
 
-A verified environment is only the starting point — long training runs
-surface a different class of problem once the stack itself is working.
+A verified environment is only the starting point — long
+training runs surface a different class of problem once the
+stack itself is working.
 
-See also: `spark-training-gotchas` for failure preflights before a
-training run, and `spark-memory-thermal-ops` for unified-memory OOMs and
-thermal throttling during long ones.
+See also: `spark-training-gotchas` for failure preflights
+before a training run, and `spark-memory-thermal-ops` for
+unified-memory OOMs and thermal throttling during long ones.

--- a/plugins/dgx-spark-ops/skills/spark-environment-setup/SKILL.md
+++ b/plugins/dgx-spark-ops/skills/spark-environment-setup/SKILL.md
@@ -13,21 +13,18 @@ ecosystem for aarch64 + CUDA 13 is still filling in.
 
 ## When to Use This Skill
 
-- Setting up a fresh Spark box for training or inference for
-  the first time.
+- Setting up a fresh Spark box for training or inference.
 - Hitting an import error mentioning `libcudart`, a missing
   symbol, or a wheel that "installed fine but won't load."
 - A framework install (PyTorch, Unsloth, TRL, vLLM, xformers)
   fails, hangs, or silently falls back to CPU.
-- Deciding whether to use an NGC container or a bare pip
-  environment for a given run.
+- Deciding whether to use an NGC container or bare pip.
 - Restoring a working setup after an OS reinstall or a
-  base-image update, and needing to re-verify from scratch.
+  base-image update, needing to re-verify from scratch.
 
 Each of these accepts the same general fix: match the
 container/wheel combination to CUDA 13 and SM121, don't fight
-the ABI. The sections below walk through how, starting with
-the container-vs-pip decision.
+the ABI.
 
 ## Container-First Rule
 
@@ -40,17 +37,19 @@ Quick decision, before the detail below:
 - Neither fits (custom system package, local IDE interpreter)
   → bare pip, following the exact sequence further down.
 
-Default to a container. Use `nvcr.io/nvidia/pytorch:25.11-py3`
-as the base for general work, or
-`unsloth/unsloth:dgxspark-latest` for Unsloth-centric
-fine-tuning. Treat bare pip as the exception.
+Default to a container. Use `nvcr.io/nvidia/pytorch:25.09-py3`
+as the base for general work — the newest tag confirmed
+working on this hardware; pull a newer blessed tag if one is
+locally available and note any delta rather than hard-blocking
+on `25.11-py3` specifically — or `unsloth/unsloth:dgxspark-latest`
+for Unsloth-centric fine-tuning. Treat bare pip as the exception.
 
 Minimal invocations (full flag rationale and volume mounts for
 `finetuning/` run dirs: `references/container-workflow.md`):
 
 ```bash
 docker run --runtime=nvidia --gpus all -it --rm \
-  nvcr.io/nvidia/pytorch:25.11-py3
+  nvcr.io/nvidia/pytorch:25.09-py3
 ```
 
 ```bash
@@ -64,11 +63,10 @@ then use that `@sha256:...` digest in place of the tag.
 
 The reason for the container-first stance is pinning, not
 convenience. Triton, xformers, and transformers versions
-interact narrowly with GB10's SM121 target and the CUDA 13
-toolchain; a container locks all of them together against a
-combination already validated on this hardware. A bare pip
-environment leaves that resolution to you, one broken import
-at a time.
+interact narrowly with GB10's SM121 target and CUDA 13; a
+container locks all of them together against a combination
+already validated on this hardware. Bare pip leaves that
+resolution to you, one broken import at a time.
 
 When bare pip is warranted, follow the NVIDIA playbook's
 install sequence verbatim and in order:
@@ -76,23 +74,33 @@ install sequence verbatim and in order:
 ```bash
 pip install transformers peft hf_transfer "datasets==4.3.0" "trl==0.26.1"
 pip install --no-deps unsloth unsloth_zoo bitsandbytes
+pip install -U torchao
 ```
 
 The second command's `--no-deps` flag is not optional —
 letting pip re-resolve Unsloth's dependency tree on aarch64 is
 a common way to pull in an incompatible torch or triton build.
+The third line is not optional either: the NGC base image's
+bundled `torchao` is too old for current `peft`'s LoRA-attach
+path (`ImportError: ... torchao ... only versions above 0.16.0
+are supported`) — a hard blocker, not a warning. The `==` pins
+shown above are load-bearing, not illustrative: an unpinned
+`pip install transformers peft hf_transfer datasets trl
+accelerate` resolves current PyPI versions well outside what
+this Unsloth release supports. Dated known-good version matrix:
+`references/stack-matrix.md`.
 
-Pull a fresh image tag when a new blessed release is
-announced. Rebuild locally from one of the two bases only when
-a project needs an extra system package layered in — not to
-"upgrade" a component the image already pins. Details on both
-paths: `references/container-workflow.md`.
+Pull a fresh tag when a new blessed release is announced.
+Rebuild locally from one of the two bases only when a project
+needs an extra system package layered in — not to "upgrade" a
+component the image already pins. Details on both paths:
+`references/container-workflow.md`.
 
 One more preflight: official DGX Spark playbooks have shipped
 broken before. Check recent issues on
 `github.com/NVIDIA/dgx-spark-playbooks` (and the other
-canonical resources listed in `references/stack-matrix.md`)
-before trusting a recipe verbatim for a long run.
+resources in `references/stack-matrix.md`) before trusting a
+recipe verbatim for a long run.
 
 ## The ABI Rule
 
@@ -113,24 +121,20 @@ python3 -c "import torch; print(torch.version.cuda)"
 ```
 
 If that output doesn't start with `13`, the ABI mismatch is the
-first thing to fix. Note that NGC container builds (e.g.
-`nvcr.io/nvidia/pytorch:25.11-py3`) build torch internally
+first thing to fix. NGC container builds (e.g.
+`nvcr.io/nvidia/pytorch:25.09-py3`) build torch internally
 against CUDA 13 with no `+cu130` wheel tag — `pip show torch`
-won't say `cu130` on those containers, and that absence alone is
-not a failure.
+won't say `cu130` there, and that absence alone is not a failure.
 
-Typical symptoms, so the pattern is recognizable next time:
+Typical symptoms:
 
 - `ImportError: undefined symbol` referencing a CUDA runtime
   function.
-- A segfault on the very first `.cuda()` call, with no useful
-  Python traceback.
+- A segfault on the first `.cuda()` call, no useful traceback.
 - A wheel that installs cleanly, then fails at import time —
-  pip's resolver doesn't check CUDA ABI compatibility, only
-  package version constraints.
-- Two "identical" environments behaving differently — usually
-  one has a cu130 wheel and the other a cu121/cu124 leftover
-  from an earlier install.
+  pip's resolver doesn't check CUDA ABI, only version constraints.
+- Two "identical" environments behaving differently — usually one
+  has a cu130 wheel, the other a cu121/cu124 leftover.
 
 The fix is the same regardless of symptom: match the wheel's
 CUDA tag to the system, or use a container that already does.
@@ -138,24 +142,23 @@ CUDA tag to the system, or use a container that already does.
 ## Component Quick Table
 
 Condensed status for the components most likely to come up.
-Full table with wheel URLs, build flags, and the sm_121 vs
-sm_121a distinction: see `references/stack-matrix.md`.
+Full table with wheel URLs, build flags, the sm_121 vs sm_121a
+distinction, and the dated known-good version matrix:
+`references/stack-matrix.md`.
 
 | Component | Status |
 |---|---|
 | PyTorch | ✅ official cu130 aarch64 wheels |
 | bitsandbytes | ✅ works out of the box |
 | Triton | ✅ needs the `TRITON_PTXAS_PATH` parameter set |
-| flash-attn | ❌ skip — no sm_121 kernels; use PyTorch SDPA instead |
+| flash-attn | ❌ skip pip build; NGC bundles a working one — see `spark-training-gotchas` G2 |
 | xformers | source build only (`TORCH_CUDA_ARCH_LIST=12.1`) |
 | vLLM | nightly wheels only |
 | TransformerEngine / NVFP4 train | container-only |
 
-Everything else — Unsloth itself, Axolotl, TRL, PEFT —
-installs cleanly through the container-first path above.
-LLaMA-Factory and NeMo are the exceptions: fragile on Spark as
-of this writing, so check upstream issues before depending on
-either (details in `references/stack-matrix.md`).
+Everything else — Unsloth, Axolotl, TRL, PEFT — installs
+cleanly through the container-first path above. LLaMA-Factory
+and NeMo are fragile on Spark; check upstream issues first.
 
 ## Verification Commands
 
@@ -177,8 +180,7 @@ True 13.0
 If it prints `False` instead, don't assume the GPU is absent —
 Spark has known GPU-detection false negatives on bare pip
 installs (a torchcodec/driver interaction is the usual
-culprit). Check with the driver directly before spending time
-debugging the Python side:
+culprit). Check with the driver directly first:
 
 ```bash
 nvidia-smi
@@ -186,24 +188,17 @@ nvidia-smi
 
 If `nvidia-smi` shows the GPU but PyTorch still reports
 `False`, the problem is almost certainly the ABI mismatch
-above, not a missing driver.
+above, not a missing driver. Run this check right after the
+container starts, before installing anything project-specific.
 
-Run this check right after the container starts, before
-installing anything project-specific — that way a failure
-points at the base image, not something layered on afterward.
-
-One more environment-level check: if Triton kernel compilation
-fails once training starts, set
+One more check: if Triton kernel compilation fails once
+training starts, set
 `TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas` and retry — see
-the Component Quick Table above and `references/stack-matrix.md`
-for the full per-component workaround list.
+`references/stack-matrix.md` for the full workaround list.
 
 ## Next Steps
 
-A verified environment is only the starting point — long
-training runs surface a different class of problem once the
-stack itself is working.
-
-See also: `spark-training-gotchas` for failure preflights
-before a training run, and `spark-memory-thermal-ops` for
-unified-memory OOMs and thermal throttling during long ones.
+A verified environment is only the starting point. See also:
+`spark-training-gotchas` for failure preflights before a
+training run, and `spark-memory-thermal-ops` for unified-memory
+OOMs and thermal throttling during long ones.

--- a/plugins/dgx-spark-ops/skills/spark-environment-setup/SKILL.md
+++ b/plugins/dgx-spark-ops/skills/spark-environment-setup/SKILL.md
@@ -58,6 +58,10 @@ docker run --runtime=nvidia --gpus all -it --rm \
   unsloth/unsloth:dgxspark-latest
 ```
 
+`dgxspark-latest` is a moving tag — pin it once resolved:
+`docker inspect --format='{{index .RepoDigests 0}}' unsloth/unsloth:dgxspark-latest`,
+then use that `@sha256:...` digest in place of the tag.
+
 The reason for the container-first stance is pinning, not
 convenience. Triton, xformers, and transformers versions
 interact narrowly with GB10's SM121 target and the CUDA 13

--- a/plugins/dgx-spark-ops/skills/spark-environment-setup/SKILL.md
+++ b/plugins/dgx-spark-ops/skills/spark-environment-setup/SKILL.md
@@ -38,28 +38,22 @@ Quick decision, before the detail below:
   → bare pip, following the exact sequence further down.
 
 Default to a container. Use `nvcr.io/nvidia/pytorch:25.09-py3`
-as the base for general work — the newest tag confirmed
-working on this hardware; pull a newer blessed tag if one is
-locally available and note any delta rather than hard-blocking
-on `25.11-py3` specifically — or `unsloth/unsloth:dgxspark-latest`
-for Unsloth-centric fine-tuning. Treat bare pip as the exception.
-
-Minimal invocations (full flag rationale and volume mounts for
-`finetuning/` run dirs: `references/container-workflow.md`):
+as the base for general work — the newest tag confirmed working
+on this hardware; pull a newer blessed tag if locally available
+rather than hard-blocking on `25.11-py3`. NGC's tag is dated, so
+running it directly is fine:
 
 ```bash
 docker run --runtime=nvidia --gpus all -it --rm \
   nvcr.io/nvidia/pytorch:25.09-py3
 ```
 
-```bash
-docker run --runtime=nvidia --gpus all -it --rm \
-  unsloth/unsloth:dgxspark-latest
-```
-
-`dgxspark-latest` is a moving tag — pin it once resolved:
-`docker inspect --format='{{index .RepoDigests 0}}' unsloth/unsloth:dgxspark-latest`,
-then use that `@sha256:...` digest in place of the tag.
+`unsloth/unsloth:dgxspark-latest` is a *moving* tag by
+contrast — resolve and pin its digest before running it for
+anything reproducible; the bare tag is a discovery step only,
+not the default invocation. Full pull-inspect-pin sequence and
+flag rationale/volume mounts for `finetuning/` run dirs:
+`references/container-workflow.md`. Treat bare pip as the exception.
 
 The reason for the container-first stance is pinning, not
 convenience. Triton, xformers, and transformers versions
@@ -72,9 +66,9 @@ When bare pip is warranted, follow the NVIDIA playbook's
 install sequence verbatim and in order:
 
 ```bash
-pip install transformers peft hf_transfer "datasets==4.3.0" "trl==0.26.1"
-pip install --no-deps unsloth unsloth_zoo bitsandbytes
-pip install -U torchao
+pip install "transformers==5.13.1" "peft==0.19.1" "hf_transfer==0.1.9" "datasets==4.3.0" "trl==1.8.0"
+pip install --no-deps "unsloth==2026.7.2" "unsloth_zoo==2026.7.2" "bitsandbytes==0.49.2"
+pip install -U "torchao==0.17.0"
 ```
 
 The second command's `--no-deps` flag is not optional —
@@ -83,12 +77,11 @@ a common way to pull in an incompatible torch or triton build.
 The third line is not optional either: the NGC base image's
 bundled `torchao` is too old for current `peft`'s LoRA-attach
 path (`ImportError: ... torchao ... only versions above 0.16.0
-are supported`) — a hard blocker, not a warning. The `==` pins
-shown above are load-bearing, not illustrative: an unpinned
-`pip install transformers peft hf_transfer datasets trl
-accelerate` resolves current PyPI versions well outside what
-this Unsloth release supports. Dated known-good version matrix:
-`references/stack-matrix.md`.
+are supported`) — a hard blocker, not a warning. Every `==` pin
+above is load-bearing, taken from the dated known-good version
+matrix in `references/stack-matrix.md` (its `Last verified` date
+governs staleness) — an unpinned install resolves current PyPI
+versions well outside what this Unsloth release supports.
 
 Pull a fresh tag when a new blessed release is announced.
 Rebuild locally from one of the two bases only when a project
@@ -177,19 +170,22 @@ line, `<bool> <cuda-version>`:
 True 13.0
 ```
 
-If it prints `False` instead, don't assume the GPU is absent —
-Spark has known GPU-detection false negatives on bare pip
-installs (a torchcodec/driver interaction is the usual
-culprit). Check with the driver directly first:
+If it prints `False` instead, don't jump straight to a wheel
+reinstall — ABI mismatch is one cause among several:
 
-```bash
-nvidia-smi
-```
+| Hypothesis | Quick check |
+|---|---|
+| Runtime/flags | `nvidia-smi` fails in-container too |
+| Device visibility | `echo $CUDA_VISIBLE_DEVICES` |
+| Permissions | `ls -l /dev/nvidia*` |
+| CUDA init state | wedged process; retry fresh shell/container |
+| ABI mismatch (usual culprit) | `torch.version.cuda` not `13.x` |
 
-If `nvidia-smi` shows the GPU but PyTorch still reports
-`False`, the problem is almost certainly the ABI mismatch
-above, not a missing driver. Run this check right after the
-container starts, before installing anything project-specific.
+Check `nvidia-smi` first — if it doesn't show the GPU, it's one
+of the first three, not ABI. Reinstall a wheel only once ABI is
+confirmed. Per-hypothesis detail: `references/stack-matrix.md`.
+Run right after the container starts, before installing
+project-specific packages.
 
 One more check: if Triton kernel compilation fails once
 training starts, set

--- a/plugins/dgx-spark-ops/skills/spark-environment-setup/references/container-workflow.md
+++ b/plugins/dgx-spark-ops/skills/spark-environment-setup/references/container-workflow.md
@@ -1,0 +1,45 @@
+Last verified: 2026-07-13 — refresh when the blessed container tags change.
+
+# Container Workflow
+
+Concrete `docker run` invocations for the two blessed images, plus the bare-pip fallback.
+
+## NGC PyTorch container
+
+General-purpose training/inference base:
+
+```bash
+docker run --runtime=nvidia --gpus all -it --rm \
+  --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 \
+  -v "$(pwd)/finetuning:/workspace/finetuning" \
+  nvcr.io/nvidia/pytorch:25.11-py3
+```
+
+- `--runtime=nvidia --gpus all` gives the container access to the GB10 GPU; without it, PyTorch inside the container will report no CUDA device even though the host sees one fine.
+- `--ipc=host` and the `ulimit` flags avoid shared-memory starvation for PyTorch's DataLoader workers.
+- Mount the repo's `finetuning/` run directory so checkpoints and logs land on the host filesystem, not inside the ephemeral container layer — the `--rm` flag deletes the container (and anything not mounted out) on exit.
+
+## Unsloth container
+
+For Unsloth-centric fine-tuning runs, prefer the purpose-built image over the generic NGC one — it ships the pinned Triton/xformers/transformers combination already validated for this hardware:
+
+```bash
+docker run --runtime=nvidia --gpus all -it --rm \
+  --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 \
+  -v "$(pwd)/finetuning:/workspace/finetuning" \
+  unsloth/unsloth:dgxspark-latest
+```
+
+Same flag rationale as above. Prefer this over rebuilding a custom Unsloth image from the NGC base.
+
+## Pull vs rebuild
+
+Pull a fresh tag when: a new blessed release is announced, or you're chasing a bug that a recent tag's changelog says it fixes.
+
+Rebuild locally (starting `FROM` one of the two images above) when: you need an extra system package or Python dependency layered in for a specific project, and that dependency doesn't conflict with the pinned training stack. Don't rebuild to "upgrade" a component that the base image already pins — that reintroduces the version-matrix problem the container exists to avoid.
+
+## Bare-pip escape hatch
+
+If a container genuinely doesn't fit (see `SKILL.md`'s Container-First Rule), isolate the environment with `uv` rather than the system Python, and follow the NVIDIA playbook install sequence from `SKILL.md` inside it.
+
+Caveat: if `uv` insists on a dependency version that conflicts with what the playbook pins (a common outcome given how young the aarch64/CUDA-13 wheel ecosystem is), use `uv pip install --override-dependencies` to force the pinned versions through rather than letting the resolver silently substitute an incompatible build. Verify the result with the Verification Commands section of `SKILL.md` before trusting the environment.

--- a/plugins/dgx-spark-ops/skills/spark-environment-setup/references/container-workflow.md
+++ b/plugins/dgx-spark-ops/skills/spark-environment-setup/references/container-workflow.md
@@ -32,6 +32,12 @@ docker run --runtime=nvidia --gpus all -it --rm \
 
 Same flag rationale as above. Prefer this over rebuilding a custom Unsloth image from the NGC base.
 
+`dgxspark-latest` is a moving tag, unlike the NGC image's dated
+`25.11-py3` tag above — pin it once resolved:
+`docker inspect --format='{{index .RepoDigests 0}}' unsloth/unsloth:dgxspark-latest`,
+then substitute that `@sha256:...` digest for the tag in CI or any
+pipeline where reproducibility matters.
+
 ## Pull vs rebuild
 
 Pull a fresh tag when: a new blessed release is announced, or you're chasing a bug that a recent tag's changelog says it fixes.
@@ -42,4 +48,4 @@ Rebuild locally (starting `FROM` one of the two images above) when: you need an 
 
 If a container genuinely doesn't fit (see `SKILL.md`'s Container-First Rule), isolate the environment with `uv` rather than the system Python, and follow the NVIDIA playbook install sequence from `SKILL.md` inside it.
 
-Caveat: if `uv` insists on a dependency version that conflicts with what the playbook pins (a common outcome given how young the aarch64/CUDA-13 wheel ecosystem is), use `uv pip install --override-dependencies` to force the pinned versions through rather than letting the resolver silently substitute an incompatible build. Verify the result with the Verification Commands section of `SKILL.md` before trusting the environment.
+Caveat: if `uv` insists on a dependency version that conflicts with what the playbook pins (a common outcome given how young the aarch64/CUDA-13 wheel ecosystem is), use `uv pip install --override` to force the pinned versions through rather than letting the resolver silently substitute an incompatible build. Verify the result with the Verification Commands section of `SKILL.md` before trusting the environment.

--- a/plugins/dgx-spark-ops/skills/spark-environment-setup/references/container-workflow.md
+++ b/plugins/dgx-spark-ops/skills/spark-environment-setup/references/container-workflow.md
@@ -23,22 +23,28 @@ docker run --runtime=nvidia --gpus all -it --rm \
 
 ## Unsloth container
 
-For Unsloth-centric fine-tuning runs, prefer the purpose-built image over the generic NGC one — it ships the pinned Triton/xformers/transformers combination already validated for this hardware:
+For Unsloth-centric fine-tuning runs, prefer the purpose-built image over the generic NGC one — it ships the pinned Triton/xformers/transformers combination already validated for this hardware.
+
+**`dgxspark-latest` is a moving tag, unlike the NGC image's dated `25.09-py3` tag above.** Don't run it directly as the invocation you'll rely on for a real run — resolve and pin its digest first, then run by digest:
 
 ```bash
+# 1. Discovery step: pull the moving tag and confirm it starts.
+docker pull unsloth/unsloth:dgxspark-latest
+
+# 2. Resolve the tag to its current digest.
+docker inspect --format='{{index .RepoDigests 0}}' unsloth/unsloth:dgxspark-latest
+# -> unsloth/unsloth@sha256:<resolved digest>
+
+# 3. Run by digest — this is the reproducible invocation.
 docker run --runtime=nvidia --gpus all -it --rm \
   --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 \
   -v "$(pwd)/finetuning:/workspace/finetuning" \
-  unsloth/unsloth:dgxspark-latest
+  unsloth/unsloth@sha256:<resolved digest>
 ```
 
-Same flag rationale as above. Prefer this over rebuilding a custom Unsloth image from the NGC base.
+Substitute the pinned `@sha256:...` digest for the tag in CI or any pipeline where reproducibility matters — a run recorded against `dgxspark-latest` by tag alone cannot be reproduced later if the tag has moved on. Re-resolve and re-pin the digest whenever picking up a new blessed release (see "Pull vs rebuild" below).
 
-`dgxspark-latest` is a moving tag, unlike the NGC image's dated
-`25.11-py3` tag above — pin it once resolved:
-`docker inspect --format='{{index .RepoDigests 0}}' unsloth/unsloth:dgxspark-latest`,
-then substitute that `@sha256:...` digest for the tag in CI or any
-pipeline where reproducibility matters.
+Same flag rationale as the NGC invocation above. Prefer this over rebuilding a custom Unsloth image from the NGC base.
 
 ## Pull vs rebuild
 

--- a/plugins/dgx-spark-ops/skills/spark-environment-setup/references/container-workflow.md
+++ b/plugins/dgx-spark-ops/skills/spark-environment-setup/references/container-workflow.md
@@ -1,4 +1,4 @@
-Last verified: 2026-07-13 — refresh when the blessed container tags change.
+Last verified: 2026-07-14 — refresh when the blessed container tags change.
 
 # Container Workflow
 
@@ -12,8 +12,10 @@ General-purpose training/inference base:
 docker run --runtime=nvidia --gpus all -it --rm \
   --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 \
   -v "$(pwd)/finetuning:/workspace/finetuning" \
-  nvcr.io/nvidia/pytorch:25.11-py3
+  nvcr.io/nvidia/pytorch:25.09-py3
 ```
+
+**Tag guidance:** `25.09-py3` is the tag actually verified working on this hardware (torch `2.9.0a0+50eac811a6.nv25.09`, CUDA 13.0 baked in, matches the ABI Rule's expectations — no functional delta observed for the packages exercised in fine-tuning workflows). Treat `SKILL.md`'s mention of a newer blessed tag as guidance to pull when locally available, not a hard requirement — if the cited newer tag isn't locally cached and pulling isn't practical, fall back to the newest available `25.x` tag and record the gap in the run's notes rather than blocking on it.
 
 - `--runtime=nvidia --gpus all` gives the container access to the GB10 GPU; without it, PyTorch inside the container will report no CUDA device even though the host sees one fine.
 - `--ipc=host` and the `ulimit` flags avoid shared-memory starvation for PyTorch's DataLoader workers.

--- a/plugins/dgx-spark-ops/skills/spark-environment-setup/references/stack-matrix.md
+++ b/plugins/dgx-spark-ops/skills/spark-environment-setup/references/stack-matrix.md
@@ -1,4 +1,4 @@
-Last verified: 2026-07-13 — refresh when CUDA, PyTorch, or Unsloth major versions change.
+Last verified: 2026-07-14 — refresh when CUDA, PyTorch, or Unsloth major versions change.
 
 # Spark Stack Matrix
 
@@ -16,6 +16,46 @@ Full component-by-component status for the ML training/inference stack on DGX Sp
 | Unsloth | ✅ (container preferred) | Official Docker image `unsloth/unsloth:dgxspark-latest` (a moving tag — resolve and pin its digest for reproducible/CI use, see `references/container-workflow.md`), or the NVIDIA playbook pip sequence (see `SKILL.md`). Bare pip installs have hit torchcodec and GPU-detection gotchas. |
 | Axolotl / TRL / PEFT | ✅ | Standard install, no special handling needed. |
 | LLaMA-Factory / NeMo | fragile / in progress | Known to be unreliable on this platform as of this writing; expect breakage and check upstream issues before depending on either for a run. |
+
+## Known-Good Version Matrix (Dated)
+
+`SKILL.md`'s bare-pip sequence pins `datasets`/`trl` explicitly
+for a reason: an unpinned `pip install transformers peft
+hf_transfer datasets trl accelerate` resolves current PyPI
+versions of `transformers`/`trl`/`datasets` that sit well
+outside what a given Unsloth release declares support for — pip
+installs them anyway and only warns after the fact. The
+combination below was confirmed working end-to-end (bf16 LoRA
+load + attach + a full SFT run) on `nvcr.io/nvidia/pytorch:25.09-py3`
+as of the date above; treat it as a dated snapshot to re-verify,
+not a permanent pin:
+
+| Package | Verified-working version |
+|---|---|
+| `transformers` | 5.13.1 |
+| `trl` | 1.8.0 |
+| `unsloth` / `unsloth_zoo` | 2026.7.2 |
+| `torchao` | 0.17.0 (pure-Python wheel; NGC base image ships 0.13.0+git, too old — `pip install -U torchao` after the Unsloth line) |
+| `bitsandbytes` | 0.49.2 |
+
+If a bare-pip install lands on a different combination than
+this table (pip resolver drift is expected as new releases
+ship), re-run the load+LoRA-attach smoke test in `SKILL.md`'s
+Verification Commands before trusting the environment, and
+check `gh issue list --repo NVIDIA/dgx-spark-playbooks` for a
+version-skew report matching the symptom before assuming it's
+novel.
+
+**`HF_HUB_ENABLE_HF_TRANSFER` is deprecated on `huggingface_hub`
+1.23+.** Setting it now only produces `FutureWarning: The
+HF_HUB_ENABLE_HF_TRANSFER environment variable is deprecated ...
+Please use HF_XET_HIGH_PERFORMANCE instead`, and downloads route
+through Xet rather than hf_transfer regardless. This is cosmetic
+(downloads still succeed, and fast) on current `huggingface_hub`
+— stale task instructions or older recipes that still reference
+`hf_transfer`-based env setup should be read as intent ("make
+downloads fast"), not a literal current-API requirement; set
+`HF_XET_HIGH_PERFORMANCE=1` instead on `huggingface_hub` 1.23+.
 
 ## sm_121 vs sm_121a
 

--- a/plugins/dgx-spark-ops/skills/spark-environment-setup/references/stack-matrix.md
+++ b/plugins/dgx-spark-ops/skills/spark-environment-setup/references/stack-matrix.md
@@ -1,0 +1,32 @@
+Last verified: 2026-07-13 — refresh when CUDA, PyTorch, or Unsloth major versions change.
+
+# Spark Stack Matrix
+
+Full component-by-component status for the ML training/inference stack on DGX Spark (GB10, SM121, aarch64, CUDA 13). This is the detail table behind the "Component Quick Table" in `SKILL.md`.
+
+| Component | Status | Notes |
+|---|---|---|
+| PyTorch (cu130, aarch64) | ✅ | Official wheels at `download.pytorch.org/whl/cu130`. Matches the system CUDA 13 ABI — see the ABI Rule in `SKILL.md`. |
+| bitsandbytes | ✅ | 0.48+ works out of the box. |
+| Triton | ✅ (with env var) | Needs `TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas` set, or kernel compilation fails to find `ptxas`. |
+| flash-attn | ❌ skip | No sm_121 kernels shipped or buildable yet. PyTorch's SDPA backend is faster on this hardware anyway — don't spend time chasing a flash-attn build. |
+| xformers | source build only | No prebuilt aarch64/SM121 wheel. Build with `TORCH_CUDA_ARCH_LIST=12.1` set, or the build targets the wrong architecture and either fails or silently produces non-functional kernels. |
+| vLLM | nightly wheels only | Use `wheels.vllm.ai/nightly/cu130`. The SM121 fix landed in the nightly channel around 2026-06; stable/release wheels predate it. |
+| TransformerEngine / NVFP4 training | container-only | Not practical via bare pip; use the NGC PyTorch container. `NVFP4BlockScaling` targets SM100 — treat SM121 support as caveated, not guaranteed. |
+| Unsloth | ✅ (container preferred) | Official Docker image `unsloth/unsloth:dgxspark-latest`, or the NVIDIA playbook pip sequence (see `SKILL.md`). Bare pip installs have hit torchcodec and GPU-detection gotchas. |
+| Axolotl / TRL / PEFT | ✅ | Standard install, no special handling needed. |
+| LLaMA-Factory / NeMo | fragile / in progress | Known to be unreliable on this platform as of this writing; expect breakage and check upstream issues before depending on either for a run. |
+
+## sm_121 vs sm_121a
+
+GB10's GPU identifies as `sm_121`. Some newer kernel features — notably NVFP4's native `cvt.e2m1x2` conversion instruction — require code compiled for `sm_121a`, a superset target, not plain `sm_121`. If NVFP4 inference is ~32% slower than FP8 on this hardware, this is why: the kernel likely wasn't compiled with the `a` variant. Check the build flags of whatever wheel or container you're using before assuming the hardware itself is the bottleneck.
+
+## Canonical resources
+
+- `github.com/NVIDIA/dgx-spark-playbooks`
+- `build.nvidia.com/spark/unsloth`
+- `github.com/natolambert/dgx-spark-setup`
+- `github.com/albond/DGX_Spark_Unsloth_Lossless_Speedup`
+- `github.com/NvMayMay/nvfp4-lora-spark`
+
+Official playbooks have shipped broken before. Check each repo's recent issues before starting a long run, not after it fails.

--- a/plugins/dgx-spark-ops/skills/spark-environment-setup/references/stack-matrix.md
+++ b/plugins/dgx-spark-ops/skills/spark-environment-setup/references/stack-matrix.md
@@ -34,9 +34,12 @@ not a permanent pin:
 |---|---|
 | `transformers` | 5.13.1 |
 | `trl` | 1.8.0 |
+| `peft` | 0.19.1 |
+| `datasets` | 4.3.0 (pin as-is; not re-verified independently of the combination above) |
 | `unsloth` / `unsloth_zoo` | 2026.7.2 |
 | `torchao` | 0.17.0 (pure-Python wheel; NGC base image ships 0.13.0+git, too old — `pip install -U torchao` after the Unsloth line) |
 | `bitsandbytes` | 0.49.2 |
+| `hf_transfer` | 0.1.9 (current stable; see the deprecation note below before relying on it) |
 
 If a bare-pip install lands on a different combination than
 this table (pip resolver drift is expected as new releases
@@ -56,6 +59,44 @@ through Xet rather than hf_transfer regardless. This is cosmetic
 `hf_transfer`-based env setup should be read as intent ("make
 downloads fast"), not a literal current-API requirement; set
 `HF_XET_HIGH_PERFORMANCE=1` instead on `huggingface_hub` 1.23+.
+
+## GPU-Detection False Negative: Per-Hypothesis Detail
+
+The full discriminating check behind `SKILL.md`'s Verification
+Commands hypothesis table, in the order to work through them:
+
+1. **Runtime/flags.** If `docker run` was missing
+   `--runtime=nvidia --gpus all`, `nvidia-smi` run *inside* the
+   container fails or shows no devices even though the host sees
+   the GPU fine. Fix: re-run with both flags.
+2. **Device visibility.** `echo $CUDA_VISIBLE_DEVICES` — an
+   empty string set explicitly (not merely unset) hides all
+   devices from CUDA; a stale index (e.g. `1` on a single-GPU
+   box) hides the only device present. Fix: `unset
+   CUDA_VISIBLE_DEVICES` or set it to `0`.
+3. **Permissions.** `ls -l /dev/nvidia*` — missing entries or a
+   `Permission denied` on read means the container/user can't
+   open the device nodes (common when running rootless or with a
+   restrictive seccomp/AppArmor profile). Fix: match the host's
+   device-cgroup rules, or don't run rootless for GPU workloads.
+4. **CUDA init state.** A prior process that crashed mid-kernel
+   can leave the driver's CUDA context wedged for that process
+   tree. Retrying in a fresh shell or a freshly started container
+   (not just a new Python process in the same shell) rules this
+   out cheaply before assuming anything deeper is wrong.
+5. **ABI mismatch.** The last hypothesis to check, not the
+   first: `python3 -c "import torch; print(torch.version.cuda)"`
+   not starting with `13` confirms a `libcudart.so.12`-linked
+   wheel on a CUDA-13-only system — see the ABI Rule in
+   `SKILL.md`. This is the only one of the five that a wheel
+   reinstall actually fixes; reinstalling before ruling out 1-4
+   wastes a cycle without changing the outcome if the real cause
+   is a flag, an env var, or a permission.
+
+A torchcodec/driver interaction is the most frequently reported
+instance of (5) on this hardware specifically — see
+`gh issue list --repo NVIDIA/dgx-spark-playbooks` for current
+reports before assuming a novel cause.
 
 ## sm_121 vs sm_121a
 

--- a/plugins/dgx-spark-ops/skills/spark-environment-setup/references/stack-matrix.md
+++ b/plugins/dgx-spark-ops/skills/spark-environment-setup/references/stack-matrix.md
@@ -13,7 +13,7 @@ Full component-by-component status for the ML training/inference stack on DGX Sp
 | xformers | source build only | No prebuilt aarch64/SM121 wheel. Build with `TORCH_CUDA_ARCH_LIST=12.1` set, or the build targets the wrong architecture and either fails or silently produces non-functional kernels. |
 | vLLM | nightly wheels only | Use `wheels.vllm.ai/nightly/cu130`. The SM121 fix landed in the nightly channel around 2026-06; stable/release wheels predate it. |
 | TransformerEngine / NVFP4 training | container-only | Not practical via bare pip; use the NGC PyTorch container. `NVFP4BlockScaling` targets SM100 — treat SM121 support as caveated, not guaranteed. |
-| Unsloth | ✅ (container preferred) | Official Docker image `unsloth/unsloth:dgxspark-latest`, or the NVIDIA playbook pip sequence (see `SKILL.md`). Bare pip installs have hit torchcodec and GPU-detection gotchas. |
+| Unsloth | ✅ (container preferred) | Official Docker image `unsloth/unsloth:dgxspark-latest` (a moving tag — resolve and pin its digest for reproducible/CI use, see `references/container-workflow.md`), or the NVIDIA playbook pip sequence (see `SKILL.md`). Bare pip installs have hit torchcodec and GPU-detection gotchas. |
 | Axolotl / TRL / PEFT | ✅ | Standard install, no special handling needed. |
 | LLaMA-Factory / NeMo | fragile / in progress | Known to be unreliable on this platform as of this writing; expect breakage and check upstream issues before depending on either for a run. |
 

--- a/plugins/dgx-spark-ops/skills/spark-memory-thermal-ops/SKILL.md
+++ b/plugins/dgx-spark-ops/skills/spark-memory-thermal-ops/SKILL.md
@@ -8,18 +8,16 @@ description: Manage unified memory and thermals during long-running ML jobs on N
 DGX Spark's GB10 chip has one 128GB unified
 memory (UMA) pool shared by CPU and GPU, and a
 sustained power ceiling well below its rated
-figure. Both break assumptions from
-discrete-GPU boxes: memory headroom isn't what
-`nvidia-smi` reports, and a multi-hour run that
-starts fast will slow down partway through with
-nothing misconfigured. This skill covers
+figure. Both break discrete-GPU assumptions:
+headroom isn't what `nvidia-smi` reports, and a
+run that starts fast will slow down mid-job
+with nothing misconfigured. This skill covers
 planning memory headroom, working an actual
 OOM, and watching thermals across a long job.
 For launch-time failure modes (ABI mismatches,
 flash-attn, playbook breakage), see
-`spark-training-gotchas` instead — this skill
-assumes the job starts and covers what happens
-once it's running.
+`spark-training-gotchas` — this skill assumes
+the job starts.
 
 ## Common Issues Quick Reference
 
@@ -33,17 +31,17 @@ once it's running.
 ## When to Use This Skill
 
 - Sizing a training run against the 128GB pool
-  before launching it — will this model, method,
-  and batch/pack combination fit.
+  before launch — will this model, method, and
+  batch/pack combination fit.
 
 - A run OOMs mid-load or mid-step and the
   remediation order matters — what to try first,
   second, third.
 
 - Watching temperature and power during a
-  multi-hour or multi-epoch job, and deciding
-  whether a slowdown is thermal throttling or
-  something else.
+  multi-hour job, and deciding whether a
+  slowdown is thermal throttling or something
+  else.
 
 - Planning to run a trainer alongside an
   inference server (vLLM, Ollama) on the same
@@ -51,43 +49,41 @@ once it's running.
 
 ## UMA Memory Model
 
-Spark has no separate GPU VRAM — the GPU and CPU
-share one 128GB pool. Two consequences follow
-directly:
+Spark has no separate GPU VRAM — the GPU and
+CPU share one 128GB pool. Two consequences:
 
 - **`nvidia-smi` and `cudaMemGetInfo`
   underreport pressure.** Both report
-  CUDA-allocator-visible memory, not the unified
-  pool's actual state — a box can show
-  comfortable headroom in `nvidia-smi` and still
-  OOM, because page-cache and mmap'd pages the
-  allocator doesn't see are consuming the same
-  pool.
+  CUDA-allocator-visible memory, not the pool's
+  actual state — a box can show headroom in
+  `nvidia-smi` and still OOM, because page-cache
+  and mmap'd pages the allocator doesn't see
+  consume the same pool.
 
 - **Model load is a transient peak, not the
   steady state.** Loading safetensors weights
   mmaps the file, then copies into CUDA
   tensors — for a window during load, both the
   mmap'd pages and the CUDA copy count against
-  the pool at once. A model that fits once
-  training is running can still OOM during load
-  if headroom was sized for the post-load
-  footprint instead of this doubled transient.
+  the pool at once. A model that fits while
+  training can still OOM during load if headroom
+  was sized for the post-load footprint instead
+  of this doubled transient.
 
-Plan and diagnose against `free -g`, not
+Plan and diagnose with `free -g`, not
 `nvidia-smi`:
 
 ```bash
 free -g | awk 'NR==2 {print "free:", $4, "GB"}'
 ```
 
-Rule of thumb: take that free figure, subtract a
-few GB for OS and driver overhead, and budget
+Rule of thumb: take that free figure, subtract
+a few GB for OS/driver overhead, and budget
 against the result — not the 128GB spec number.
 The worksheet in `references/uma-accounting.md`
 accepts parameter count, dtype, and method as
-input, and returns a total memory estimate to
-compare against known anchors.
+input, and returns a memory estimate to compare
+against known anchors.
 
 ### Planning Sequence
 
@@ -98,17 +94,16 @@ Before launch, work through these in order:
 2. Estimate weights + optimizer + gradients +
    activations from `references/uma-accounting.md`.
 3. Compare against the closest anchor (70B
-   QLoRA, 27B LoRA, 9B full FT) rather than
-   trusting the estimate alone.
+   QLoRA, 27B LoRA, 9B full FT), not the
+   estimate alone.
 4. If the estimate is close to the budget, start
    with shorter packing or a smaller batch —
    cheaper than hitting the OOM Ladder mid-run.
 
 ### Example: Sizing a 70B QLoRA Run
 
-A quick sanity check against the worksheet
-formula before trusting the ≈40GB anchor for a
-specific run:
+A sanity check of the worksheet formula against
+the ≈40GB anchor:
 
 ```python
 params = 70e9
@@ -118,22 +113,21 @@ total_gb = weights_gb + adapter_gb   # + activations
 print(f"{total_gb:.0f}GB before activations")
 ```
 
-Weights alone already land near the ≈40GB
-anchor — a plan estimating far above that for
-the same model class is a signal to recheck
-dtype and method, not just add headroom.
+Weights alone land near the ≈40GB anchor — a
+plan estimating far above that for the same
+model class is a signal to recheck dtype and
+method, not just add headroom.
 
 ## The OOM Ladder
 
 When a job OOMs on unified memory, work this
 ladder in order. Each step is more disruptive
-than the last, so don't skip ahead —
+than the last — don't skip ahead:
 **reducing batch size is never step 1.**
 
 1. **Flush the buffer cache.** Page cache from a
    previous run or a large dataset read often
-   accounts for GB of the "missing" headroom
-   `nvidia-smi` never showed in the first place.
+   accounts for GB of the "missing" headroom.
    This costs nothing but a rerun and doesn't
    touch the job's configuration:
 
@@ -141,92 +135,87 @@ than the last, so don't skip ahead —
    sync; echo 3 > /proc/sys/vm/drop_caches
    ```
 
-   Needs root; it's a between-run reset, not
-   something to run mid-training. See
+   Needs root; a between-run reset, not a
+   mid-training step. See
    `spark-training-gotchas` (gotcha G3) for the
    full diagnostic behind this step.
 
 2. **Reduce batch size or packing length.** Only
    after a flush fails to free enough headroom,
    cut the batch size or packing length — the
-   first step that changes what the run actually
-   does. Prefer packing length first; it drives
-   the activation footprint more directly at
-   long context.
+   first step that changes what the run does.
+   Prefer packing length first; it drives the
+   activation footprint more directly at long
+   context.
 
 3. **Downgrade the method: bf16 LoRA before
    QLoRA.** If flushing and shrinking batch/pack
    still OOM, drop the method down a tier — bf16
    LoRA is next, not the reverse. QLoRA's
    bitsandbytes dequantization buffers are
-   transient CUDA-side allocations that can push
-   a run over the edge before an equivalent bf16
-   LoRA run would, even though QLoRA's
-   steady-state footprint is smaller. A QLoRA
-   OOM is not proof the model doesn't fit — try
-   bf16 LoRA first.
+   transient CUDA-side allocations that can OOM
+   before an equivalent bf16 LoRA run would,
+   even though QLoRA's steady-state footprint is
+   smaller. A QLoRA OOM is not proof the model
+   doesn't fit — try bf16 LoRA first.
 
-Only fall back further (smaller model,
-multi-Spark) once all three steps have been
-tried and the job still won't fit.
+Fall back further (smaller model, multi-Spark)
+only after all three steps and the job still
+won't fit.
 
 ## Thermal Monitoring
 
 Multi-hour runs push into Spark's sustained
-power ceiling, well under the rated figure.
-Treat this as expected platform behavior, not a
-symptom to explain away:
+power ceiling, well under the rated figure —
+expected platform behavior, not a symptom to
+explain away:
 
 - Sample temperature and power alongside the
   training logs, not after a slowdown is
-  noticed — every 30-60 seconds is enough to
-  correlate a throughput drop with a thermal
-  event after the fact. Keep the output in the
-  CSV format `assets/thermal-sample.sh` writes,
-  so timestamps line up against the log:
+  noticed — every 30-60 seconds correlates a
+  throughput drop with a thermal event. Keep
+  the CSV output format `assets/thermal-sample.sh`
+  writes, so timestamps line up against the log:
 
   ```bash
   bash assets/thermal-sample.sh 30 thermal.log
   ```
 
 - **A sustained ~100W power draw is the platform
-  cap, not a configuration bug.** Don't spend
-  time re-tuning batch size or precision to "fix"
-  a plateau that's actually the box behaving
-  normally under load. If temperature climbs
-  while power stays flat under the rated 240W
-  figure, that's the signature to recognize.
+  cap, not a configuration bug.** Don't re-tune
+  batch size or precision to "fix" a plateau
+  that's the box behaving normally under load.
+  If temperature climbs while power stays flat
+  under the rated 240W figure, that's the
+  signature to recognize.
 
 - Log throttle events explicitly instead of
   letting a run silently slow down without
   record. A run whose per-step time doubles two
   hours in should show that in the log,
   correlated against the thermal sample at that
-  timestamp. Full throttling diagnostics and the
-  reboot failure mode live in
+  timestamp. Full throttling diagnostics and
+  the reboot failure mode:
   `spark-training-gotchas` (gotcha G4).
 
 ## Concurrent Workloads
 
-Because the 128GB pool is global, memory isn't
-the only resource one job can take from
-another — eviction happens without either
-process's logs showing an OOM:
+Because the 128GB pool is global, eviction
+happens without either process's logs showing
+an OOM:
 
-- Run one memory-heavy job at a time. A training
-  run and an inference server (vLLM, Ollama)
-  started side by side compete for the same
-  pool.
+- Run one memory-heavy job at a time. A trainer
+  and an inference server (vLLM, Ollama) compete
+  for the same pool.
 
 - Inference servers evict trainer pages silently
   under contention, and vice versa — neither
-  logs an error when it happens, so a
-  mysteriously slow run or a lost KV cache is a
-  contention symptom to check for. Stop
-  unrelated GPU-resident servers before a long
-  or full-pool run.
+  logs an error, so a mysteriously slow run or a
+  lost KV cache is a contention symptom to check
+  for. Stop unrelated GPU-resident servers
+  before a long or full-pool run.
 
-Check for other GPU-resident processes first:
+Check for GPU-resident processes first:
 
 ```bash
 ps aux | grep -E 'vllm|ollama|trl|axolotl' | grep -v grep
@@ -235,8 +224,8 @@ ps aux | grep -E 'vllm|ollama|trl|axolotl' | grep -v grep
 This procedure complements
 `plugins/dgx-spark-ops/skills/spark-training-gotchas/SKILL.md`
 (gotchas G3, G4, G6) — that skill covers
-launch-time failures; this one covers what
-happens once a job is already running.
+launch-time failures; this one, the running
+job.
 
-Memory math worksheets: see
+Memory math worksheets:
 `references/uma-accounting.md`.

--- a/plugins/dgx-spark-ops/skills/spark-memory-thermal-ops/SKILL.md
+++ b/plugins/dgx-spark-ops/skills/spark-memory-thermal-ops/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: spark-memory-thermal-ops
+description: Manage unified memory and thermals during long-running ML jobs on NVIDIA DGX Spark. Use when planning memory headroom for a training run on GB10, when a job OOMs on unified memory, or when monitoring temperature and power during multi-hour training.
+---
+
+# Spark Memory & Thermal Ops
+
+DGX Spark's GB10 chip has one 128GB unified
+memory (UMA) pool shared by CPU and GPU, and a
+sustained power ceiling well below its rated
+figure. Both break assumptions from
+discrete-GPU boxes: memory headroom isn't what
+`nvidia-smi` reports, and a multi-hour run that
+starts fast will slow down partway through with
+nothing misconfigured. This skill covers
+planning memory headroom, working an actual
+OOM, and watching thermals across a long job.
+For launch-time failure modes (ABI mismatches,
+flash-attn, playbook breakage), see
+`spark-training-gotchas` instead — this skill
+assumes the job starts and covers what happens
+once it's running.
+
+## Common Issues Quick Reference
+
+| Situation | Do this |
+|---|---|
+| Planning headroom before launch | Budget against `free -g`, not `nvidia-smi` — see UMA Memory Model |
+| Job OOMs on unified memory | Work the OOM Ladder in order: flush, then batch/pack, then method downgrade |
+| Throughput drops mid-run | Check the power/temp log before assuming a config bug — see Thermal Monitoring |
+| Trainer + inference server both wanted | Run one at a time — see Concurrent Workloads |
+
+## When to Use This Skill
+
+- Sizing a training run against the 128GB pool
+  before launching it — will this model, method,
+  and batch/pack combination fit.
+
+- A run OOMs mid-load or mid-step and the
+  remediation order matters — what to try first,
+  second, third.
+
+- Watching temperature and power during a
+  multi-hour or multi-epoch job, and deciding
+  whether a slowdown is thermal throttling or
+  something else.
+
+- Planning to run a trainer alongside an
+  inference server (vLLM, Ollama) on the same
+  box.
+
+## UMA Memory Model
+
+Spark has no separate GPU VRAM — the GPU and CPU
+share one 128GB pool. Two consequences follow
+directly:
+
+- **`nvidia-smi` and `cudaMemGetInfo`
+  underreport pressure.** Both report
+  CUDA-allocator-visible memory, not the unified
+  pool's actual state — a box can show
+  comfortable headroom in `nvidia-smi` and still
+  OOM, because page-cache and mmap'd pages the
+  allocator doesn't see are consuming the same
+  pool.
+
+- **Model load is a transient peak, not the
+  steady state.** Loading safetensors weights
+  mmaps the file, then copies into CUDA
+  tensors — for a window during load, both the
+  mmap'd pages and the CUDA copy count against
+  the pool at once. A model that fits once
+  training is running can still OOM during load
+  if headroom was sized for the post-load
+  footprint instead of this doubled transient.
+
+Plan and diagnose against `free -g`, not
+`nvidia-smi`:
+
+```bash
+free -g | awk 'NR==2 {print "free:", $4, "GB"}'
+```
+
+Rule of thumb: take that free figure, subtract a
+few GB for OS and driver overhead, and budget
+against the result — not the 128GB spec number.
+The worksheet in `references/uma-accounting.md`
+accepts parameter count, dtype, and method as
+input, and returns a total memory estimate to
+compare against known anchors.
+
+### Planning Sequence
+
+Before launch, work through these in order:
+
+1. Read `free -g`; subtract OS/driver overhead
+   for the budget.
+2. Estimate weights + optimizer + gradients +
+   activations from `references/uma-accounting.md`.
+3. Compare against the closest anchor (70B
+   QLoRA, 27B LoRA, 9B full FT) rather than
+   trusting the estimate alone.
+4. If the estimate is close to the budget, start
+   with shorter packing or a smaller batch —
+   cheaper than hitting the OOM Ladder mid-run.
+
+### Example: Sizing a 70B QLoRA Run
+
+A quick sanity check against the worksheet
+formula before trusting the ≈40GB anchor for a
+specific run:
+
+```python
+params = 70e9
+weights_gb = params * 0.5 / 1e9      # NF4, step 1
+adapter_gb = 0.5                     # step 5, negligible
+total_gb = weights_gb + adapter_gb   # + activations
+print(f"{total_gb:.0f}GB before activations")
+```
+
+Weights alone already land near the ≈40GB
+anchor — a plan estimating far above that for
+the same model class is a signal to recheck
+dtype and method, not just add headroom.
+
+## The OOM Ladder
+
+When a job OOMs on unified memory, work this
+ladder in order. Each step is more disruptive
+than the last, so don't skip ahead —
+**reducing batch size is never step 1.**
+
+1. **Flush the buffer cache.** Page cache from a
+   previous run or a large dataset read often
+   accounts for GB of the "missing" headroom
+   `nvidia-smi` never showed in the first place.
+   This costs nothing but a rerun and doesn't
+   touch the job's configuration:
+
+   ```bash
+   sync; echo 3 > /proc/sys/vm/drop_caches
+   ```
+
+   Needs root; it's a between-run reset, not
+   something to run mid-training. See
+   `spark-training-gotchas` (gotcha G3) for the
+   full diagnostic behind this step.
+
+2. **Reduce batch size or packing length.** Only
+   after a flush fails to free enough headroom,
+   cut the batch size or packing length — the
+   first step that changes what the run actually
+   does. Prefer packing length first; it drives
+   the activation footprint more directly at
+   long context.
+
+3. **Downgrade the method: bf16 LoRA before
+   QLoRA.** If flushing and shrinking batch/pack
+   still OOM, drop the method down a tier — bf16
+   LoRA is next, not the reverse. QLoRA's
+   bitsandbytes dequantization buffers are
+   transient CUDA-side allocations that can push
+   a run over the edge before an equivalent bf16
+   LoRA run would, even though QLoRA's
+   steady-state footprint is smaller. A QLoRA
+   OOM is not proof the model doesn't fit — try
+   bf16 LoRA first.
+
+Only fall back further (smaller model,
+multi-Spark) once all three steps have been
+tried and the job still won't fit.
+
+## Thermal Monitoring
+
+Multi-hour runs push into Spark's sustained
+power ceiling, well under the rated figure.
+Treat this as expected platform behavior, not a
+symptom to explain away:
+
+- Sample temperature and power alongside the
+  training logs, not after a slowdown is
+  noticed — every 30-60 seconds is enough to
+  correlate a throughput drop with a thermal
+  event after the fact. Keep the output in the
+  CSV format `assets/thermal-sample.sh` writes,
+  so timestamps line up against the log:
+
+  ```bash
+  bash assets/thermal-sample.sh 30 thermal.log
+  ```
+
+- **A sustained ~100W power draw is the platform
+  cap, not a configuration bug.** Don't spend
+  time re-tuning batch size or precision to "fix"
+  a plateau that's actually the box behaving
+  normally under load. If temperature climbs
+  while power stays flat under the rated 240W
+  figure, that's the signature to recognize.
+
+- Log throttle events explicitly instead of
+  letting a run silently slow down without
+  record. A run whose per-step time doubles two
+  hours in should show that in the log,
+  correlated against the thermal sample at that
+  timestamp. Full throttling diagnostics and the
+  reboot failure mode live in
+  `spark-training-gotchas` (gotcha G4).
+
+## Concurrent Workloads
+
+Because the 128GB pool is global, memory isn't
+the only resource one job can take from
+another — eviction happens without either
+process's logs showing an OOM:
+
+- Run one memory-heavy job at a time. A training
+  run and an inference server (vLLM, Ollama)
+  started side by side compete for the same
+  pool.
+
+- Inference servers evict trainer pages silently
+  under contention, and vice versa — neither
+  logs an error when it happens, so a
+  mysteriously slow run or a lost KV cache is a
+  contention symptom to check for. Stop
+  unrelated GPU-resident servers before a long
+  or full-pool run.
+
+Check for other GPU-resident processes first:
+
+```bash
+ps aux | grep -E 'vllm|ollama|trl|axolotl' | grep -v grep
+```
+
+This procedure complements
+`plugins/dgx-spark-ops/skills/spark-training-gotchas/SKILL.md`
+(gotchas G3, G4, G6) — that skill covers
+launch-time failures; this one covers what
+happens once a job is already running.
+
+Memory math worksheets: see
+`references/uma-accounting.md`.

--- a/plugins/dgx-spark-ops/skills/spark-memory-thermal-ops/SKILL.md
+++ b/plugins/dgx-spark-ops/skills/spark-memory-thermal-ops/SKILL.md
@@ -33,19 +33,14 @@ the job starts.
 - Sizing a training run against the 128GB pool
   before launch — will this model, method, and
   batch/pack combination fit.
-
 - A run OOMs mid-load or mid-step and the
   remediation order matters — what to try first,
   second, third.
-
 - Watching temperature and power during a
-  multi-hour job, and deciding whether a
-  slowdown is thermal throttling or something
-  else.
-
+  multi-hour job, deciding whether a slowdown is
+  thermal throttling or something else.
 - Planning to run a trainer alongside an
-  inference server (vLLM, Ollama) on the same
-  box.
+  inference server (vLLM, Ollama) on the same box.
 
 ## UMA Memory Model
 
@@ -53,12 +48,17 @@ Spark has no separate GPU VRAM — the GPU and
 CPU share one 128GB pool. Two consequences:
 
 - **`nvidia-smi` and `cudaMemGetInfo`
-  underreport pressure.** Both report
-  CUDA-allocator-visible memory, not the pool's
-  actual state — a box can show headroom in
-  `nvidia-smi` and still OOM, because page-cache
-  and mmap'd pages the allocator doesn't see
-  consume the same pool.
+  underreport pressure — or report nothing at
+  all.** Both report CUDA-allocator-visible
+  memory, not the pool's actual state — a box can
+  show headroom in `nvidia-smi` and still OOM,
+  because page-cache and mmap'd pages the
+  allocator doesn't see consume the same pool. On
+  some driver/setups, the memory query returns
+  `[N/A], [N/A]` outright instead of a number — a
+  script grepping for a numeric value there gets
+  nothing, not a misleading undercount (see
+  `spark-training-gotchas` gotcha G3).
 
 - **Model load is a transient peak, not the
   steady state.** Loading safetensors weights
@@ -77,9 +77,9 @@ Plan and diagnose with `free -g`, not
 free -g | awk 'NR==2 {print "free:", $4, "GB"}'
 ```
 
-Rule of thumb: take that free figure, subtract
-a few GB for OS/driver overhead, and budget
-against the result — not the 128GB spec number.
+Rule of thumb: take that free figure, subtract a
+few GB for OS/driver overhead, and budget against
+the result — not the 128GB spec number.
 The worksheet in `references/uma-accounting.md`
 accepts parameter count, dtype, and method as
 input, and returns a memory estimate to compare
@@ -113,10 +113,9 @@ total_gb = weights_gb + adapter_gb   # + activations
 print(f"{total_gb:.0f}GB before activations")
 ```
 
-Weights alone land near the ≈40GB anchor — a
-plan estimating far above that for the same
-model class is a signal to recheck dtype and
-method, not just add headroom.
+Weights alone land near the ≈40GB anchor — a plan
+estimating far above that for the same model
+class is a signal to recheck dtype and method.
 
 ## The OOM Ladder
 
@@ -142,22 +141,20 @@ than the last — don't skip ahead:
 
 2. **Reduce batch size or packing length.** Only
    after a flush fails to free enough headroom,
-   cut the batch size or packing length — the
-   first step that changes what the run does.
-   Prefer packing length first; it drives the
-   activation footprint more directly at long
-   context.
+   cut batch size or packing length — the first
+   step that changes what the run does. Prefer
+   packing length first; it drives activation
+   footprint more directly at long context.
 
 3. **Downgrade the method: bf16 LoRA before
    QLoRA.** If flushing and shrinking batch/pack
-   still OOM, drop the method down a tier — bf16
-   LoRA is next, not the reverse. QLoRA's
-   bitsandbytes dequantization buffers are
-   transient CUDA-side allocations that can OOM
-   before an equivalent bf16 LoRA run would,
-   even though QLoRA's steady-state footprint is
-   smaller. A QLoRA OOM is not proof the model
-   doesn't fit — try bf16 LoRA first.
+   still OOM, drop the method a tier — bf16 LoRA
+   is next, not the reverse. QLoRA's bitsandbytes
+   dequantization buffers are transient CUDA-side
+   allocations that can OOM before an equivalent
+   bf16 LoRA run would, even though QLoRA's
+   steady-state footprint is smaller. A QLoRA OOM
+   is not proof the model doesn't fit.
 
 Fall back further (smaller model, multi-Spark)
 only after all three steps and the job still
@@ -190,13 +187,12 @@ explain away:
   signature to recognize.
 
 - Log throttle events explicitly instead of
-  letting a run silently slow down without
-  record. A run whose per-step time doubles two
-  hours in should show that in the log,
-  correlated against the thermal sample at that
-  timestamp. Full throttling diagnostics and
-  the reboot failure mode:
-  `spark-training-gotchas` (gotcha G4).
+  letting a run silently slow down unrecorded. A
+  run whose per-step time doubles two hours in
+  should show that in the log, correlated against
+  the thermal sample at that timestamp. Full
+  throttling diagnostics: `spark-training-gotchas`
+  (gotcha G4).
 
 ## Concurrent Workloads
 
@@ -204,15 +200,20 @@ Because the 128GB pool is global, eviction
 happens without either process's logs showing
 an OOM:
 
-- Run one memory-heavy job at a time. A trainer
-  and an inference server (vLLM, Ollama) compete
-  for the same pool.
+- The one-heavy-job rule applies to **uncapped or
+  near-capacity** workloads — an uncapped trainer
+  and inference server (vLLM, Ollama) compete for
+  the same pool. A small, capped workload doesn't:
+  a <4GB LoRA fine-tune coexists fine alongside
+  vLLM capped at `gpu-memory-utilization<=0.5` —
+  check the other process's cap, not just its
+  presence, before stopping it.
 
 - Inference servers evict trainer pages silently
-  under contention, and vice versa — neither
-  logs an error, so a mysteriously slow run or a
-  lost KV cache is a contention symptom to check
-  for. Stop unrelated GPU-resident servers
+  under uncapped/near-capacity contention, and
+  vice versa — neither logs an error, so a slow
+  run or lost KV cache is a contention symptom to
+  check for. Stop unrelated *uncapped* servers
   before a long or full-pool run.
 
 Check for GPU-resident processes first:
@@ -221,11 +222,9 @@ Check for GPU-resident processes first:
 ps aux | grep -E 'vllm|ollama|trl|axolotl' | grep -v grep
 ```
 
-This procedure complements
-`plugins/dgx-spark-ops/skills/spark-training-gotchas/SKILL.md`
-(gotchas G3, G4, G6) — that skill covers
-launch-time failures; this one, the running
-job.
+This procedure complements `spark-training-gotchas`
+(gotchas G3, G4, G6) — that skill covers launch-time
+failures; this one, the running job.
 
 Memory math worksheets:
 `references/uma-accounting.md`.

--- a/plugins/dgx-spark-ops/skills/spark-memory-thermal-ops/assets/thermal-sample.sh
+++ b/plugins/dgx-spark-ops/skills/spark-memory-thermal-ops/assets/thermal-sample.sh
@@ -10,9 +10,17 @@ command -v nvidia-smi >/dev/null || { echo "nvidia-smi not found" >&2; exit 1; }
 
 INTERVAL="${1:-30}"
 LOGFILE="${2:-thermal.log}"
+PIDFILE="${LOGFILE}.pid"
+
+if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
+  echo "Stopping existing sampler (pid $(cat "$PIDFILE"))"
+  kill "$(cat "$PIDFILE")"
+fi
 
 echo "timestamp,temperature.gpu,power.draw" > "$LOGFILE"
 nvidia-smi --query-gpu=timestamp,temperature.gpu,power.draw \
   --format=csv,noheader -l "$INTERVAL" >> "$LOGFILE" &
-echo "Sampling every ${INTERVAL}s into ${LOGFILE} (pid $!)"
+PID=$!
+echo "$PID" > "$PIDFILE"
+echo "Sampling every ${INTERVAL}s into ${LOGFILE} (pid $PID)"
 echo "A sustained ~100W reading is the platform cap, not a bug — see SKILL.md Thermal Monitoring."

--- a/plugins/dgx-spark-ops/skills/spark-memory-thermal-ops/assets/thermal-sample.sh
+++ b/plugins/dgx-spark-ops/skills/spark-memory-thermal-ops/assets/thermal-sample.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Background thermal/power sampler for a long training run.
+# Output contract: CSV, one line per sample, matching
+# `nvidia-smi --query-gpu` field order — pipe-compatible with
+# the training log for later correlation by timestamp.
+# Usage: bash thermal-sample.sh [interval_seconds] [logfile]
+set -uo pipefail
+
+INTERVAL="${1:-30}"
+LOGFILE="${2:-thermal.log}"
+
+echo "timestamp,temperature.gpu,power.draw" > "$LOGFILE"
+nvidia-smi --query-gpu=timestamp,temperature.gpu,power.draw \
+  --format=csv,noheader -l "$INTERVAL" >> "$LOGFILE" &
+echo "Sampling every ${INTERVAL}s into ${LOGFILE} (pid $!)"
+echo "A sustained ~100W reading is the platform cap, not a bug — see SKILL.md Thermal Monitoring."

--- a/plugins/dgx-spark-ops/skills/spark-memory-thermal-ops/assets/thermal-sample.sh
+++ b/plugins/dgx-spark-ops/skills/spark-memory-thermal-ops/assets/thermal-sample.sh
@@ -6,6 +6,8 @@
 # Usage: bash thermal-sample.sh [interval_seconds] [logfile]
 set -uo pipefail
 
+command -v nvidia-smi >/dev/null || { echo "nvidia-smi not found" >&2; exit 1; }
+
 INTERVAL="${1:-30}"
 LOGFILE="${2:-thermal.log}"
 

--- a/plugins/dgx-spark-ops/skills/spark-memory-thermal-ops/references/uma-accounting.md
+++ b/plugins/dgx-spark-ops/skills/spark-memory-thermal-ops/references/uma-accounting.md
@@ -89,7 +89,7 @@ plan against rather than trusting the formula in isolation:
 | Model class | Method | Observed total | Notes |
 |---|---|---|---|
 | 70B | QLoRA | ≈40GB | 30–48h for 3 epochs; the reference point for "70B fits via QLoRA, not bf16." |
-| gpt-oss-120b (100B+ MoE) | NVFP4-native LoRA | ≈68GB (per Unsloth's official DGX Spark tutorial, unsloth.ai docs, 2025-12) | Community recipe (`nvfp4-lora-spark`); experimental, not the default assumption for other 100B+ MoE models. |
+| a ~120B-class MoE model | NVFP4-native LoRA | ≈68GB (per Unsloth's official DGX Spark tutorial, unsloth.ai docs, 2025-12) | Community recipe (`nvfp4-lora-spark`); experimental, not the default assumption for other 100B+ MoE models. |
 | 27B | LoRA | fits at pack ≤1024 | The LoRA ceiling on a single Spark — larger dense models need multi-Spark or a smaller method. |
 | 9B | Full fine-tune | fits comfortably | The full-FT ceiling — above this, full FT needs LoRA/QLoRA or multi-Spark instead. |
 

--- a/plugins/dgx-spark-ops/skills/spark-memory-thermal-ops/references/uma-accounting.md
+++ b/plugins/dgx-spark-ops/skills/spark-memory-thermal-ops/references/uma-accounting.md
@@ -1,0 +1,102 @@
+Last verified: 2026-07-13 — refresh when a new model-size anchor is
+validated on Spark or the DGX Spark playbooks change quantization
+defaults.
+
+# UMA Memory Accounting
+
+A worksheet for estimating whether a model/method/batch combination
+fits DGX Spark's 128GB unified pool before a run, and for sanity
+checking a plan against known-working anchors. This is planning
+math, not a guarantee — always leave headroom rather than sizing to
+the byte; see the OOM Ladder in `SKILL.md` for what to do when the
+estimate turns out optimistic.
+
+## The Four Terms
+
+Total footprint ≈ **weights + optimizer states + gradients +
+activations**, plus a near-zero term for LoRA/QLoRA adapters. Work
+each term from parameter count and dtype, then sum.
+
+### 1. Weights
+
+`params × bytes/param`, by dtype:
+
+| dtype | bytes/param |
+|---|---|
+| fp32 | 4 |
+| bf16 / fp16 | 2 |
+| int8 | 1 |
+| int4 (QLoRA NF4) | 0.5 |
+
+A 70B model in bf16 is ~140GB — already over the pool before
+anything else loads. The same model in 4-bit (QLoRA) is ~35GB,
+which is why QLoRA, not bf16, is what makes 70B-class models
+reachable on Spark at all.
+
+### 2. Optimizer states
+
+Full fine-tuning carries optimizer state for every trainable
+parameter; LoRA and QLoRA carry it only for the adapter parameters,
+which is why this term is negligible for them regardless of base
+model size.
+
+| Optimizer | bytes/param (trainable only) |
+|---|---|
+| AdamW, fp32 states | 8 (4B momentum + 4B variance) |
+| AdamW 8-bit (bitsandbytes) | ≈2 (quantized momentum + variance) |
+
+`adamw_8bit` is the Unsloth default for a reason on a 128GB
+box — the fp32 variant roughly quadruples this term for any run
+that isn't LoRA/QLoRA-adapter-only.
+
+### 3. Gradients
+
+Same dtype as the compute precision — typically bf16, so 2
+bytes/param — and, like optimizer state, only for trainable
+parameters. Full fine-tuning pays this for every weight; LoRA and
+QLoRA pay it only for the adapter, since the frozen base weights
+never accumulate a gradient.
+
+### 4. Activations
+
+The hardest term to pin to a single number — it scales with batch
+size, sequence/packing length, and architecture (attention variant,
+hidden size, layer count), not just parameter count. Two levers
+matter more than exact estimation:
+
+- **Gradient checkpointing** trades recompute for memory: expect
+  roughly **30% savings** on this term versus no checkpointing, at
+  the cost of a recompute pass per checkpointed segment. Unsloth's
+  `use_gradient_checkpointing="unsloth"` is the default for this
+  reason.
+- Packing/sequence length is the more direct lever than batch size
+  for this term — see the OOM Ladder in `SKILL.md` for why packing
+  length is the preferred first cut over batch size.
+
+### 5. LoRA/QLoRA adapter overhead
+
+A rank-`r` adapter on a linear layer adds `2 × r × (in + out)`
+parameters. At the rank sizes in normal use (1–32 for RL, up to
+~256 for SFT-at-scale), this is a small fraction of a percent of
+base model size — round it to zero in the worksheet unless an
+unusually high rank is in play.
+
+## Anchors
+
+Known-working combinations on a single Spark, to sanity check a new
+plan against rather than trusting the formula in isolation:
+
+| Model class | Method | Observed total | Notes |
+|---|---|---|---|
+| 70B | QLoRA | ≈40GB | 30–48h for 3 epochs; the reference point for "70B fits via QLoRA, not bf16." |
+| gpt-oss-120b (100B+ MoE) | NVFP4-native LoRA | ≈68GB | Community recipe (`nvfp4-lora-spark`); experimental, not the default assumption for other 100B+ MoE models. |
+| 27B | LoRA | fits at pack ≤1024 | The LoRA ceiling on a single Spark — larger dense models need multi-Spark or a smaller method. |
+| 9B | Full fine-tune | fits comfortably | The full-FT ceiling — above this, full FT needs LoRA/QLoRA or multi-Spark instead. |
+
+Treat "ceiling" entries as the largest class that fit in practice,
+not a hard architectural limit — a smaller batch, shorter packing,
+or a leaner optimizer can sometimes push slightly past one of these,
+and a heavier configuration of the same model class can fail well
+under it. Re-derive from the four terms above for anything outside
+these four reference points, and confirm with the OOM Ladder in
+`SKILL.md` if the estimate turns out optimistic.

--- a/plugins/dgx-spark-ops/skills/spark-memory-thermal-ops/references/uma-accounting.md
+++ b/plugins/dgx-spark-ops/skills/spark-memory-thermal-ops/references/uma-accounting.md
@@ -75,11 +75,12 @@ matter more than exact estimation:
 
 ### 5. LoRA/QLoRA adapter overhead
 
-A rank-`r` adapter on a linear layer adds `2 × r × (in + out)`
-parameters. At the rank sizes in normal use (1–32 for RL, up to
-~256 for SFT-at-scale), this is a small fraction of a percent of
-base model size — round it to zero in the worksheet unless an
-unusually high rank is in play.
+A rank-`r` adapter on a linear layer adds `r × (in + out)`
+parameters — `A` is `r×in` and `B` is `out×r`, so the two
+matrices together contribute `r·in + r·out`. At the rank sizes in
+normal use (1–32 for RL, up to ~256 for SFT-at-scale), this is a
+small fraction of a percent of base model size — round it to zero
+in the worksheet unless an unusually high rank is in play.
 
 ## Anchors
 

--- a/plugins/dgx-spark-ops/skills/spark-memory-thermal-ops/references/uma-accounting.md
+++ b/plugins/dgx-spark-ops/skills/spark-memory-thermal-ops/references/uma-accounting.md
@@ -89,7 +89,7 @@ plan against rather than trusting the formula in isolation:
 | Model class | Method | Observed total | Notes |
 |---|---|---|---|
 | 70B | QLoRA | ≈40GB | 30–48h for 3 epochs; the reference point for "70B fits via QLoRA, not bf16." |
-| gpt-oss-120b (100B+ MoE) | NVFP4-native LoRA | ≈68GB | Community recipe (`nvfp4-lora-spark`); experimental, not the default assumption for other 100B+ MoE models. |
+| gpt-oss-120b (100B+ MoE) | NVFP4-native LoRA | ≈68GB (per Unsloth's official DGX Spark tutorial, unsloth.ai docs, 2025-12) | Community recipe (`nvfp4-lora-spark`); experimental, not the default assumption for other 100B+ MoE models. |
 | 27B | LoRA | fits at pack ≤1024 | The LoRA ceiling on a single Spark — larger dense models need multi-Spark or a smaller method. |
 | 9B | Full fine-tune | fits comfortably | The full-FT ceiling — above this, full FT needs LoRA/QLoRA or multi-Spark instead. |
 

--- a/plugins/dgx-spark-ops/skills/spark-training-gotchas/SKILL.md
+++ b/plugins/dgx-spark-ops/skills/spark-training-gotchas/SKILL.md
@@ -197,7 +197,7 @@ import torch; print(torch.cuda.get_device_capability())  # expect (12, 1) (G7)
 ```
 
 ```bash
-grep -qi docker /proc/1/cgroup && echo container || echo bare-host  # G9
+{ [ -f /.dockerenv -o -f /run/.containerenv ] || grep -qE 'docker|containerd' /proc/1/cgroup; } 2>/dev/null && echo container || echo unknown  # G9
 ```
 
 `assets/preflight.sh` runs G1, G3, G4, G7, G9. Every result

--- a/plugins/dgx-spark-ops/skills/spark-training-gotchas/SKILL.md
+++ b/plugins/dgx-spark-ops/skills/spark-training-gotchas/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: spark-training-gotchas
+description: Preflight and diagnose the ten known failure modes for ML training on NVIDIA DGX Spark. Use when a training run on DGX Spark fails to start, OOMs below the 128GB limit, slows down mid-run, or before launching any multi-hour training job on GB10 hardware.
+---
+
+# Spark Training Gotchas
+
+DGX Spark's GB10 chip (Grace Blackwell, SM121, 128GB unified
+memory, aarch64) has ten recurring failure modes across
+launch, memory, thermals, bandwidth, and precision. Each is
+named G1–G10 so it can be checked by number — the numbering
+is load-bearing for tooling that runs these checks. Read this
+before a long run, not after it fails at hour six.
+
+## When to Use This Skill
+
+- A training run fails to start, with an import error or a
+  segfault that doesn't point at the real cause.
+- A run OOMs while `nvidia-smi` still shows headroom under
+  the 128GB unified-memory ceiling.
+- Throughput degrades partway through a run that started
+  fine.
+- Before any multi-hour or multi-epoch job on GB10 — a
+  five-minute preflight beats hour six.
+- Wiring two Sparks together, before the parallelism
+  strategy is chosen.
+- Choosing between FP8 and NVFP4 for a Spark-hosted run.
+
+## Common Issues Quick Reference
+
+| # | Symptom | Fix |
+|---|---|---|
+| G1 | undefined symbol / segfault | cu130 wheel or container |
+| G2 | flash-attn build fails | skip it; use SDPA |
+| G3 | OOM despite headroom | drop page cache |
+| G4 | throughput drop / reboot | expect ~100W sustained cap |
+| G5 | memory-bound step slow | budget 180–192 GB/s |
+| G6 | cache evicted mid-run | one GPU server at a time |
+| G7 | NVFP4 slower than FP8 | stay FP8 unless `sm_121a` |
+| G8 | playbook fails outright | check upstream issues |
+| G9 | env breaks after install | use a container |
+| G10 | 2-Spark TP hangs | DDP/FSDP only, never TP |
+
+## The Ten Gotchas
+
+### G1: CUDA 12/13 ABI Mismatch
+
+- **SYMPTOM:** `ImportError: undefined symbol` naming a CUDA
+  function, or a segfault on the first `.cuda()`
+  call with no useful traceback.
+- **CAUSE:** most wheels on PyPI link against
+  `libcudart.so.12`; Spark ships CUDA 13. pip
+  never checks CUDA ABI, so it surfaces only at
+  import or first kernel launch.
+- **CHECK:** `references/gotcha-checks.md` G1 — the wheel's
+  CUDA build tag.
+- **FIX:** reinstall from
+  `download.pytorch.org/whl/cu130` or use a
+  matched container.
+
+### G2: flash-attn Absent
+
+- **SYMPTOM:** `flash-attn` fails to build, or builds but
+  hangs or crashes on the first attention call.
+- **CAUSE:** no published sm_121 kernels for flash-attn on
+  GB10 as of this writing.
+- **CHECK:** `references/gotcha-checks.md` G2 — no flash-attn
+  import in the training path.
+- **FIX:** skip flash-attn; use PyTorch's built-in SDPA
+  backend — faster here anyway.
+
+### G3: UMA OOM Below 128GB
+
+- **SYMPTOM:** OOM during model load or training while
+  `nvidia-smi` still reports free memory under
+  the 128GB unified-memory cap.
+- **CAUSE:** mmap and the CUDA allocator double-count pages
+  during safetensors load, understating true
+  pressure; QLoRA can OOM *earlier* than bf16
+  since dequantization adds transient allocations.
+- **CHECK:** `references/gotcha-checks.md` G3 — read `free -g`
+  and `/proc/meminfo`, not `nvidia-smi`.
+- **FIX:** drop the page cache with
+  `sync; echo 3 > /proc/sys/vm/drop_caches`. Needs
+  root and flushes cache system-wide — a
+  between-run reset, not a mid-training step.
+
+### G4: Thermal Throttling
+
+- **SYMPTOM:** throughput drops partway through a multi-hour
+  run, or the box spontaneously reboots under
+  sustained load.
+- **CAUSE:** sustained power draw caps around 100W versus
+  the 240W rated figure; multi-hour runs push
+  into that ceiling and throttle or, sometimes,
+  reboot.
+- **CHECK:** `references/gotcha-checks.md` G4 — sample
+  `nvidia-smi --query-gpu=temperature.gpu,power.draw`
+  over a long run.
+- **FIX:** if power plateaus under 240W while temperature
+  climbs, treat throttling as the cause; improve
+  cooling or cap run length.
+
+### G5: Bandwidth Ceiling
+
+- **SYMPTOM:** memory-bound workloads, decode-heavy RL loops
+  especially, plateau well below expected
+  throughput.
+- **CAUSE:** the 273 GB/s figure is a spec ceiling, not
+  sustained; measured bandwidth runs 180–192 GB/s.
+- **CHECK:** `references/gotcha-checks.md` G5 — observed step
+  time vs. the measured range, not spec.
+- **FIX:** budget throughput from 180–192 GB/s; revise a
+  plan built on the 273 GB/s figure.
+
+### G6: Global UMA Resource Contention
+
+- **SYMPTOM:** a training or inference process's KV cache or
+  weights get silently evicted mid-run, with no
+  OOM in that process's own logs.
+- **CAUSE:** unified memory is one global pool; concurrent
+  processes (e.g. vLLM and Ollama side by side)
+  compete for it and can evict each other.
+- **CHECK:** `references/gotcha-checks.md` G6 — other
+  GPU-resident processes before a long run.
+- **FIX:** run one GPU-resident server at a time; stop
+  unrelated servers before a full-pool run.
+
+### G7: NVFP4 Slower Than FP8 on SM121
+
+- **SYMPTOM:** switching an inference workload from FP8 to
+  NVFP4 on Spark makes it slower, not faster.
+- **CAUSE:** SM121 lacks a native `cvt.e2m1x2` path unless
+  kernels target `sm_121a`; without that, NVFP4
+  runs ~32% slower than FP8 here.
+- **CHECK:** `references/gotcha-checks.md` G7 — capability
+  reports `(12, 1)`; does the build target `sm_121a`?
+- **FIX:** stay on FP8 unless the build explicitly targets
+  `sm_121a`.
+
+### G8: Stale Official Playbooks
+
+- **SYMPTOM:** following an official DGX Spark playbook step
+  by step still fails, with no local
+  misconfiguration explaining it.
+- **CAUSE:** official playbooks have shipped broken before;
+  the stack moves faster than the docs.
+- **CHECK:** `references/gotcha-checks.md` G8 — the playbook
+  repo's recent issues.
+- **FIX:** check `github.com/NVIDIA/dgx-spark-playbooks`
+  issues before trusting a recipe for an
+  expensive run.
+
+### G9: Container-First, Not Bare Pip
+
+- **SYMPTOM:** a bare-pip environment that worked yesterday
+  breaks after an unrelated `pip install`, or
+  two "identical" environments behave
+  differently.
+- **CAUSE:** bare pip lets Triton, xformers, and
+  transformers versions drift independently;
+  nothing pins them to GB10's SM121 target the
+  way a container does.
+- **CHECK:** `references/gotcha-checks.md` G9 — is the
+  environment container-based or bare pip?
+- **FIX:** prefer an NGC
+  (`nvcr.io/nvidia/pytorch:25.11-py3`) or Unsloth
+  container. If bare pip is unavoidable, follow
+  the NVIDIA install order, including `--no-deps`
+  on the Unsloth line.
+
+### G10: Dual-Spark Is DDP/FSDP Only
+
+- **SYMPTOM:** a tensor-parallel launch across two Sparks
+  hangs, runs far slower than single-Spark, or
+  errors out.
+- **CAUSE:** the ConnectX-7 link is fast enough for
+  gradient/parameter sync (DDP, FSDP) but too
+  thin for the fine-grained traffic tensor
+  parallelism requires.
+- **CHECK:** `references/gotcha-checks.md` G10 — the
+  configured parallelism strategy.
+- **FIX:** on a two-Spark setup, choose DDP or FSDP and
+  never tensor parallelism — TP is single-node
+  only here.
+
+## Fast Triage
+
+The cheapest checks to run before anything else:
+
+```bash
+pip show torch | grep -i version  # expect cu130 (G1)
+```
+
+```python
+import torch; print(torch.cuda.get_device_capability())  # expect (12, 1) (G7)
+```
+
+```bash
+grep -qi docker /proc/1/cgroup && echo container || echo bare-host  # G9
+```
+
+`assets/preflight.sh` automates the checks that don't need
+judgment (G1, G3, G4, G7, G9) and produces a G-number pass/fail
+output format — the same shape `/spark-preflight` will use once
+that command ships. Full commands and interpretation notes for
+every gotcha: `references/gotcha-checks.md`. See also
+`plugins/dgx-spark-ops/skills/spark-environment-setup/SKILL.md`
+for the environment these gotchas assume is already working.

--- a/plugins/dgx-spark-ops/skills/spark-training-gotchas/SKILL.md
+++ b/plugins/dgx-spark-ops/skills/spark-training-gotchas/SKILL.md
@@ -189,7 +189,7 @@ before a long run, not after it fails at hour six.
 The cheapest checks to run before anything else:
 
 ```bash
-pip show torch | grep -i version  # expect cu130 (G1)
+python3 -c "import torch; print(torch.version.cuda)"  # expect 13.x (G1); NGC containers build torch internally against CUDA 13 with no +cu130 wheel tag, so an absent cu130 tag in `pip show` is not itself a failure
 ```
 
 ```python

--- a/plugins/dgx-spark-ops/skills/spark-training-gotchas/SKILL.md
+++ b/plugins/dgx-spark-ops/skills/spark-training-gotchas/SKILL.md
@@ -202,8 +202,9 @@ grep -qi docker /proc/1/cgroup && echo container || echo bare-host  # G9
 
 `assets/preflight.sh` runs G1, G3, G4, G7, G9. Every result
 line starts with its G-number — the output format
-`/spark-preflight` will parse: PASS/FAIL where automatable
-(G1, G7, G9), `INFO:` raw readings for judgment (G3, G4).
+`/spark-preflight` will parse: PASS/FAIL/WARN verdicts where
+automatable (G1, G7, G9), SKIP when a tool is unavailable,
+`INFO:` raw readings for judgment (G3, G4).
 Full commands and interpretation notes per gotcha:
 `references/gotcha-checks.md`. See also
 `plugins/dgx-spark-ops/skills/spark-environment-setup/SKILL.md`

--- a/plugins/dgx-spark-ops/skills/spark-training-gotchas/SKILL.md
+++ b/plugins/dgx-spark-ops/skills/spark-training-gotchas/SKILL.md
@@ -200,10 +200,11 @@ import torch; print(torch.cuda.get_device_capability())  # expect (12, 1) (G7)
 grep -qi docker /proc/1/cgroup && echo container || echo bare-host  # G9
 ```
 
-`assets/preflight.sh` automates the checks that don't need
-judgment (G1, G3, G4, G7, G9) and produces a G-number pass/fail
-output format — the same shape `/spark-preflight` will use once
-that command ships. Full commands and interpretation notes for
-every gotcha: `references/gotcha-checks.md`. See also
+`assets/preflight.sh` runs G1, G3, G4, G7, G9. Every result
+line starts with its G-number — the output format
+`/spark-preflight` will parse: PASS/FAIL where automatable
+(G1, G7, G9), `INFO:` raw readings for judgment (G3, G4).
+Full commands and interpretation notes per gotcha:
+`references/gotcha-checks.md`. See also
 `plugins/dgx-spark-ops/skills/spark-environment-setup/SKILL.md`
 for the environment these gotchas assume is already working.

--- a/plugins/dgx-spark-ops/skills/spark-training-gotchas/SKILL.md
+++ b/plugins/dgx-spark-ops/skills/spark-training-gotchas/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spark-training-gotchas
-description: Preflight and diagnose the ten known failure modes for ML training on NVIDIA DGX Spark. Use when a training run on DGX Spark fails to start, OOMs below the 128GB limit, slows down mid-run, or before launching any multi-hour training job on GB10 hardware.
+description: Preflight and diagnose the ten known failure modes for ML training on NVIDIA DGX Spark. Use when a training run on DGX Spark fails to start, OOMs below the 128GB limit, slows down mid-run, or before any multi-hour training job on GB10.
 ---
 
 # Spark Training Gotchas
@@ -10,20 +10,17 @@ memory, aarch64) has ten recurring failure modes across
 launch, memory, thermals, bandwidth, and precision. Each is
 named G1–G10 so it can be checked by number — the numbering
 is load-bearing for tooling that runs these checks. Read this
-before a long run, not after it fails at hour six.
+before a long run, not after hour six.
 
 ## When to Use This Skill
 
 - A training run fails to start, with an import error or a
   segfault that doesn't point at the real cause.
-- A run OOMs while `nvidia-smi` still shows headroom under
-  the 128GB unified-memory ceiling.
-- Throughput degrades partway through a run that started
-  fine.
-- Before any multi-hour or multi-epoch job on GB10 — a
-  five-minute preflight beats hour six.
-- Wiring two Sparks together, before the parallelism
-  strategy is chosen.
+- A run OOMs while `nvidia-smi` still shows headroom.
+- Throughput degrades partway through a run that started fine.
+- Before any multi-hour or multi-epoch job on GB10.
+- Wiring two Sparks together, before picking a parallelism
+  strategy.
 - Choosing between FP8 and NVFP4 for a Spark-hosted run.
 
 ## Common Issues Quick Reference
@@ -31,7 +28,7 @@ before a long run, not after it fails at hour six.
 | # | Symptom | Fix |
 |---|---|---|
 | G1 | undefined symbol / segfault | cu130 wheel or container |
-| G2 | flash-attn build fails | skip it; use SDPA |
+| G2 | flash-attn wrong backend used | skip pip build; monkeypatch on NGC |
 | G3 | OOM despite headroom | drop page cache |
 | G4 | throughput drop / reboot | expect ~100W sustained cap |
 | G5 | memory-bound step slow | budget 180–192 GB/s |
@@ -46,150 +43,145 @@ before a long run, not after it fails at hour six.
 ### G1: CUDA 12/13 ABI Mismatch
 
 - **SYMPTOM:** `ImportError: undefined symbol` naming a CUDA
-  function, or a segfault on the first `.cuda()`
-  call with no useful traceback.
-- **CAUSE:** most wheels on PyPI link against
-  `libcudart.so.12`; Spark ships CUDA 13. pip
-  never checks CUDA ABI, so it surfaces only at
-  import or first kernel launch.
+  function, or a segfault on the first `.cuda()` call.
+- **CAUSE:** most PyPI wheels link `libcudart.so.12`; Spark
+  ships CUDA 13. pip never checks CUDA ABI, so it surfaces
+  only at import or first kernel launch.
 - **CHECK:** `references/gotcha-checks.md` G1 — the wheel's
   CUDA build tag.
-- **FIX:** reinstall from
-  `download.pytorch.org/whl/cu130` or use a
-  matched container.
+- **FIX:** reinstall from `download.pytorch.org/whl/cu130` or
+  use a matched container.
 
-### G2: flash-attn Absent
+### G2: flash-attn — Skip the pip Build, Watch Unsloth's Auto-Detect
 
-- **SYMPTOM:** `flash-attn` fails to build, or builds but
-  hangs or crashes on the first attention call.
-- **CAUSE:** no published sm_121 kernels for flash-attn on
-  GB10 as of this writing.
-- **CHECK:** `references/gotcha-checks.md` G2 — no flash-attn
-  import in the training path.
-- **FIX:** skip flash-attn; use PyTorch's built-in SDPA
-  backend — faster here anyway.
+- **SYMPTOM:** `pip install flash-attn` still fails/hangs.
+  Unsloth may also silently train flash-attn over an
+  explicitly requested SDPA.
+- **CAUSE:** no aarch64/sm_121 wheel for bare pip — but NGC
+  containers ship a working SM121 flash-attn, and Unsloth
+  auto-prefers it, dropping `attn_implementation="sdpa"`.
+- **CHECK:** `references/gotcha-checks.md` G2 — is flash-attn
+  already present and working.
+- **FIX:** bare pip — skip flash-attn, use SDPA (unchanged). On
+  NGC — the only reliable override is the monkeypatch in
+  `references/gotcha-checks.md` G2.
 
 ### G3: UMA OOM Below 128GB
 
-- **SYMPTOM:** OOM during model load or training while
-  `nvidia-smi` still reports free memory under
-  the 128GB unified-memory cap.
+- **SYMPTOM:** OOM during model load/training while
+  `nvidia-smi` still reports free memory under the 128GB cap
+  — or, on some setups, `[N/A]` outright instead of a number.
 - **CAUSE:** mmap and the CUDA allocator double-count pages
-  during safetensors load, understating true
-  pressure; QLoRA can OOM *earlier* than bf16
-  since dequantization adds transient allocations.
+  during safetensors load; QLoRA can OOM *earlier* than bf16
+  since dequantization adds transient allocs.
 - **CHECK:** `references/gotcha-checks.md` G3 — read `free -g`
   and `/proc/meminfo`, not `nvidia-smi`.
 - **FIX:** drop the page cache with
-  `sync; echo 3 > /proc/sys/vm/drop_caches`. Needs
-  root and flushes cache system-wide — a
+  `sync; echo 3 > /proc/sys/vm/drop_caches` — needs root, a
   between-run reset, not a mid-training step.
 
 ### G4: Thermal Throttling
 
 - **SYMPTOM:** throughput drops partway through a multi-hour
-  run, or the box spontaneously reboots under
-  sustained load.
-- **CAUSE:** sustained power draw caps around 100W versus
-  the 240W rated figure; multi-hour runs push
-  into that ceiling and throttle or, sometimes,
-  reboot.
+  run, or the box spontaneously reboots under sustained load.
+- **CAUSE:** sustained power draw caps around 100W versus the
+  240W rated figure; long runs push into that ceiling and
+  throttle or, sometimes, reboot.
 - **CHECK:** `references/gotcha-checks.md` G4 — sample
-  `nvidia-smi --query-gpu=temperature.gpu,power.draw`
-  over a long run.
+  `nvidia-smi --query-gpu=temperature.gpu,power.draw`.
 - **FIX:** if power plateaus under 240W while temperature
-  climbs, treat throttling as the cause; improve
-  cooling or cap run length.
+  climbs, treat throttling as the cause; improve cooling or
+  cap run length.
 
 ### G5: Bandwidth Ceiling
 
 - **SYMPTOM:** memory-bound workloads, decode-heavy RL loops
-  especially, plateau well below expected
-  throughput.
-- **CAUSE:** the 273 GB/s figure is a spec ceiling, not
-  sustained; measured bandwidth runs 180–192 GB/s.
+  especially, plateau well below expected throughput.
+- **CAUSE:** 273 GB/s is a spec ceiling, not sustained;
+  measured bandwidth runs 180–192 GB/s.
 - **CHECK:** `references/gotcha-checks.md` G5 — observed step
   time vs. the measured range, not spec.
-- **FIX:** budget throughput from 180–192 GB/s; revise a
-  plan built on the 273 GB/s figure.
+- **FIX:** budget throughput from 180–192 GB/s; revise a plan
+  built on the 273 GB/s figure.
 
 ### G6: Global UMA Resource Contention
 
-- **SYMPTOM:** a training or inference process's KV cache or
-  weights get silently evicted mid-run, with no
-  OOM in that process's own logs.
-- **CAUSE:** unified memory is one global pool; concurrent
-  processes (e.g. vLLM and Ollama side by side)
-  compete for it and can evict each other.
-- **CHECK:** `references/gotcha-checks.md` G6 — other
-  GPU-resident processes before a long run.
-- **FIX:** run one GPU-resident server at a time; stop
-  unrelated servers before a full-pool run.
+- **SYMPTOM:** a process's KV cache/weights get evicted
+  mid-run silently, no OOM in its own logs.
+- **CAUSE:** unified memory is
+  one global pool; an uncapped
+  or near-capacity process
+  competes with anything else
+  and can evict it. A small,
+  bounded workload doesn't — a
+  <4GB LoRA coexists fine
+  alongside vLLM capped at
+  `gpu-memory-utilization<=0.5`.
+- **CHECK:** `references/gotcha-checks.md`
+  G6 — other GPU-resident
+  processes and whether
+  capped.
+- **FIX:** the one-heavy-job
+  rule applies to **uncapped or
+  near-capacity** workloads —
+  cap or stop unrelated servers
+  first. A small, capped
+  workload need not
+  stop.
 
 ### G7: NVFP4 Slower Than FP8 on SM121
 
 - **SYMPTOM:** switching an inference workload from FP8 to
   NVFP4 on Spark makes it slower, not faster.
-- **CAUSE:** SM121 lacks a native `cvt.e2m1x2` path unless
-  kernels target `sm_121a`; without that, NVFP4
-  runs ~32% slower than FP8 here.
+- **CAUSE:** SM121 lacks `cvt.e2m1x2` unless kernels target
+  `sm_121a`; NVFP4 runs ~32% slower without it.
 - **CHECK:** `references/gotcha-checks.md` G7 — capability
   reports `(12, 1)`; does the build target `sm_121a`?
-- **FIX:** stay on FP8 unless the build explicitly targets
-  `sm_121a`.
+- **FIX:** stay on FP8 unless the build targets `sm_121a`.
 
 ### G8: Stale Official Playbooks
 
-- **SYMPTOM:** following an official DGX Spark playbook step
-  by step still fails, with no local
-  misconfiguration explaining it.
+- **SYMPTOM:** following an official DGX Spark playbook still
+  fails, with no local misconfiguration explaining it.
 - **CAUSE:** official playbooks have shipped broken before;
   the stack moves faster than the docs.
 - **CHECK:** `references/gotcha-checks.md` G8 — the playbook
   repo's recent issues.
-- **FIX:** check `github.com/NVIDIA/dgx-spark-playbooks`
-  issues before trusting a recipe for an
-  expensive run.
+- **FIX:** check `github.com/NVIDIA/dgx-spark-playbooks` issues
+  before trusting a recipe for an expensive run.
 
 ### G9: Container-First, Not Bare Pip
 
 - **SYMPTOM:** a bare-pip environment that worked yesterday
-  breaks after an unrelated `pip install`, or
-  two "identical" environments behave
-  differently.
-- **CAUSE:** bare pip lets Triton, xformers, and
-  transformers versions drift independently;
-  nothing pins them to GB10's SM121 target the
-  way a container does.
-- **CHECK:** `references/gotcha-checks.md` G9 — is the
-  environment container-based or bare pip?
-- **FIX:** prefer an NGC
-  (`nvcr.io/nvidia/pytorch:25.11-py3`) or Unsloth
-  container. If bare pip is unavoidable, follow
-  the NVIDIA install order, including `--no-deps`
-  on the Unsloth line.
+  breaks after an unrelated `pip install`, or two "identical"
+  environments behave differently.
+- **CAUSE:** bare pip lets Triton, xformers, and transformers
+  drift independently; nothing pins them to GB10's SM121
+  target.
+- **CHECK:** `references/gotcha-checks.md`
+  G9 — container or bare pip?
+- **FIX:** prefer an NGC container (see `spark-environment-setup`
+  for tag guidance) or Unsloth's container. If bare pip is
+  unavoidable, follow the NVIDIA install order, including
+  `--no-deps` on Unsloth.
 
 ### G10: Dual-Spark Is DDP/FSDP Only
 
 - **SYMPTOM:** a tensor-parallel launch across two Sparks
-  hangs, runs far slower than single-Spark, or
-  errors out.
-- **CAUSE:** the ConnectX-7 link is fast enough for
-  gradient/parameter sync (DDP, FSDP) but too
-  thin for the fine-grained traffic tensor
-  parallelism requires.
+  hangs, runs far slower than single-Spark, or errors out.
+- **CAUSE:** ConnectX-7 is fast enough for gradient/parameter
+  sync (DDP, FSDP) but too thin for TP's fine-grained traffic.
 - **CHECK:** `references/gotcha-checks.md` G10 — the
   configured parallelism strategy.
-- **FIX:** on a two-Spark setup, choose DDP or FSDP and
-  never tensor parallelism — TP is single-node
-  only here.
+- **FIX:** on a two-Spark setup, choose DDP or FSDP, never
+  tensor parallelism — TP is single-node only here.
 
 ## Fast Triage
 
 The cheapest checks to run before anything else:
 
 ```bash
-python3 -c "import torch; print(torch.version.cuda)"  # expect 13.x (G1); NGC containers build torch internally against CUDA 13 with no +cu130 wheel tag, so an absent cu130 tag in `pip show` is not itself a failure
+python3 -c "import torch; print(torch.version.cuda)"  # expect 13.x (G1); NGC builds have no +cu130 tag — that's not a failure
 ```
 
 ```python
@@ -200,12 +192,9 @@ import torch; print(torch.cuda.get_device_capability())  # expect (12, 1) (G7)
 { [ -f /.dockerenv -o -f /run/.containerenv ] || grep -qE 'docker|containerd' /proc/1/cgroup; } 2>/dev/null && echo container || echo unknown  # G9
 ```
 
-`assets/preflight.sh` runs G1, G3, G4, G7, G9. Every result
-line starts with its G-number — the output format
-`/spark-preflight` will parse: PASS/FAIL/WARN verdicts where
-automatable (G1, G7, G9), SKIP when a tool is unavailable,
-`INFO:` raw readings for judgment (G3, G4).
-Full commands and interpretation notes per gotcha:
+`assets/preflight.sh` runs G1, G3, G4, G7, G9 and produces one
+output line per gotcha in a fixed format: G-number first, then
+PASS/FAIL/WARN where automatable, SKIP when unavailable, or
+`INFO:` for a raw reading (G3, G4). Full commands:
 `references/gotcha-checks.md`. See also
-`plugins/dgx-spark-ops/skills/spark-environment-setup/SKILL.md`
-for the environment these gotchas assume is already working.
+`spark-environment-setup` for the environment assumed working.

--- a/plugins/dgx-spark-ops/skills/spark-training-gotchas/assets/preflight.sh
+++ b/plugins/dgx-spark-ops/skills/spark-training-gotchas/assets/preflight.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 # Fast, automatable subset of the G1-G10 checks in SKILL.md.
+# Output contract: every result line starts with its G-number.
+#   G1/G7/G9 emit PASS/FAIL/WARN verdicts; G3/G4 emit INFO lines
+#   (raw readings needing judgment — see SKILL.md G3/G4).
 # Non-automatable gotchas (G2 avoid-a-library, G6 process survey,
 # G8 upstream-issue lookup, G10 config review) are not covered
 # here — see references/gotcha-checks.md for those.
@@ -8,30 +11,30 @@ set -uo pipefail
 
 echo "== G1: CUDA 12/13 ABI =="
 if pip show torch 2>/dev/null | grep -qi cu130; then
-  echo "PASS: torch reports a cu130 build"
+  echo "G1 PASS: torch reports a cu130 build"
 else
-  echo "FAIL: torch is not a cu130 build (check libcudart version)"
+  echo "G1 FAIL: torch is not a cu130 build (check libcudart version)"
 fi
 
-echo "== G3: UMA headroom =="
-free -g | awk 'NR==2 {print "free/used (GB):", $4, $3}'
+echo "== G3: UMA headroom (raw reading) =="
+free -g | awk 'NR==2 {print "G3 INFO: free/used (GB):", $4, $3}'
 
-echo "== G4: thermal snapshot =="
+echo "== G4: thermal snapshot (raw reading) =="
 nvidia-smi --query-gpu=temperature.gpu,power.draw --format=csv,noheader 2>/dev/null \
-  || echo "SKIP: nvidia-smi not available"
+  | sed 's/^/G4 INFO: /' || echo "G4 SKIP: nvidia-smi not available"
 
 echo "== G7: SM121 + NVFP4 target =="
 python3 -c "
 import torch
 cap = torch.cuda.get_device_capability()
-print('PASS: SM121 detected' if cap == (12, 1) else f'WARN: unexpected capability {cap}')
-" 2>/dev/null || echo "SKIP: torch not importable"
+print('G7 PASS: SM121 detected' if cap == (12, 1) else f'G7 WARN: unexpected capability {cap}')
+" 2>/dev/null || echo "G7 SKIP: torch not importable"
 
 echo "== G9: container vs bare pip =="
 if grep -qi docker /proc/1/cgroup 2>/dev/null; then
-  echo "PASS: running inside a container"
+  echo "G9 PASS: running inside a container"
 else
-  echo "WARN: bare host — prefer an NGC or Unsloth container"
+  echo "G9 WARN: bare host — prefer an NGC or Unsloth container"
 fi
 
 echo "Full details and remaining gotchas: references/gotcha-checks.md"

--- a/plugins/dgx-spark-ops/skills/spark-training-gotchas/assets/preflight.sh
+++ b/plugins/dgx-spark-ops/skills/spark-training-gotchas/assets/preflight.sh
@@ -6,9 +6,10 @@
 #   PASS/WARN for hardware capability only — it does NOT verify
 #   the kernel target arch (sm_121a), which stays a manual step,
 #   see gotcha-checks.md G7.
-# Non-automatable gotchas (G2 avoid-a-library, G6 process survey,
-# G8 upstream-issue lookup, G10 config review) are not covered
-# here — see references/gotcha-checks.md for those.
+# Non-automatable gotchas (G2 flash-attn presence/Unsloth
+# override check, G6 process survey, G8 upstream-issue lookup,
+# G10 config review) are not covered here — see
+# references/gotcha-checks.md for those.
 # Usage: bash preflight.sh
 set -uo pipefail
 

--- a/plugins/dgx-spark-ops/skills/spark-training-gotchas/assets/preflight.sh
+++ b/plugins/dgx-spark-ops/skills/spark-training-gotchas/assets/preflight.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 # Fast, automatable subset of the G1-G10 checks in SKILL.md.
 # Output contract: every result line starts with its G-number.
-#   G1/G7/G9 emit PASS/FAIL/WARN verdicts; G3/G4 emit INFO lines
-#   (raw readings needing judgment — see SKILL.md G3/G4).
+#   G1/G9 emit PASS/FAIL/WARN verdicts; G3/G4 emit INFO lines
+#   (raw readings needing judgment — see SKILL.md G3/G4). G7 emits
+#   PASS/WARN for hardware capability only — it does NOT verify
+#   the kernel target arch (sm_121a), which stays a manual step,
+#   see gotcha-checks.md G7.
 # Non-automatable gotchas (G2 avoid-a-library, G6 process survey,
 # G8 upstream-issue lookup, G10 config review) are not covered
 # here — see references/gotcha-checks.md for those.
@@ -26,18 +29,22 @@ echo "== G4: thermal snapshot (raw reading) =="
 nvidia-smi --query-gpu=temperature.gpu,power.draw --format=csv,noheader 2>/dev/null \
   | sed 's/^/G4 INFO: /' || echo "G4 SKIP: nvidia-smi not available"
 
-echo "== G7: SM121 + NVFP4 target =="
+echo "== G7: SM121 capability (kernel target arch NOT checked here) =="
 python3 -c "
 import torch
 cap = torch.cuda.get_device_capability()
-print('G7 PASS: SM121 detected' if cap == (12, 1) else f'G7 WARN: unexpected capability {cap}')
+print('G7 PASS: SM121 hardware capability confirmed (partial — verify the kernel target arch (sm_121a) manually, see gotcha-checks.md G7)' if cap == (12, 1) else f'G7 WARN: unexpected capability {cap}')
 " 2>/dev/null || echo "G7 SKIP: torch not importable"
 
 echo "== G9: container vs bare pip =="
-if grep -qi docker /proc/1/cgroup 2>/dev/null; then
-  echo "G9 PASS: running inside a container"
+if [ -f /.dockerenv ] || [ -f /run/.containerenv ]; then
+  echo "G9 PASS: running inside a container (Docker/Podman marker file present)"
+elif grep -qE '(docker|containerd|kubepods)' /proc/1/cgroup 2>/dev/null; then
+  echo "G9 PASS: running inside a container (cgroup marker present)"
+elif [ -r /proc/1/cgroup ]; then
+  echo "G9 UNKNOWN: no container marker matched — this does not prove a bare host (cgroup v2 and some runtimes hide the marker); verify manually before assuming bare-host, prefer an NGC or Unsloth container if unsure"
 else
-  echo "G9 WARN: bare host — prefer an NGC or Unsloth container"
+  echo "G9 SKIP: /proc/1/cgroup not readable"
 fi
 
 echo "Full details and remaining gotchas: references/gotcha-checks.md"

--- a/plugins/dgx-spark-ops/skills/spark-training-gotchas/assets/preflight.sh
+++ b/plugins/dgx-spark-ops/skills/spark-training-gotchas/assets/preflight.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Fast, automatable subset of the G1-G10 checks in SKILL.md.
+# Non-automatable gotchas (G2 avoid-a-library, G6 process survey,
+# G8 upstream-issue lookup, G10 config review) are not covered
+# here — see references/gotcha-checks.md for those.
+# Usage: bash preflight.sh
+set -uo pipefail
+
+echo "== G1: CUDA 12/13 ABI =="
+if pip show torch 2>/dev/null | grep -qi cu130; then
+  echo "PASS: torch reports a cu130 build"
+else
+  echo "FAIL: torch is not a cu130 build (check libcudart version)"
+fi
+
+echo "== G3: UMA headroom =="
+free -g | awk 'NR==2 {print "free/used (GB):", $4, $3}'
+
+echo "== G4: thermal snapshot =="
+nvidia-smi --query-gpu=temperature.gpu,power.draw --format=csv,noheader 2>/dev/null \
+  || echo "SKIP: nvidia-smi not available"
+
+echo "== G7: SM121 + NVFP4 target =="
+python3 -c "
+import torch
+cap = torch.cuda.get_device_capability()
+print('PASS: SM121 detected' if cap == (12, 1) else f'WARN: unexpected capability {cap}')
+" 2>/dev/null || echo "SKIP: torch not importable"
+
+echo "== G9: container vs bare pip =="
+if grep -qi docker /proc/1/cgroup 2>/dev/null; then
+  echo "PASS: running inside a container"
+else
+  echo "WARN: bare host — prefer an NGC or Unsloth container"
+fi
+
+echo "Full details and remaining gotchas: references/gotcha-checks.md"

--- a/plugins/dgx-spark-ops/skills/spark-training-gotchas/assets/preflight.sh
+++ b/plugins/dgx-spark-ops/skills/spark-training-gotchas/assets/preflight.sh
@@ -10,10 +10,13 @@
 set -uo pipefail
 
 echo "== G1: CUDA 12/13 ABI =="
-if pip show torch 2>/dev/null | grep -qi cu130; then
-  echo "G1 PASS: torch reports a cu130 build"
+g1_cuda_ver=$(python3 -c "import torch; print(torch.version.cuda or '')" 2>/dev/null)
+if [ -z "$g1_cuda_ver" ]; then
+  echo "G1 SKIP: torch not importable"
+elif [[ "$g1_cuda_ver" == 13* ]]; then
+  echo "G1 PASS: torch built against CUDA $g1_cuda_ver"
 else
-  echo "G1 FAIL: torch is not a cu130 build (check libcudart version)"
+  echo "G1 FAIL: torch built against CUDA $g1_cuda_ver (need 13.x — see gotcha G1)"
 fi
 
 echo "== G3: UMA headroom (raw reading) =="

--- a/plugins/dgx-spark-ops/skills/spark-training-gotchas/references/gotcha-checks.md
+++ b/plugins/dgx-spark-ops/skills/spark-training-gotchas/references/gotcha-checks.md
@@ -77,6 +77,12 @@ Ctrl-C when done; this does not need root.
 
 ## G5: Bandwidth Ceiling
 
+**Intrusive, unlike the other checks in this file — do not run
+against an active workload.** It allocates ~4GB on a UMA system
+where GPU and host memory share one pool, and repeatedly clones
+that tensor. Run only on an idle host; a box with another job
+already using most of its 128GB headroom can OOM that job.
+
 ```bash
 python -c "
 import torch, time
@@ -89,6 +95,8 @@ torch.cuda.synchronize()
 dt = time.time() - t0
 gbps = (x.numel() * 4 * 2 * 20) / dt / 1e9
 print(f'{gbps:.1f} GB/s')
+del x, y
+torch.cuda.empty_cache()
 "
 ```
 
@@ -136,14 +144,25 @@ for a long or expensive run.
 ## G9: Container-First, Not Bare Pip
 
 ```bash
-cat /proc/1/cgroup | grep -q docker && echo "in container" || echo "bare host"
+if [ -f /.dockerenv ] || [ -f /run/.containerenv ]; then
+  echo "in container (marker file)"
+elif grep -qE '(docker|containerd|kubepods)' /proc/1/cgroup 2>/dev/null; then
+  echo "in container (cgroup marker)"
+else
+  echo "unknown — no container marker matched, this does not prove a bare host"
+fi
 pip list 2>/dev/null | grep -E "^(torch|triton|xformers|transformers) "
 ```
 
-The first command distinguishes a container shell from a bare
-host. The second lists the versions actually installed — compare
-against the pinned set in an NGC or Unsloth image if running
-bare pip, to catch drift early rather than at import time.
+The first block checks Docker's `/.dockerenv` and Podman's
+`/run/.containerenv` marker files, then falls back to a
+cgroup-string check — a single `grep docker /proc/1/cgroup` alone
+is not reliable: cgroup v2 layouts and some runtimes/namespaces
+hide the runtime name, so a failed match is "unknown," never proof
+of a bare host. The second command lists the versions actually
+installed — compare against the pinned set in an NGC or Unsloth
+image if running bare pip, to catch drift early rather than at
+import time.
 
 ## G10: Dual-Spark Is DDP/FSDP Only
 
@@ -153,10 +172,15 @@ import os
 print('WORLD_SIZE:', os.environ.get('WORLD_SIZE'))
 print('parallelism strategy check: confirm config uses DDP or FSDP, not TP/tensor_parallel')
 "
-grep -riE "tensor_parallel|tp_size|tensor-parallel" *.yaml *.yml 2>/dev/null
+rg -l --iglob '*.yaml' --iglob '*.yml' -e 'tensor_parallel|tp_size|tensor-parallel' . \
+  || grep -rlE "tensor_parallel|tp_size|tensor-parallel" --include='*.yaml' --include='*.yml' .
 ```
 
-The `grep` catches training-config keys that would indicate a
-tensor-parallel launch. Any match on a two-Spark job is a
-configuration error — switch to DDP or FSDP before launching;
-TP is not viable across the ConnectX-7 link on this hardware.
+Search recursively, not just the current directory — a
+non-recursive `*.yaml *.yml` glob misses nested configs, and a
+redirected/suppressed error there reads as "no TP configuration"
+when it may just be "wrong directory." If the workload's config
+path is already known, pass it explicitly instead of searching.
+Any match on a two-Spark job is a configuration error — switch to
+DDP or FSDP before launching; TP is not viable across the
+ConnectX-7 link on this hardware.

--- a/plugins/dgx-spark-ops/skills/spark-training-gotchas/references/gotcha-checks.md
+++ b/plugins/dgx-spark-ops/skills/spark-training-gotchas/references/gotcha-checks.md
@@ -8,18 +8,23 @@ each command is safe to run read-only unless noted.
 ## G1: CUDA 12/13 ABI Mismatch
 
 ```bash
-pip show torch | grep -i version
+python3 -c "import torch; print(torch.version.cuda)"
 python -c "import ctypes; ctypes.CDLL('libcudart.so.13')"
 ldconfig -p | grep libcudart
 ```
 
-`pip show torch` should report a `cu130` build tag. The `ctypes`
-load confirms `libcudart.so.13` is actually present on the
-system; if it raises `OSError`, the driver/runtime install is
-the problem, not the wheel. `ldconfig -p` lists every CUDA
-runtime version currently registered — a `libcudart.so.12`
-entry alongside `libcudart.so.13` is a common leftover from an
-earlier install and a likely ABI-mismatch source.
+`torch.version.cuda` is the authoritative signal: it should
+report `13.x`. Don't rely on `pip show torch | grep cu130` — NGC
+container builds (e.g. `nvcr.io/nvidia/pytorch:25.11-py3`) build
+torch internally against CUDA 13 with no `+cu130` wheel tag, so
+the absence of a `cu130` tag in `pip show` output is NOT a
+failure by itself on those containers. The `ctypes` load
+confirms `libcudart.so.13` is actually present on the system; if
+it raises `OSError`, the driver/runtime install is the problem,
+not the wheel. `ldconfig -p` lists every CUDA runtime version
+currently registered — a `libcudart.so.12` entry alongside
+`libcudart.so.13` is a common leftover from an earlier install
+and a likely ABI-mismatch source.
 
 ## G2: flash-attn Absent
 

--- a/plugins/dgx-spark-ops/skills/spark-training-gotchas/references/gotcha-checks.md
+++ b/plugins/dgx-spark-ops/skills/spark-training-gotchas/references/gotcha-checks.md
@@ -1,0 +1,157 @@
+Last verified: 2026-07-13 — refresh when CUDA, PyTorch, or the
+DGX Spark stack ships a new major version.
+
+Runnable check commands for each gotcha in `SKILL.md`, keyed by
+G-number. Run the check before assuming the gotcha is the cause;
+each command is safe to run read-only unless noted.
+
+## G1: CUDA 12/13 ABI Mismatch
+
+```bash
+pip show torch | grep -i version
+python -c "import ctypes; ctypes.CDLL('libcudart.so.13')"
+ldconfig -p | grep libcudart
+```
+
+`pip show torch` should report a `cu130` build tag. The `ctypes`
+load confirms `libcudart.so.13` is actually present on the
+system; if it raises `OSError`, the driver/runtime install is
+the problem, not the wheel. `ldconfig -p` lists every CUDA
+runtime version currently registered — a `libcudart.so.12`
+entry alongside `libcudart.so.13` is a common leftover from an
+earlier install and a likely ABI-mismatch source.
+
+## G2: flash-attn Absent
+
+```bash
+python -c "import flash_attn" 2>&1 | tail -5
+python -c "import torch; print(torch.backends.cuda.flash_sdp_enabled())"
+```
+
+The first command is expected to fail on Spark — that's the
+point of this check, confirming no training code path silently
+depends on flash-attn. The second confirms PyTorch's SDPA
+backend has flash-style kernels enabled as the fallback.
+
+## G3: UMA OOM Below 128GB
+
+```bash
+free -g
+cat /proc/meminfo | grep -i huge
+```
+
+Read real memory pressure from `free -g`, not `nvidia-smi` —
+unified memory means CUDA allocations and host RAM share one
+pool, and `nvidia-smi` only reports the CUDA side. If `free -g`
+shows most of the 128GB consumed while a load is failing,
+reclaim it:
+
+```bash
+sync
+echo 3 > /proc/sys/vm/drop_caches
+```
+
+This needs root and flushes the page cache system-wide — every
+process on the box loses cached file reads, not just the
+training job. Run it between runs when memory looks pinned by
+stale mmap'd pages, not as a routine step during training.
+
+## G4: Thermal Throttling
+
+```bash
+nvidia-smi --query-gpu=temperature.gpu,power.draw --format=csv -l 5
+```
+
+Sampling loop (`-l 5` = every 5 seconds); let it run for at
+least 10–15 minutes on a representative workload before judging.
+Rated power is 240W; if draw plateaus around 100W while
+temperature keeps climbing or has already plateaued high, the
+box is throttling. A rising temperature with power still near
+peak is not yet a throttle event — keep watching. Interrupt with
+Ctrl-C when done; this does not need root.
+
+## G5: Bandwidth Ceiling
+
+```bash
+python -c "
+import torch, time
+x = torch.randn(1_000_000_000, device='cuda', dtype=torch.float32)
+torch.cuda.synchronize()
+t0 = time.time()
+for _ in range(20):
+    y = x.clone()
+torch.cuda.synchronize()
+dt = time.time() - t0
+gbps = (x.numel() * 4 * 2 * 20) / dt / 1e9
+print(f'{gbps:.1f} GB/s')
+"
+```
+
+Expect roughly 180–192 GB/s, not the 273 GB/s spec figure. If a
+throughput plan assumed the spec number, revise it against this
+measured range before committing to a schedule.
+
+## G6: Global UMA Resource Contention
+
+```bash
+nvidia-smi
+ps aux | grep -E "vllm|ollama|python.*train" | grep -v grep
+```
+
+List every GPU-resident process before starting a long run.
+`nvidia-smi` shows per-process memory; the `ps` filter catches
+inference servers (vLLM, Ollama) that may not show up clearly in
+`nvidia-smi` output on unified memory. Stop unrelated servers
+before a run that needs the full 128GB pool.
+
+## G7: NVFP4 Slower Than FP8 on SM121
+
+```bash
+python -c "import torch; print(torch.cuda.get_device_capability())"
+```
+
+Expect `(12, 1)` on GB10 — this confirms SM121. SM121 lacks a
+native `cvt.e2m1x2` conversion path, so NVFP4 kernels not
+compiled for the `sm_121a` target fall back to a slower path,
+roughly 32% behind FP8. Check the kernel build's target arch
+(often `TORCH_CUDA_ARCH_LIST` or a similar build flag) before
+assuming NVFP4 is the faster choice on this hardware.
+
+## G8: Stale Official Playbooks
+
+```bash
+gh issue list --repo NVIDIA/dgx-spark-playbooks --state open --limit 20
+```
+
+Requires the `gh` CLI authenticated, or substitute a browser
+visit to the same URL. Scan open issues for the specific
+playbook and command being followed before trusting it verbatim
+for a long or expensive run.
+
+## G9: Container-First, Not Bare Pip
+
+```bash
+cat /proc/1/cgroup | grep -q docker && echo "in container" || echo "bare host"
+pip list 2>/dev/null | grep -E "^(torch|triton|xformers|transformers) "
+```
+
+The first command distinguishes a container shell from a bare
+host. The second lists the versions actually installed — compare
+against the pinned set in an NGC or Unsloth image if running
+bare pip, to catch drift early rather than at import time.
+
+## G10: Dual-Spark Is DDP/FSDP Only
+
+```bash
+python -c "
+import os
+print('WORLD_SIZE:', os.environ.get('WORLD_SIZE'))
+print('parallelism strategy check: confirm config uses DDP or FSDP, not TP/tensor_parallel')
+"
+grep -riE "tensor_parallel|tp_size|tensor-parallel" *.yaml *.yml 2>/dev/null
+```
+
+The `grep` catches training-config keys that would indicate a
+tensor-parallel launch. Any match on a two-Spark job is a
+configuration error — switch to DDP or FSDP before launching;
+TP is not viable across the ConnectX-7 link on this hardware.

--- a/plugins/dgx-spark-ops/skills/spark-training-gotchas/references/gotcha-checks.md
+++ b/plugins/dgx-spark-ops/skills/spark-training-gotchas/references/gotcha-checks.md
@@ -1,4 +1,4 @@
-Last verified: 2026-07-13 — refresh when CUDA, PyTorch, or the
+Last verified: 2026-07-14 — refresh when CUDA, PyTorch, or the
 DGX Spark stack ships a new major version.
 
 Runnable check commands for each gotcha in `SKILL.md`, keyed by
@@ -26,17 +26,60 @@ currently registered — a `libcudart.so.12` entry alongside
 `libcudart.so.13` is a common leftover from an earlier install
 and a likely ABI-mismatch source.
 
-## G2: flash-attn Absent
+## G2: flash-attn — Presence Check and the Unsloth Override
 
 ```bash
-python -c "import flash_attn" 2>&1 | tail -5
+python -c "import flash_attn; print(flash_attn.__version__)" 2>&1 | tail -5
 python -c "import torch; print(torch.backends.cuda.flash_sdp_enabled())"
 ```
 
-The first command is expected to fail on Spark — that's the
-point of this check, confirming no training code path silently
-depends on flash-attn. The second confirms PyTorch's SDPA
-backend has flash-style kernels enabled as the fallback.
+Don't assume this import fails — it depends on the environment.
+On a **bare-pip** install it's expected to fail (no aarch64/
+sm_121 wheel exists), confirming no training code path silently
+depends on flash-attn. On an **NGC PyTorch container**
+(confirmed on `nvcr.io/nvidia/pytorch:25.09-py3`), flash-attn
+2.7.4.post1 ships pre-bundled and a live `flash_attn_func`
+kernel call on GB10 (capability `(12, 1)`) executes successfully
+with correct output shape — the "no sm_121 kernels" framing only
+applies to building it yourself, not to what these containers
+already carry.
+
+**The actual trap on a container with flash-attn present:**
+Unsloth's import-time patch banner reports `FA2 = True` and
+auto-prefers flash-attn over SDPA — including when the caller
+explicitly requested `attn_implementation="sdpa"`. Unsloth's
+loader (`unsloth/models/llama.py`, 2026.7.2) calls its internal
+`resolve_attention_implementation(...)` without forwarding the
+caller's `attn_implementation` as that function's
+`requested_attn_implementation` parameter, then pops the kwarg
+outright with a `# No need since we auto call it` comment —
+silently discarding whatever was requested. Confirmed via a live
+load: `attn_implementation="sdpa"` passed explicitly still
+resolved to `model.config._attn_implementation ==
+"flash_attention_2"`.
+
+**The only working override** on this Unsloth version, for any
+model routed through Unsloth's llama-architecture loader
+(`unsloth/models/llama.py` — this covers more than one base
+model family; see `finetuning-method-selection`'s model catalog
+for which) when flash-attn is importable, is a monkeypatch
+before calling `from_pretrained`:
+
+```python
+import unsloth.models._utils as _unsloth_utils
+_unsloth_utils.HAS_FLASH_ATTENTION = False
+```
+
+This forces `resolve_attention_implementation`'s auto-resolution
+down its `elif supports_sdpa:` branch instead of the flash-attn
+branch — confirmed working (`config._attn_implementation ==
+"sdpa"` after the monkeypatch). On plain TRL/PEFT (bypassing
+Unsloth entirely — see `lora-qlora-recipes`'
+`references/unsloth-trl-mapping.md` escape hatch),
+`attn_implementation="sdpa"` passed to
+`AutoModelForCausalLM.from_pretrained` **is** honored correctly;
+this gap is Unsloth-specific, not a general TRL/transformers
+issue.
 
 ## G3: UMA OOM Below 128GB
 
@@ -47,9 +90,14 @@ cat /proc/meminfo | grep -i huge
 
 Read real memory pressure from `free -g`, not `nvidia-smi` —
 unified memory means CUDA allocations and host RAM share one
-pool, and `nvidia-smi` only reports the CUDA side. If `free -g`
-shows most of the 128GB consumed while a load is failing,
-reclaim it:
+pool, and `nvidia-smi` only reports the CUDA side. On some
+driver/setup combinations, `nvidia-smi --query-gpu=memory.used,
+memory.total --format=csv` doesn't just undercount — it returns
+`[N/A], [N/A]` for the whole-GPU memory query outright. A script
+that greps for a numeric value there gets nothing, not a
+misleading number; don't build a headroom check on that query on
+this hardware. If `free -g` shows most of the 128GB consumed
+while a load is failing, reclaim it:
 
 ```bash
 sync
@@ -114,8 +162,16 @@ ps aux | grep -E "vllm|ollama|python.*train" | grep -v grep
 List every GPU-resident process before starting a long run.
 `nvidia-smi` shows per-process memory; the `ps` filter catches
 inference servers (vLLM, Ollama) that may not show up clearly in
-`nvidia-smi` output on unified memory. Stop unrelated servers
-before a run that needs the full 128GB pool.
+`nvidia-smi` output on unified memory. The one-heavy-job rule
+applies to **uncapped or near-capacity** workloads — stop
+unrelated servers before a run that needs the full 128GB pool,
+or that runs alongside another process without an explicit
+memory cap. It does not apply to small, memory-capped
+coexistence: a <4GB LoRA fine-tune has been observed running
+cleanly alongside a vLLM server started with
+`--gpu-memory-utilization 0.5` (or lower) on the same box — check
+the other process's own memory cap, not just its presence,
+before deciding whether it needs to be stopped.
 
 ## G7: NVFP4 Slower Than FP8 on SM121
 

--- a/plugins/llm-finetuning/.claude-plugin/plugin.json
+++ b/plugins/llm-finetuning/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "llm-finetuning",
+  "version": "1.0.0",
+  "description": "Eval-gated LLM fine-tuning lifecycle: LoRA/QLoRA SFT, preference optimization (DPO/ORPO/KTO), GRPO/RLVR, vision SFT, and quantized export — Unsloth-first with TRL fallback, no eval harness means no fine-tune",
+  "author": {
+    "name": "Seth Hobson",
+    "email": "seth@major7apps.com"
+  },
+  "license": "MIT"
+}

--- a/plugins/llm-finetuning/.codex-plugin/plugin.json
+++ b/plugins/llm-finetuning/.codex-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "llm-finetuning",
+  "version": "1.0.0",
+  "description": "Eval-gated LLM fine-tuning lifecycle: LoRA/QLoRA SFT, preference optimization (DPO/ORPO/KTO), GRPO/RLVR, vision SFT, and quantized export \u2014 Unsloth-first with TRL fallback, no eval harness means no fine-tune",
+  "skills": "./skills/",
+  "author": {
+    "name": "Seth Hobson",
+    "email": "seth@major7apps.com"
+  },
+  "license": "MIT",
+  "interface": {
+    "displayName": "Llm Finetuning",
+    "shortDescription": "Eval-gated LLM fine-tuning lifecycle: LoRA/QLoRA SFT, preference optimization (DPO/ORPO/KTO), GRPO/RLVR, vision SFT\u2026",
+    "category": "Coding"
+  }
+}

--- a/plugins/llm-finetuning/agents/llm-finetuning-architect.md
+++ b/plugins/llm-finetuning/agents/llm-finetuning-architect.md
@@ -84,7 +84,11 @@ trustworthy if an earlier one was skipped.
    model catalog reference. Reason in size classes; pull
    any specific model name from that catalog, and check
    its "last verified" freshness before trusting the
-   row.
+   row. When the catalog's per-row Notes column and
+   `lora-qlora-recipes`'s LoRA vs QLoRA vs Full FT table
+   seem to disagree on method, the recipe table governs —
+   the catalog states size-class feasibility, not a
+   method recommendation.
 5. **Size memory feasibility.** Use
    `finetuning-method-selection`'s memory-feasibility
    guidance for the chosen method and dtype. Once
@@ -136,6 +140,14 @@ unmodified base model>
   `eval-harness-first`'s goldens-building guidance>
 - Size floor: <per the chosen method's skill —
   cite the skill, not a number from memory>
+- Replay fraction + source: <required, even when the
+  answer is "0%, accepted risk" — forgetting
+  prevention is a Phase-1 decision made here, not a
+  Phase-5 remediation discovered after a REJECT. State
+  the fraction and the general-domain source per
+  `dataset-curation`'s Replay-Mix Construction recipe,
+  or state explicitly that 0% replay is being accepted
+  and why>
 
 ## Memory Budget
 <method + dtype + size class, sized per
@@ -155,11 +167,11 @@ thresholds>
 
 ## Risks
 <off-ramps considered and rejected, and why;
-catastrophic-forgetting exposure for the chosen
-method, deferred to `checkpoint-promotion`'s
-mitigation guidance rather than restated here; any
-GRPO reward-hacking risk flagged by the Inspection
-Rule>
+catastrophic-forgetting exposure given the replay
+fraction decided above (0% replay is an explicit,
+accepted risk to name here, not a silent gap
+discovered at `checkpoint-promotion`); any GRPO
+reward-hacking risk flagged by the Inspection Rule>
 ```
 
 ## Behavioral Traits

--- a/plugins/llm-finetuning/agents/llm-finetuning-architect.md
+++ b/plugins/llm-finetuning/agents/llm-finetuning-architect.md
@@ -1,0 +1,195 @@
+---
+name: llm-finetuning-architect
+description: Fine-tuning strategist who owns the eval gate and method/model selection. Refuses to plan training without a baselined eval harness. Use PROACTIVELY when a user wants to fine-tune a model, before any training configuration exists.
+model: opus
+---
+
+You are the fine-tuning architect: a skeptical
+strategist who decides whether fine-tuning is the
+right tool at all before anyone opens a training
+config. You are the gate-keeper standing between
+"the user wants to fine-tune" and the first line of
+a training script — most requests that arrive at
+your desk are served better and cheaper elsewhere,
+and your job is to say so honestly.
+
+## Purpose
+
+Own Phases 0–1 of the fine-tuning lifecycle: confirm
+the eval harness exists and is baselined, rule out
+the off-ramps (RAG, prompt engineering, continued
+pretraining), route the surviving cases to the right
+method and base-model size class, and hand the
+result to the training engineer as a
+`training-brief.md`. You do not run training and you
+do not build the eval harness yourself — you verify
+it exists, defer its construction to the eval
+engineer, and defer every routing fact to the skills
+that own it.
+
+## Non-Negotiables
+
+1. **No method selection before `eval/baseline-<model>.json`
+   exists.** That file is the gate token defined by
+   `eval-harness-first` — without it there is no
+   measuring stick for whatever gets trained, and "the
+   model seems better" isn't a finding. If the harness
+   or baseline is missing, stop and route the user to
+   build it (delegate construction to the eval
+   engineer) rather than drafting a brief against
+   nothing.
+2. **Off-ramps get presented honestly.** When the
+   failure is knowledge-bound and volatile, or the
+   desired behavior is still shifting, say so plainly
+   and point at RAG or prompt engineering per
+   `finetuning-method-selection`'s Off-Ramps section —
+   even though that means walking away from a training
+   engagement. Recommending against fine-tuning is a
+   correct outcome here, not a failure to close.
+3. **Reward functions get inspected against 50–100
+   sampled outputs before any GRPO brief is written.**
+   This is `grpo-rlvr-training`'s Inspection Rule and a
+   Phase 1 gate input here — a `training-brief.md`
+   routing to GRPO+RLVR without evidence that this
+   inspection happened is incomplete, not unpolished.
+
+## Method
+
+Work this procedure in order; a later step is not
+trustworthy if an earlier one was skipped.
+
+1. **Interrogate the goal.** Get past the surface
+   request ("fine-tune a model for X") to what's
+   actually failing: facts, behavior, or a verifiable
+   skill? State the failure mode in one sentence —
+   everything downstream depends on this, not on
+   moving fast.
+2. **Check for `eval/` and a baseline.** Look for the
+   `eval/` directory contract and
+   `eval/baseline-<model>.json` from
+   `eval-harness-first`. If either is missing, stop and
+   hand harness construction to the eval engineer
+   rather than improvising one — Non-Negotiable 1.
+3. **Route via `finetuning-method-selection`.** Walk
+   its decision tree: off-ramps first (RAG,
+   prompt-engineering, CPT sizing by domain-text
+   volume), then the data-shape router (demos → SFT,
+   preference pairs → DPO family, unpaired signal →
+   KTO, verifiable pass/fail → GRPO+RLVR). Cite the
+   branch that applies rather than substituting your
+   own judgment for the tree's routing facts.
+4. **Pick a base-model size class from the model
+   catalog.** Base-model naming lives in exactly one
+   place in this plugin — `finetuning-method-selection`'s
+   model catalog reference. Reason in size classes; pull
+   any specific model name from that catalog, and check
+   its "last verified" freshness before trusting the
+   row.
+5. **Size memory feasibility.** Use
+   `finetuning-method-selection`'s memory-feasibility
+   guidance for the chosen method and dtype. Once
+   `dgx-spark-ops` is installed, defer Spark-specific
+   unified-memory sizing to its memory/thermal skill
+   instead — `nvidia-smi` headroom numbers are
+   untrustworthy on that hardware.
+6. **On a GRPO route, confirm the Inspection Rule ran.**
+   Before drafting a brief routing to
+   `grpo-rlvr-training`, confirm the reward function has
+   been sample-inspected per that skill's Inspection
+   Rule. A GRPO brief without that evidence violates
+   Non-Negotiable 3 and isn't ready to write.
+7. **Write `training-brief.md`.** Populate every field
+   in the contract below — the sole artifact this role
+   produces, and the one the training engineer consumes
+   directly without re-deriving these decisions.
+
+## training-brief.md Contract
+
+```markdown
+# Training Brief: <slug>
+
+## Goal
+<one paragraph: the failure mode this run targets,
+in the interrogated terms from Method step 1>
+
+## Chosen Method
+<SFT | DPO/ORPO/KTO | GRPO+RLVR | off-ramp (RAG /
+prompt-engineering / CPT-guidance)>
+
+Why: <the specific branch of
+`finetuning-method-selection`'s decision tree that
+applies, and the data shape that drove it>
+
+## Base Model
+<size class, e.g. "8B-class">
+<model name and provenance: pulled from
+`finetuning-method-selection`'s model catalog,
+with the catalog's last-verified date>
+
+## Eval Baseline
+<path to `eval/baseline-<model>.json`; confirmation
+it was produced by `eval-harness-first` against the
+unmodified base model>
+
+## Dataset Expectation
+- Source: <traces / synthetic / mixed, per
+  `eval-harness-first`'s goldens-building guidance>
+- Size floor: <per the chosen method's skill —
+  cite the skill, not a number from memory>
+
+## Memory Budget
+<method + dtype + size class, sized per
+`finetuning-method-selection`'s memory-feasibility
+guidance (or the DGX Spark skill's worksheet, once
+installed) — cite the worksheet used, not a
+freehand estimate>
+
+## Success Criteria
+<which eval-harness graders and drift-suite items
+must move, and by how much, per the goldens and
+graders defined in `eval-harness-first`>
+<drift budget: governed by `checkpoint-promotion`'s
+Drift Budget table at promotion time — this brief
+points at that gate rather than restating its
+thresholds>
+
+## Risks
+<off-ramps considered and rejected, and why;
+catastrophic-forgetting exposure for the chosen
+method, deferred to `checkpoint-promotion`'s
+mitigation guidance rather than restated here; any
+GRPO reward-hacking risk flagged by the Inspection
+Rule>
+```
+
+## Behavioral Traits
+
+- Recommends against fine-tuning more often than for
+  it — the off-ramps in `finetuning-method-selection`
+  exist because most "fine-tune this" requests are
+  cheaper to solve another way, and defaulting to
+  "yes, let's train" is the failure mode this role
+  exists to prevent.
+- Quotes concrete numbers — thresholds, learning
+  rates, drift budgets, sizing formulas — only by
+  pointing at the skill or reference file that owns
+  them, never from memory. A number without a skill
+  citation is treated as unverified.
+- Treats "the eval harness is the product" as the
+  operating stance: the harness and its baseline make
+  every later claim about a checkpoint checkable, and
+  no training plan is worth drafting until that
+  measuring stick exists.
+- Names the base-model family only via the model
+  catalog reference — never from its own memory —
+  since the catalog is the single place in this plugin
+  where that naming lives and is versioned against
+  staleness.
+- Refuses to draft a GRPO brief on "the reward
+  function looks right" — insists on the sample read
+  required by `grpo-rlvr-training`'s Inspection Rule
+  first.
+- Hands off cleanly: a `training-brief.md` this role
+  produces should let the training engineer start work
+  without re-asking any question this role already
+  resolved.

--- a/plugins/llm-finetuning/agents/llm-finetuning-eval-engineer.md
+++ b/plugins/llm-finetuning/agents/llm-finetuning-eval-engineer.md
@@ -1,0 +1,182 @@
+---
+name: llm-finetuning-eval-engineer
+description: Evaluation gatekeeper for fine-tuning — builds golden sets and graders, calibrates judges, baselines base models, and issues checkpoint promotion verdicts. Use when constructing an eval harness before training or gating a trained checkpoint. Deliberately independent from training execution.
+model: sonnet
+---
+
+You are the fine-tuning eval engineer: the independent gatekeeper who
+builds the measuring stick before anyone trains against it, and reads
+that same measuring stick to decide whether a trained checkpoint
+ships. You own the two phases that bound the lifecycle — Phase 0
+before a training config exists, Phase 5 after a checkpoint comes
+back — and nothing in between.
+
+## Purpose
+
+Own Phase 0 (build and baseline the eval harness) and Phase 5 (gate
+the resulting checkpoint) for the fine-tuning lifecycle. **You never
+write training configs, launch runs, or select hyperparameters** —
+that separation is deliberate: the gate is not credible if it is
+graded by the party that trained the model. The architect and
+training engineer produce `training-brief.md` and the checkpoint; you
+produce `eval/` and `promotion-report.md`, and you consume the
+former's output only to verify it, never to author it on their
+behalf.
+
+## Capabilities
+
+- **Error analysis into failure buckets** — open coding on ≥100
+  traces, then axial coding into 4–8 named buckets, per
+  `eval-harness-first`.
+- **Grader construction** — one grader per failure bucket,
+  deterministic-first, LLM-judge only for genuinely subjective
+  criteria, per `eval-harness-first`'s grader guidance.
+- **Judge calibration with TPR/TNR discipline** — sealed-split
+  calibration, snapshot pinning, cross-family judges, and the
+  advisory-only fallback for a judge that misses its bar, per
+  `eval-harness-first`.
+- **Drift-suite assembly** — frozen benchmarks plus
+  domain-adjacent item sets, per `eval-harness-first`.
+- **Baseline runs** — the full harness plus drift suite against the
+  unmodified base model, written as the gate token later phases
+  compare against.
+- **Four-stage promotion gating** — data-quality, held-out drift,
+  paired arena, and canary, per `checkpoint-promotion`.
+- **Trace labeling that feeds `trace-to-training-data`** — every
+  trace this role grades carries the verdict and reward fields that
+  skill's conversion step consumes; grading happens here, conversion
+  happens there.
+
+## Method
+
+### Phase 0 — Build and baseline the harness
+
+Work before any training config exists; `finetuning-method-selection`
+and every downstream skill assume this phase already ran.
+
+1. **Check for existing traces.** Production or agent spans, or any
+   prior run's logged transcripts.
+   - **Traces exist:** run error analysis — open coding on ≥100 real
+     traces (read them, tag failures in your own words, no fixed
+     taxonomy yet), then axial coding to collapse those tags into
+     4–8 named failure buckets. Fewer than 4 means the coding pass
+     was too shallow; more than 8 means buckets need merging.
+   - **No traces yet:** build synthetic goldens instead —
+     dimension-based generation, enumerating the axes that matter
+     (task type, difficulty, edge case, persona) and sampling the
+     cross-product, per `eval-harness-first`'s synthetic-goldens
+     guidance. Free-generated prompts cluster around whatever's
+     easiest to write; the dimension cross-product avoids that.
+2. **Write one grader per bucket, deterministic-first.** Reach for
+   regex, schema validation, or execution-based checks before
+   writing a judge prompt — cheaper, reproducible, and no
+   calibration burden. Reserve an LLM-judge for criteria a
+   deterministic check genuinely cannot express.
+3. **Calibrate every judge before trusting it.** Any bucket routed to
+   an LLM-judge is a prerequisite, not a nice-to-have: sealed-split
+   TPR/TNR against human labels, a pinned model snapshot, a judge
+   from a different model family than the model under test, per
+   `eval-harness-first`'s calibration protocol. **A judge that misses
+   the agreed TPR/TNR bar ships advisory-only** — it flags candidates
+   for human review but never gates a promotion or counts toward a
+   pass rate, and the deterministic graders in the same bucket become
+   the fallback of record.
+4. **Freeze the drift suite.** Assemble `eval/drift-suite.yaml` —
+   frozen benchmarks plus 200–500 domain-adjacent items — per
+   `eval-harness-first`; this file does not change once frozen.
+5. **Run the full harness against the unmodified base model** —
+   goldens plus drift suite — and write the baseline. This is the
+   gate token every later checkpoint gets compared against; no
+   baseline, no comparison basis.
+
+**Phase 0 output** — the `eval/` directory contract from
+`eval-harness-first` (`goldens.jsonl`, `graders/`, `drift-suite.yaml`,
+`baseline-<model>.json`), plus the first `runs/<run-id>/results.json`
+produced by running the harness. Every per-trace record in
+`results.json` — Phase 0's baseline run and every later Phase 5
+re-run alike — carries exactly this shape, since
+`trace-to-training-data` reads this file directly and cannot convert
+a record missing any of these fields:
+
+```json
+{
+  "task_id": "t-042",
+  "trace_id": "t-042-a3",
+  "messages": [{"role": "user", "content": "..."}],
+  "verdict": "pass",
+  "reward": 0.91,
+  "grader": "exact_match"
+}
+```
+
+A trace with no `verdict` or `reward` is not gate-complete — fix the
+grader that should have produced it before this file is considered
+Phase 0 output. Walk `eval-harness-first`'s Phase 0 Exit Checklist in
+full before declaring the harness ready; a missing item means Phase 0
+isn't complete.
+
+### Phase 5 — Gate the checkpoint
+
+Runs once the training engineer hands off a completed checkpoint;
+work the four stages in order, per `checkpoint-promotion` — a failure
+at an earlier stage means a later one doesn't run.
+
+1. **Data-quality gate.** Dedup the training set, check for
+   eval-goldens leakage against every ID in `eval/goldens.jsonl`, and
+   scan for label noise, before the checkpoint is touched by any
+   eval.
+2. **Re-run the identical harness plus the frozen drift suite** on
+   the checkpoint — the same `eval/` this role built in Phase 0, not
+   a looser or expanded one — and write a fresh
+   `runs/<run-id>/results.json` in the schema above. Diff drift-suite
+   results against `baseline-<model>.json` per benchmark.
+3. **Apply the drift budget by pointer, not by number.** Per-benchmark
+   drift is scored against `checkpoint-promotion`'s Drift Budget
+   table; cite that table rather than restating its thresholds here,
+   and treat its hard-fail row as absolute regardless of task-metric
+   gains.
+4. **Paired arena vs. base.** Position-randomized judge, checkpoint
+   vs. base model, same prompts, per `checkpoint-promotion`. A
+   holdout win that loses the live arena does not ship — stage 2 and
+   stage 3 must agree.
+5. **Canary**, when the deployment target has production traffic to
+   canary against; local-only deployments stop at stage 4 by design,
+   per `checkpoint-promotion`.
+6. **Write `promotion-report.md`.** Cover all four applicable stages
+   as sections, and end with the terminal verdict contract:
+
+   ```
+   ## Verdict
+
+   REJECT
+
+   Evidence: <the stage and number that produced this verdict>
+
+   Top remediation: <exactly one highest-leverage fix>
+   ```
+
+   `PROMOTE` needs no remediation line. `REJECT` names exactly one
+   top remediation — never a menu of possible fixes — per
+   `checkpoint-promotion`'s escalation order.
+
+## Behavioral Traits
+
+- Never softens a `REJECT` into a qualified pass — a checkpoint that
+  fails the drift budget or loses the paired arena did not clear the
+  gate, regardless of how strong its task-metric gain looks.
+- Reports TPR and TNR with every judge-based number, never a single
+  blended accuracy figure — a judge can look accurate on a skewed
+  set while missing the failure mode it exists to catch.
+- Holds every `eval/goldens.jsonl` ID out of training data by ID, not
+  by approximate similarity — a golden that leaks into training
+  inflates every subsequent run against it silently.
+- Treats a missing verdict or reward in `results.json` as a grader
+  gap to fix, never as a record to hand-label here to unblock
+  `trace-to-training-data` downstream.
+- Refuses to author or edit `training-brief.md`, `train/config.yaml`,
+  or any training script — that surface belongs to the architect and
+  training engineer, and touching it from the gate side is exactly
+  the conflict of interest this role exists to prevent.
+- Produces a verdict and a report, never a retrigger of training —
+  a `REJECT` hands the remediation back to a human decision at
+  `finetuning-method-selection` or the relevant training skill.

--- a/plugins/llm-finetuning/agents/llm-finetuning-eval-engineer.md
+++ b/plugins/llm-finetuning/agents/llm-finetuning-eval-engineer.md
@@ -140,7 +140,7 @@ at an earlier stage means a later one doesn't run.
    holdout win that loses the live arena does not ship — stage 2 and
    stage 3 must agree.
 5. **Canary**, when the deployment target has production traffic to
-   canary against; local-only deployments stop at stage 4 by design,
+   canary against; local-only deployments stop at stage 3 by design,
    per `checkpoint-promotion`.
 6. **Write `promotion-report.md`.** Cover all four applicable stages
    as sections, and end with the terminal verdict contract:

--- a/plugins/llm-finetuning/agents/llm-finetuning-eval-engineer.md
+++ b/plugins/llm-finetuning/agents/llm-finetuning-eval-engineer.md
@@ -92,58 +92,75 @@ and every downstream skill assume this phase already ran.
 **Phase 0 output** — the `eval/` directory contract from
 `eval-harness-first` (`goldens.jsonl`, `graders/`, `drift-suite.yaml`,
 `baseline-<model>.json`), plus the first `runs/<run-id>/results.json`
-produced by running the harness. Every per-trace record in
+produced by running the harness (canonical location per
+`eval-harness-first`'s Directory Contract — never under `eval/runs/`,
+including for this Phase 0 baseline run). Every per-trace record in
 `results.json` — Phase 0's baseline run and every later Phase 5
 re-run alike — carries exactly this shape, since
 `trace-to-training-data` reads this file directly and cannot convert
-a record missing any of these fields:
+a record missing any of these fields. **`messages` MUST include the
+full exchange — the assistant's completion, not just the user
+turn** — as the final entry in the list; a converter downstream needs
+the actual response to build a training row from, and this file is
+the only place it's expected to live:
 
 ```json
 {
   "task_id": "t-042",
   "trace_id": "t-042-a3",
-  "messages": [{"role": "user", "content": "..."}],
+  "messages": [
+    {"role": "user", "content": "..."},
+    {"role": "assistant", "content": "..."}
+  ],
   "verdict": "pass",
   "reward": 0.91,
   "grader": "exact_match"
 }
 ```
 
-A trace with no `verdict` or `reward` is not gate-complete — fix the
-grader that should have produced it before this file is considered
-Phase 0 output. Walk `eval-harness-first`'s Phase 0 Exit Checklist in
-full before declaring the harness ready; a missing item means Phase 0
-isn't complete.
+`grader` names the module and function that produced the verdict
+(e.g. `"grade.py:grade_schema_compliance"`) — enough to trace a
+verdict back to the exact check that produced it, not just a bucket
+label. A trace with no `verdict` or `reward` is not gate-complete —
+fix the grader that should have produced it before this file is
+considered Phase 0 output. Walk `eval-harness-first`'s Phase 0 Exit
+Checklist in full before declaring the harness ready; a missing item
+(or its stated N/A, for judge calibration on an all-deterministic
+harness) means Phase 0 isn't complete.
 
 ### Phase 5 — Gate the checkpoint
 
 Runs once the training engineer hands off a completed checkpoint;
-work the four stages in order, per `checkpoint-promotion` — a failure
-at an earlier stage means a later one doesn't run.
+work the four stages below in order, per `checkpoint-promotion` — a
+failure at an earlier stage means a later one doesn't run. (Four
+stages, four numbered steps — the sub-work of scoring drift and
+applying its budget both belong to stage 2, not two separate stages.)
 
-1. **Data-quality gate.** Dedup the training set, check for
+1. **Stage 1 — Data-quality gate.** Dedup the training set, check for
    eval-goldens leakage against every ID in `eval/goldens.jsonl`, and
    scan for label noise, before the checkpoint is touched by any
    eval.
-2. **Re-run the identical harness plus the frozen drift suite** on
-   the checkpoint — the same `eval/` this role built in Phase 0, not
-   a looser or expanded one — and write a fresh
-   `runs/<run-id>/results.json` in the schema above. Diff drift-suite
-   results against `baseline-<model>.json` per benchmark.
-3. **Apply the drift budget by pointer, not by number.** Per-benchmark
-   drift is scored against `checkpoint-promotion`'s Drift Budget
-   table; cite that table rather than restating its thresholds here,
-   and treat its hard-fail row as absolute regardless of task-metric
-   gains.
-4. **Paired arena vs. base.** Position-randomized judge, checkpoint
-   vs. base model, same prompts, per `checkpoint-promotion`. A
-   holdout win that loses the live arena does not ship — stage 2 and
-   stage 3 must agree.
-5. **Canary**, when the deployment target has production traffic to
-   canary against; local-only deployments stop at stage 3 by design,
-   per `checkpoint-promotion`.
-6. **Write `promotion-report.md`.** Cover all four applicable stages
-   as sections, and end with the terminal verdict contract:
+2. **Stage 2 — Capability drift.** Re-run the identical harness plus
+   the frozen drift suite on the checkpoint — the same `eval/` this
+   role built in Phase 0, not a looser or expanded one — and write a
+   fresh `runs/<run-id>/results.json` in the schema above. Diff
+   drift-suite results against `baseline-<model>.json` per benchmark,
+   then apply `checkpoint-promotion`'s Drift Budget table **by
+   pointer, not by number** — cite the table rather than restating
+   its thresholds, and treat its hard-fail row as absolute regardless
+   of task-metric gains.
+3. **Stage 3 — Paired arena vs. base.** Position-randomized judge,
+   checkpoint vs. base model, same prompts — or the deterministic
+   paired-comparison variant from `checkpoint-promotion`'s
+   `references/gate-templates.md` when every grader is deterministic.
+   A holdout win that loses the live arena does not ship — stage 2
+   and stage 3 must agree.
+4. **Stage 4 — Canary**, when the deployment target has production
+   traffic to canary against; local-only deployments stop at stage 3
+   by design, per `checkpoint-promotion`.
+
+**Write `promotion-report.md`.** Cover all four applicable stages
+as sections, and end with the terminal verdict contract:
 
    ```
    ## Verdict

--- a/plugins/llm-finetuning/agents/llm-finetuning-training-engineer.md
+++ b/plugins/llm-finetuning/agents/llm-finetuning-training-engineer.md
@@ -113,11 +113,18 @@ Every run gets one directory; don't scatter its artifacts elsewhere:
 
 ```
 runs/<date>-<slug>/
+├── training-brief.md
+├── data/
+│   ├── dataset-card.md
+│   └── validation-report.md
+├── env-report.json
 ├── train/
 │   ├── config.yaml
-│   └── train.py
-├── logs/
-└── export/
+│   ├── train.py
+│   └── logs/
+├── promotion-report.md
+├── export/
+└── roadbook.md
 ```
 
 ## Failure Triage

--- a/plugins/llm-finetuning/agents/llm-finetuning-training-engineer.md
+++ b/plugins/llm-finetuning/agents/llm-finetuning-training-engineer.md
@@ -1,0 +1,180 @@
+---
+name: llm-finetuning-training-engineer
+description: Fine-tuning implementation workhorse — prepares datasets, generates Unsloth-first training scripts, launches and monitors runs, and exports artifacts. Use after a training brief exists, for dataset preparation, training execution, or model export.
+model: sonnet
+---
+
+You are the fine-tuning training engineer: the workhorse who takes a
+`training-brief.md` someone else already justified and turns it into
+a dataset, a running job, and an exported artifact. You don't re-
+litigate method or model choice, and you don't decide whether a
+checkpoint ships — that verdict belongs to the eval engineer. Your
+job is executing the lifecycle's middle correctly and reporting what
+actually happened, including when it didn't work.
+
+## Purpose
+
+Own Phases 2–4 and 6: build and validate the dataset, confirm the
+environment, generate and launch the training script, monitor the
+run to completion or failure, and export a promoted checkpoint.
+Every fact you need — formats, hyperparameters, thresholds, base-
+model names, the OOM remediation order — lives in a skill; cite it,
+don't recall it from memory.
+
+## Capabilities
+
+- **Dataset preparation and validation** — format selection, chat-
+  template/packing mechanics, the synthetic-data collapse guard, and
+  the dataset card, all per `dataset-curation`.
+- **Config generation per method** — SFT LoRA/QLoRA via `lora-qlora-
+  recipes`, DPO/ORPO/KTO/SimPO via `preference-optimization`,
+  GRPO+RLVR via `grpo-rlvr-training`, VLM SFT via `vision-sft`; the
+  brief's `## Chosen Method` field picks exactly one — never blend
+  hyperparameters across them.
+- **Unsloth-first, TRL escape hatch.** Generate scripts against
+  Unsloth's fast path by default; when a point-release regression
+  forces a fallback, work the escape-hatch procedure in `lora-qlora-
+  recipes`' `references/unsloth-trl-mapping.md` instead of hand-
+  translating configs from memory.
+- **Environment confirmation and run monitoring** — read or produce
+  `env-report.json` before touching a launch command, then launch as
+  a background process, poll logs, emit structured progress, and
+  triage failures against the three classes below.
+- **Export** — format selection and the mandatory smoke test per
+  `quantized-export`, run only after a `PROMOTE` verdict.
+
+## Method
+
+Work the phases in order — don't start Phase 4 without a committed
+Phase 2 dataset card and a Phase 3 environment verdict in hand.
+
+### Phase 2 — Dataset
+
+1. Read `training-brief.md`'s `## Dataset Expectation` and `##
+   Chosen Method` fields.
+2. Build the dataset per `dataset-curation`'s format table; apply
+   the chat template before any concatenation or packing, never
+   after.
+3. If packing is enabled, decode and manually inspect 5–10 packed
+   sequences — mandatory, not a spot check — and attach the decoded
+   samples to the validation report, not just a pass/fail line.
+4. Write the dataset card with all six required fields and walk
+   `dataset-curation`'s Phase 2 Exit Checklist in full — a card
+   missing a field, or a checklist item left unverified, means Phase
+   2 isn't complete.
+
+### Phase 3 — Environment
+
+1. Require `env-report.json` before generating any training script.
+   No report, no launch.
+2. On DGX Spark hardware, run `/spark-preflight` and consume its
+   verdict directly. On any other hardware, run the generic fallback
+   checks it would otherwise perform (driver, VRAM, disk) and write
+   `env-report.json` with `"platform": "generic-nvidia"`.
+3. Treat `blocked` as a hard stop and `ready-with-warnings` as a
+   caller decision to surface, not one to make silently on the
+   caller's behalf.
+
+### Phase 4 — Training
+
+1. Generate `train/config.yaml` and `train/train.py` from the
+   method-specific skill's config, using the brief's method, base
+   model, and memory budget — never a hyperparameter the brief and
+   the method skill didn't together specify.
+2. **Commit both files before launching.** A run whose config isn't
+   committed first is unreproducible the moment it fails — this
+   ordering is not negotiable regardless of how confident the config
+   looks.
+3. Launch training as a background process; don't block the session
+   on it.
+4. Poll `logs/` and emit structured progress lines in this exact
+   shape, one per observed step:
+
+   ```json
+   {"step": 340, "loss": 0.812, "lr": 1.8e-4, "mem_gb": 71, "temp_c": 68}
+   ```
+
+5. On completion, hand the checkpoint to the eval engineer for Phase
+   5 gating — you do not gate your own output.
+
+### Phase 6 — Export
+
+Runs only after a `PROMOTE` verdict reaches you from the eval
+engineer. Pick format and merged-vs-LoRA posture per `quantized-
+export`'s Format Map and the brief's deployment target, write the
+artifact to `export/`, and run the mandatory smoke test — load the
+artifact in its actual target runtime and diff 3–5 golden outputs
+pre- and post-export. An export that skips the smoke test is not
+done, regardless of whether the file loads.
+
+## Run Directory Layout
+
+Every run gets one directory; don't scatter its artifacts elsewhere:
+
+```
+runs/<date>-<slug>/
+├── train/
+│   ├── config.yaml
+│   └── train.py
+├── logs/
+└── export/
+```
+
+## Failure Triage
+
+Three failure classes, each with an exact response. Diagnose which
+class you're in before touching a config value — a fix aimed at the
+wrong class wastes a run and can mask the real cause.
+
+1. **Environment failure** — a launch-time crash, driver mismatch,
+   or resource error traceable to the platform rather than the
+   training config. Go back to preflight, name the specific G-number
+   (on DGX Spark) or the equivalent generic check that failed, and
+   re-run it. **Never retry the launch blind** — relaunching without
+   a fresh preflight just spends another run confirming the same
+   diagnosis.
+2. **Divergence** — loss spikes, NaNs, or a curve that stops
+   improving mid-run. Halt the run, then check causes in this exact
+   order and stop at the first that explains it:
+   1. **fp16 vs. bf16** — confirm `bf16=True` and hardware BF16
+      support per `lora-qlora-recipes`' Failure Modes; fp16 on
+      hardware without solid BF16 support is a known silent-
+      divergence source.
+   2. **Learning rate vs. method** — check the LR against the
+      method-specific skill's table (SFT vs. DPO-family vs. GRPO
+      carry very different settled ranges); a rate ported from the
+      wrong method is the next most common cause.
+   3. **Packing corruption** — only after the first two are cleared,
+      decode packed sequences again per `dataset-curation` and
+      confirm boundaries and masking are still intact; packing bugs
+      are silent at the loss level and only surface as divergence or
+      a flat eval later.
+3. **UMA OOM** — a job that OOMs on unified memory. Work `dgx-spark-
+   ops`'s `spark-memory-thermal-ops` OOM Ladder in its fixed order —
+   flush, then reduce batch size or packing length, then downgrade
+   the method (bf16 LoRA before QLoRA) — citing the ladder by name
+   rather than restating its steps from memory. **Reducing batch
+   size is never step 1.**
+
+A `REJECT` verdict arriving from the eval engineer at Phase 5 is a
+result to report, not a bug in your Phase 4 output to fix silently —
+pass along the verdict, its evidence, and its named top remediation,
+then wait for the next instruction rather than launching a
+corrective retrain on your own authority.
+
+## Behavioral Traits
+
+- Commits `train/config.yaml` and `train/train.py` before launching,
+  every time — no exception for a run that "should" reproduce fine
+  without it.
+- Never edits eval goldens, the drift suite, or anything under
+  `eval/` — that surface belongs to the eval engineer, and touching
+  it from the training side undermines the independence the gate
+  depends on.
+- Reports a failed run with the actual log excerpt that shows the
+  failure, not a paraphrased summary — a reviewer needs to see the
+  loss spike or the traceback itself, not a description of one.
+- Escalates an unresolved OOM past the full ladder (smaller model,
+  multi-Spark) only after flush, batch/pack reduction, and method
+  downgrade have all been tried in order — not as a first resort
+  under time pressure.

--- a/plugins/llm-finetuning/commands/finetune.md
+++ b/plugins/llm-finetuning/commands/finetune.md
@@ -21,6 +21,17 @@ artifact the prior phase produced:
   run. Every Phase 5 checkpoint gets scored against the exact goldens
   and drift suite Phase 0 baselined, so a "pass" always means the
   same thing across every run this command ever launches.
+- **Two lifecycle realities the phase numbering doesn't spell out.**
+  (1) Phase 0's baseline requires a *working inference environment*
+  before Phase 3 would otherwise preflight one — in practice, do
+  enough of Phase 3's environment setup to run inference before
+  Phase 0 needs it, rather than reading the phase order as "Phase 3
+  environment work only starts after Phase 0 finishes." (2)
+  Synthetic goldens/training data generation (Phase 0/Phase 2) needs
+  a teacher LLM to sample from — if a local model is already
+  resident for another purpose, using it and then releasing it
+  before training needs the memory back is expected, not a deviation
+  to justify.
 
 ## Phase 0: Eval Harness & Baseline
 
@@ -184,16 +195,21 @@ prompt: |
   Baseline: {phase0.output}
   Checkpoint: {phase4.output}
 
-  Work the four promotion stages in order per `checkpoint-promotion`:
-  1. Data-quality gate — dedup and eval-goldens leakage check against
-     `eval/goldens.jsonl`.
-  2. Re-run the identical harness plus frozen drift suite used in
-     Phase 0 — not a looser or expanded one — and diff against
-     `eval/baseline-<model>.json`.
-  3. Apply the drift budget by pointer to `checkpoint-promotion`'s
-     Drift Budget table.
-  4. Paired arena vs. base model, position-randomized judge.
-  5. Canary, if the deployment target has production traffic.
+  Work the four promotion stages in order per `checkpoint-promotion`
+  (drift scoring and applying its budget are both part of stage 2,
+  not separate stages):
+  1. Stage 1 — data-quality gate: dedup and eval-goldens leakage
+     check against `eval/goldens.jsonl`.
+  2. Stage 2 — capability drift: re-run the identical harness plus
+     frozen drift suite used in Phase 0 — not a looser or expanded
+     one — diff against `eval/baseline-<model>.json`, and apply the
+     drift budget by pointer to `checkpoint-promotion`'s Drift Budget
+     table.
+  3. Stage 3 — paired arena vs. base model, position-randomized
+     judge (or the deterministic paired-comparison variant when
+     every grader is deterministic).
+  4. Stage 4 — canary, if the deployment target has production
+     traffic.
 
   Write `promotion-report.md` per `checkpoint-promotion`'s template,
   including a `**Goldens fingerprint:**` field with the current

--- a/plugins/llm-finetuning/commands/finetune.md
+++ b/plugins/llm-finetuning/commands/finetune.md
@@ -120,6 +120,8 @@ prompt: |
   identity, execute the G1–G10 gotcha checks, compute UMA memory
   headroom for the planned workload, and write `env-report.json` with
   a verdict of `ready`, `ready-with-warnings`, or `blocked`.
+  Write it to `runs/<date>-<slug>/env-report.json` — this run
+  directory, not your current directory, is where it belongs.
 
   If the dgx-spark-ops plugin is not installed, perform generic NVIDIA
   checks (driver, VRAM, disk) and write env-report.json with platform:
@@ -234,3 +236,9 @@ Summarize:
 - **Lessons worth recording**: anything about the failure buckets,
   the drift budget, or the OOM ladder that would change how the next
   run against this `eval/` should be planned.
+
+**Phase 7 — Roadbook.** Append this summary's lessons and any
+non-obvious workarounds hit during the run to
+`runs/<date>-<slug>/roadbook.md`, under a dated heading for this
+attempt — create the file if it doesn't exist yet, and append rather
+than overwrite on every later run against the same slug.

--- a/plugins/llm-finetuning/commands/finetune.md
+++ b/plugins/llm-finetuning/commands/finetune.md
@@ -30,14 +30,18 @@ prompt: |
   Build or verify the eval harness for: $ARGUMENTS
 
   1. Check whether `eval/` already exists (goldens.jsonl, graders/,
-     drift-suite.yaml). If it does, verify it's complete rather than
-     rebuilding it.
+     drift-suite.yaml, and `baseline-<model>.json`). If it does,
+     verify it's complete rather than rebuilding it.
   2. If it does not exist, build it per `eval-harness-first`: error
      analysis into failure buckets (or synthetic goldens if no traces
      exist), one grader per bucket, judge calibration for any
      LLM-judge bucket, and a frozen `drift-suite.yaml`.
-  3. Run the full harness plus drift suite against the unmodified
-     base model and write `eval/baseline-<model>.json`.
+  3. Only if `eval/baseline-<model>.json` is missing, run the full
+     harness plus drift suite against the unmodified base model and
+     write it. If it already exists, preserve it as-is — it is the
+     measuring stick every later run's checkpoint gets diffed
+     against, and rewriting it on a later run would change what
+     "PROMOTE" means between runs.
   4. Walk `eval-harness-first`'s Phase 0 Exit Checklist in full before
      reporting done.
 
@@ -133,9 +137,11 @@ prompt: |
   its fix.
 </Task>
 
-**Gate:** `env-report.json` must exist with a verdict other than
-`blocked` before Phase 4 starts. A `blocked` verdict is a hard stop —
-report it and the named fix, and do not launch training.
+**Gate:** `env-report.json` must exist with verdict `ready` before
+Phase 4 starts. For `ready-with-warnings`, surface the warnings and
+require explicit caller confirmation before proceeding — this is a
+caller decision, not an automatic pass. A `blocked` verdict is a hard
+stop — report it and the named fix, and do not launch training.
 
 ## Phase 4: Training
 
@@ -189,7 +195,11 @@ prompt: |
   4. Paired arena vs. base model, position-randomized judge.
   5. Canary, if the deployment target has production traffic.
 
-  Write `promotion-report.md` covering all applicable stages, ending
+  Write `promotion-report.md` per `checkpoint-promotion`'s template,
+  including a `**Goldens fingerprint:**` field with the current
+  `sha256sum eval/goldens.jsonl` (first 12 hex chars) — later re-gates
+  via `/promote-checkpoint` compare against this field to detect
+  goldens changes since this gate. Cover all applicable stages, ending
   with the terminal verdict contract: `PROMOTE` or `REJECT`, with
   evidence and — for `REJECT` — exactly one top remediation.
 

--- a/plugins/llm-finetuning/commands/finetune.md
+++ b/plugins/llm-finetuning/commands/finetune.md
@@ -204,6 +204,7 @@ subagent_type: llm-finetuning-training-engineer
 prompt: |
   Export the promoted checkpoint for: $ARGUMENTS
   Brief: {phase1.output}
+  Checkpoint: {phase4.output}
   Promotion report: {phase5.output}
 
   Runs only because Phase 5 returned `PROMOTE`. Pick format and

--- a/plugins/llm-finetuning/commands/finetune.md
+++ b/plugins/llm-finetuning/commands/finetune.md
@@ -1,0 +1,235 @@
+---
+description: Run the eval-gated fine-tuning lifecycle end to end — eval harness, method selection, data, environment, training, checkpoint gate, export
+argument-hint: "[goal, e.g. 'tune an 8B model to write our support replies']"
+---
+
+# Fine-tune for: $ARGUMENTS
+
+## Thinking
+
+This command orchestrates the eval-gated fine-tuning lifecycle across
+seven phases, each owned by a specialist agent and gated by the
+artifact the prior phase produced:
+
+- **Artifact-gating, not step-skipping.** Every phase below is gated
+  by a specific file the previous phase must produce. A missing
+  artifact means the phase still runs — it does not get skipped —
+  and the run stops at that gate rather than improvising downstream
+  work against nothing.
+- **`eval/` outlives `runs/`.** The eval harness and its baseline,
+  built once in Phase 0, are never rebuilt or loosened for a later
+  run. Every Phase 5 checkpoint gets scored against the exact goldens
+  and drift suite Phase 0 baselined, so a "pass" always means the
+  same thing across every run this command ever launches.
+
+## Phase 0: Eval Harness & Baseline
+
+<Task>
+subagent_type: llm-finetuning-eval-engineer
+prompt: |
+  Build or verify the eval harness for: $ARGUMENTS
+
+  1. Check whether `eval/` already exists (goldens.jsonl, graders/,
+     drift-suite.yaml). If it does, verify it's complete rather than
+     rebuilding it.
+  2. If it does not exist, build it per `eval-harness-first`: error
+     analysis into failure buckets (or synthetic goldens if no traces
+     exist), one grader per bucket, judge calibration for any
+     LLM-judge bucket, and a frozen `drift-suite.yaml`.
+  3. Run the full harness plus drift suite against the unmodified
+     base model and write `eval/baseline-<model>.json`.
+  4. Walk `eval-harness-first`'s Phase 0 Exit Checklist in full before
+     reporting done.
+
+  Report the path to `eval/baseline-<model>.json` and a one-paragraph
+  summary of the failure buckets and grader mix.
+</Task>
+
+**Gate:** `eval/baseline-<model>.json` must exist before Phase 1
+starts. If this agent reports the baseline is missing or incomplete,
+stop here and resolve it — do not proceed to method selection against
+no measuring stick.
+
+## Phase 1: Off-Ramps, Method & Model Selection
+
+<Task>
+subagent_type: llm-finetuning-architect
+prompt: |
+  Determine whether fine-tuning is the right tool for: $ARGUMENTS
+  Baseline: {phase0.output}
+
+  1. Interrogate the goal and state the failure mode in one sentence.
+  2. Confirm `eval/baseline-<model>.json` exists (from the baseline
+     above) before considering any method — refuse to proceed without
+     it.
+  3. Walk `finetuning-method-selection`'s decision tree: off-ramps
+     first (RAG, prompt-engineering, CPT), then the data-shape router.
+     If an off-ramp applies, say so plainly and stop — do not draft a
+     training brief for a request better served elsewhere.
+  4. If fine-tuning is warranted, pick a base-model size class and
+     model from the model catalog, size memory feasibility, and — on
+     a GRPO route — confirm the reward function's Inspection Rule ran.
+  5. Write `runs/<date>-<slug>/training-brief.md` per the contract in
+     your instructions, populating every field.
+
+  Report the path to `training-brief.md`, or the off-ramp
+  recommendation if fine-tuning is not warranted.
+</Task>
+
+**Gate:** `runs/<date>-<slug>/training-brief.md` must exist with every
+contract field populated before Phase 2 starts. If Phase 1 recommends
+an off-ramp instead, stop here and report that recommendation — do not
+continue the lifecycle.
+
+## Phase 2: Dataset Preparation
+
+<Task>
+subagent_type: llm-finetuning-training-engineer
+prompt: |
+  Build and validate the training dataset for: $ARGUMENTS
+  Brief: {phase1.output}
+
+  1. Read the brief's `## Dataset Expectation` and `## Chosen Method`
+     fields.
+  2. Build the dataset per `dataset-curation`'s format table, applying
+     the chat template before any concatenation or packing.
+  3. If packing is enabled, decode and manually inspect 5–10 packed
+     sequences and attach the decoded samples to the validation
+     report — mandatory, not a spot check.
+  4. Write the dataset card with all six required fields and walk
+     `dataset-curation`'s Phase 2 Exit Checklist in full.
+
+  Report the dataset card path and the validation report, including
+  the decoded packed samples.
+</Task>
+
+**Gate:** the dataset card and validation report (with decoded packed
+samples, if packing was used) must be complete per the Phase 2 Exit
+Checklist before Phase 3 starts.
+
+## Phase 3: Environment Preflight
+
+<Task>
+subagent_type: dgx-spark-ops-engineer
+prompt: |
+  Preflight the training environment for: $ARGUMENTS
+  Brief: {phase1.output}
+  Dataset: {phase2.output}
+
+  Run the full DGX Spark preflight procedure: confirm hardware
+  identity, execute the G1–G10 gotcha checks, compute UMA memory
+  headroom for the planned workload, and write `env-report.json` with
+  a verdict of `ready`, `ready-with-warnings`, or `blocked`.
+
+  If the dgx-spark-ops plugin is not installed, perform generic NVIDIA
+  checks (driver, VRAM, disk) and write env-report.json with platform:
+  generic-nvidia.
+
+  Report the verdict and, if `blocked`, the specific failing check and
+  its fix.
+</Task>
+
+**Gate:** `env-report.json` must exist with a verdict other than
+`blocked` before Phase 4 starts. A `blocked` verdict is a hard stop —
+report it and the named fix, and do not launch training.
+
+## Phase 4: Training
+
+<Task>
+subagent_type: llm-finetuning-training-engineer
+prompt: |
+  Launch and monitor training for: $ARGUMENTS
+  Brief: {phase1.output}
+  Dataset: {phase2.output}
+  Environment: {phase3.output}
+
+  1. Generate `train/config.yaml` and `train/train.py` from the
+     method-specific skill's config, using the brief's method, base
+     model, and memory budget.
+  2. Commit both files before launching — non-negotiable.
+  3. Launch training as a background process; poll `logs/` and emit
+     structured progress lines (step, loss, lr, mem_gb, temp_c).
+  4. If a failure occurs, triage it against the three failure classes
+     (environment failure, divergence, UMA OOM) in your instructions
+     before touching any config value, and report which class applied
+     and the remediation taken.
+  5. On completion, report the checkpoint location — do not gate it
+     yourself.
+
+  Report the committed config paths, the run directory, and the final
+  checkpoint location (or the failure class and remediation if the
+  run did not complete).
+</Task>
+
+**Gate:** a completed checkpoint must exist before Phase 5 starts. If
+training failed and triage could not produce a completed checkpoint,
+stop here and report the failure class and what was tried.
+
+## Phase 5: Checkpoint Gate
+
+<Task>
+subagent_type: llm-finetuning-eval-engineer
+prompt: |
+  Gate the trained checkpoint for: $ARGUMENTS
+  Baseline: {phase0.output}
+  Checkpoint: {phase4.output}
+
+  Work the four promotion stages in order per `checkpoint-promotion`:
+  1. Data-quality gate — dedup and eval-goldens leakage check against
+     `eval/goldens.jsonl`.
+  2. Re-run the identical harness plus frozen drift suite used in
+     Phase 0 — not a looser or expanded one — and diff against
+     `eval/baseline-<model>.json`.
+  3. Apply the drift budget by pointer to `checkpoint-promotion`'s
+     Drift Budget table.
+  4. Paired arena vs. base model, position-randomized judge.
+  5. Canary, if the deployment target has production traffic.
+
+  Write `promotion-report.md` covering all applicable stages, ending
+  with the terminal verdict contract: `PROMOTE` or `REJECT`, with
+  evidence and — for `REJECT` — exactly one top remediation.
+
+  Report the verdict and the path to `promotion-report.md`.
+</Task>
+
+**Gate:** on `REJECT`, report the verdict, its evidence, and its named
+top remediation, then **STOP** — do not auto-retrigger training or
+loop back to Phase 4 on this command's own authority. On `PROMOTE`,
+continue to Phase 6.
+
+## Phase 6: Export
+
+<Task>
+subagent_type: llm-finetuning-training-engineer
+prompt: |
+  Export the promoted checkpoint for: $ARGUMENTS
+  Brief: {phase1.output}
+  Promotion report: {phase5.output}
+
+  Runs only because Phase 5 returned `PROMOTE`. Pick format and
+  merged-vs-LoRA posture per `quantized-export`'s Format Map and the
+  brief's deployment target, write the artifact to `export/`, and run
+  the mandatory smoke test — load the artifact in its actual target
+  runtime and diff 3–5 golden outputs pre- and post-export.
+
+  Report the export artifact path and the smoke test result. An
+  export that skips the smoke test is not done, regardless of whether
+  the file loads.
+</Task>
+
+**Gate:** the export artifact and a passing smoke test must both exist
+before this command reports success.
+
+## Wrap-up
+
+Summarize:
+
+- **Verdict**: PROMOTE (exported) or REJECT (stopped at Phase 5), or
+  the off-ramp recommendation if the lifecycle stopped at Phase 1.
+- **Artifact paths**: `eval/baseline-<model>.json`,
+  `runs/<date>-<slug>/training-brief.md`, the dataset card,
+  `env-report.json`, the committed `train/config.yaml`,
+  `promotion-report.md`, and (on PROMOTE) the `export/` artifact.
+- **Lessons worth recording**: anything about the failure buckets,
+  the drift budget, or the OOM ladder that would change how the next
+  run against this `eval/` should be planned.

--- a/plugins/llm-finetuning/commands/finetune.md
+++ b/plugins/llm-finetuning/commands/finetune.md
@@ -109,6 +109,12 @@ Checklist before Phase 3 starts.
 
 ## Phase 3: Environment Preflight
 
+If the `dgx-spark-ops` plugin is not installed, send this same prompt
+instead to `llm-finetuning-training-engineer` (whose environment
+method covers the generic path): perform generic NVIDIA checks
+(driver, VRAM, disk) and write `runs/<date>-<slug>/env-report.json`
+with `platform: generic-nvidia`.
+
 <Task>
 subagent_type: dgx-spark-ops-engineer
 prompt: |
@@ -122,10 +128,6 @@ prompt: |
   a verdict of `ready`, `ready-with-warnings`, or `blocked`.
   Write it to `runs/<date>-<slug>/env-report.json` — this run
   directory, not your current directory, is where it belongs.
-
-  If the dgx-spark-ops plugin is not installed, perform generic NVIDIA
-  checks (driver, VRAM, disk) and write env-report.json with platform:
-  generic-nvidia.
 
   Report the verdict and, if `blocked`, the specific failing check and
   its fix.

--- a/plugins/llm-finetuning/commands/promote-checkpoint.md
+++ b/plugins/llm-finetuning/commands/promote-checkpoint.md
@@ -30,19 +30,30 @@ subagent_type: llm-finetuning-eval-engineer
 prompt: |
   Re-gate the trained checkpoint in run directory: $ARGUMENTS
 
-  1. Locate the checkpoint under `$ARGUMENTS/train/` — if none exists,
+  1. Locate the checkpoint by searching `$ARGUMENTS` for checkpoint
+     artifacts, in this order: method-specific training output
+     directories (`outputs-*/`, e.g. `outputs-sft/`, `outputs-grpo/`),
+     `checkpoint-*/` directories, adapter or merged safetensors
+     anywhere under the run directory, and `train/` as one more
+     candidate location. If several match, take the most recent
+     complete checkpoint and state which you chose and why. Only if
+     no checkpoint artifact exists anywhere in the run directory,
      stop and report that this run directory has no checkpoint to
      gate.
   2. Confirm `eval/` exists (goldens.jsonl, graders/, drift-suite.yaml,
      and `eval/baseline-<model>.json`) — if it's missing or
      incomplete, stop and report that rather than gating against
      nothing.
-  3. Compare the current `eval/goldens.jsonl` against the goldens
-     state implied by this run's original gate (its prior
-     `$ARGUMENTS/promotion-report.md`, if one exists). If the goldens
-     have changed since that original gate, note this explicitly in
-     the new report — this verdict is being produced against a
-     different measuring stick than the run's first gate.
+  3. Compute the current goldens fingerprint —
+     `sha256sum eval/goldens.jsonl`, first 12 hex chars — and compare
+     it against the `**Goldens fingerprint:**` field in this run's
+     prior `$ARGUMENTS/promotion-report.md`, if one exists. If the
+     fingerprints differ, note this explicitly in the new report —
+     this verdict is being produced against a different measuring
+     stick than the run's first gate. If the prior report predates
+     the fingerprint field (or there is no prior report), note
+     "goldens provenance unknown for original gate" instead — do not
+     fabricate a comparison.
   4. Work the four promotion stages in order per
      `checkpoint-promotion`:
      - Data-quality gate — dedup and eval-goldens leakage check

--- a/plugins/llm-finetuning/commands/promote-checkpoint.md
+++ b/plugins/llm-finetuning/commands/promote-checkpoint.md
@@ -60,8 +60,9 @@ prompt: |
      verdict contract: `PROMOTE` or `REJECT`, with evidence and — for
      `REJECT` — exactly one top remediation.
 
-  Report the verdict, the path to `promotion-report.md`, and whether
-  the goldens changed since this run's original gate.
+  Report the verdict, the checkpoint path located in step 1, the path
+  to `promotion-report.md`, and whether the goldens changed since this
+  run's original gate.
 </Task>
 
 **Gate:** on `REJECT`, report the verdict, its evidence, and its named
@@ -75,8 +76,7 @@ loop back into the lifecycle on this command's own authority. On
 subagent_type: llm-finetuning-training-engineer
 prompt: |
   Export the promoted checkpoint for run directory: $ARGUMENTS
-  Checkpoint: the checkpoint path located and gated in Phase 5.
-  Promotion report: {phase5.output}
+  Checkpoint and promotion report: {phase5.output}
 
   Runs only because Phase 5 returned `PROMOTE`. Pick format and
   merged-vs-LoRA posture per `quantized-export`'s Format Map and the

--- a/plugins/llm-finetuning/commands/promote-checkpoint.md
+++ b/plugins/llm-finetuning/commands/promote-checkpoint.md
@@ -55,16 +55,20 @@ prompt: |
      "goldens provenance unknown for original gate" instead — do not
      fabricate a comparison.
   4. Work the four promotion stages in order per
-     `checkpoint-promotion`:
-     - Data-quality gate — dedup and eval-goldens leakage check
-       against `eval/goldens.jsonl`.
-     - Re-run the identical harness plus frozen drift suite used for
-       the baseline — not a looser or expanded one — and diff against
-       `eval/baseline-<model>.json`.
-     - Apply the drift budget by pointer to `checkpoint-promotion`'s
+     `checkpoint-promotion` (drift scoring and applying its budget
+     are both part of stage 2, not separate stages):
+     - Stage 1 — data-quality gate: dedup and eval-goldens leakage
+       check against `eval/goldens.jsonl`.
+     - Stage 2 — capability drift: re-run the identical harness plus
+       frozen drift suite used for the baseline — not a looser or
+       expanded one — diff against `eval/baseline-<model>.json`, and
+       apply the drift budget by pointer to `checkpoint-promotion`'s
        Drift Budget table.
-     - Paired arena vs. base model, position-randomized judge.
-     - Canary, if the deployment target has production traffic.
+     - Stage 3 — paired arena vs. base model, position-randomized
+       judge (or the deterministic paired-comparison variant when
+       every grader is deterministic).
+     - Stage 4 — canary, if the deployment target has production
+       traffic.
   5. Write `$ARGUMENTS/promotion-report.md`, overwriting any prior
      report in this run directory, covering all applicable stages and
      the goldens-version note from step 3, ending with the terminal

--- a/plugins/llm-finetuning/commands/promote-checkpoint.md
+++ b/plugins/llm-finetuning/commands/promote-checkpoint.md
@@ -1,0 +1,104 @@
+---
+description: Re-gate an existing fine-tuned checkpoint against the current eval harness and export it on PROMOTE
+argument-hint: "[run directory, e.g. runs/2026-07-13-support-bot]"
+---
+
+# Re-gate checkpoint in: $ARGUMENTS
+
+## Thinking
+
+This command is the standalone re-gate: Phases 5–6 of `/finetune`,
+retargeted at a run directory that already has a trained checkpoint.
+It exists for the case a checkpoint needs re-gating without rerunning
+the whole lifecycle — most commonly because `eval/` changed after the
+run's original gate.
+
+- **`eval/` outlives `runs/`.** The eval harness at `eval/` is the
+  live one, not a copy frozen at the run's original gate time. If its
+  goldens have changed since that gate, this run's verdict is being
+  produced against a different measuring stick than the original —
+  that must be stated in the report, not silently absorbed into the
+  numbers.
+- **Overwrite, not append.** A prior `promotion-report.md` in this run
+  directory reflects the old gate. This command replaces it — the new
+  report is the only one that matters once this command finishes.
+
+## Phase 5: Checkpoint Re-Gate
+
+<Task>
+subagent_type: llm-finetuning-eval-engineer
+prompt: |
+  Re-gate the trained checkpoint in run directory: $ARGUMENTS
+
+  1. Locate the checkpoint under `$ARGUMENTS/train/` — if none exists,
+     stop and report that this run directory has no checkpoint to
+     gate.
+  2. Confirm `eval/` exists (goldens.jsonl, graders/, drift-suite.yaml,
+     and `eval/baseline-<model>.json`) — if it's missing or
+     incomplete, stop and report that rather than gating against
+     nothing.
+  3. Compare the current `eval/goldens.jsonl` against the goldens
+     state implied by this run's original gate (its prior
+     `$ARGUMENTS/promotion-report.md`, if one exists). If the goldens
+     have changed since that original gate, note this explicitly in
+     the new report — this verdict is being produced against a
+     different measuring stick than the run's first gate.
+  4. Work the four promotion stages in order per
+     `checkpoint-promotion`:
+     - Data-quality gate — dedup and eval-goldens leakage check
+       against `eval/goldens.jsonl`.
+     - Re-run the identical harness plus frozen drift suite used for
+       the baseline — not a looser or expanded one — and diff against
+       `eval/baseline-<model>.json`.
+     - Apply the drift budget by pointer to `checkpoint-promotion`'s
+       Drift Budget table.
+     - Paired arena vs. base model, position-randomized judge.
+     - Canary, if the deployment target has production traffic.
+  5. Write `$ARGUMENTS/promotion-report.md`, overwriting any prior
+     report in this run directory, covering all applicable stages and
+     the goldens-version note from step 3, ending with the terminal
+     verdict contract: `PROMOTE` or `REJECT`, with evidence and — for
+     `REJECT` — exactly one top remediation.
+
+  Report the verdict, the path to `promotion-report.md`, and whether
+  the goldens changed since this run's original gate.
+</Task>
+
+**Gate:** on `REJECT`, report the verdict, its evidence, and its named
+top remediation, then **STOP** — do not auto-retrigger training or
+loop back into the lifecycle on this command's own authority. On
+`PROMOTE`, continue to Phase 6.
+
+## Phase 6: Export
+
+<Task>
+subagent_type: llm-finetuning-training-engineer
+prompt: |
+  Export the promoted checkpoint for run directory: $ARGUMENTS
+  Checkpoint: the checkpoint path located and gated in Phase 5.
+  Promotion report: {phase5.output}
+
+  Runs only because Phase 5 returned `PROMOTE`. Pick format and
+  merged-vs-LoRA posture per `quantized-export`'s Format Map and the
+  deployment target recorded in this run's `training-brief.md` (if
+  present), write the artifact to `$ARGUMENTS/export/`, and run the
+  mandatory smoke test — load the artifact in its actual target
+  runtime and diff 3–5 golden outputs pre- and post-export.
+
+  Report the export artifact path and the smoke test result. An
+  export that skips the smoke test is not done, regardless of whether
+  the file loads.
+</Task>
+
+**Gate:** the export artifact and a passing smoke test must both exist
+before this command reports success.
+
+## Wrap-up
+
+Summarize:
+
+- **Verdict**: PROMOTE (exported) or REJECT (stopped at Phase 5).
+- **Goldens note**: whether `eval/`'s goldens changed since this run's
+  original gate, and how that affects confidence in the verdict.
+- **Artifact paths**: `$ARGUMENTS/promotion-report.md` (overwritten)
+  and, on PROMOTE, the `$ARGUMENTS/export/` artifact.

--- a/plugins/llm-finetuning/skills/checkpoint-promotion/SKILL.md
+++ b/plugins/llm-finetuning/skills/checkpoint-promotion/SKILL.md
@@ -11,10 +11,9 @@ cleanly and beats its task metric
 still doesn't ship without
 clearing all four stages below.
 `eval-harness-first` built the
-suite being re-run here — this
-skill is where that suite's
-baseline actually decides
-something.
+suite re-run here — this skill is
+where that suite's baseline
+decides something.
 
 **Input:** a trained checkpoint,
 `eval/baseline-<model>.json` from
@@ -32,7 +31,16 @@ directly.
 
 Each stage gates the next — a
 failure at stage 2 means stage 3
-doesn't run.
+doesn't run. Stages 2 and 3 share
+one expensive inference pass, so
+running them concurrently and
+applying gate order at verdict
+time is licensed on a
+**deterministic** arena (nothing
+saved by serializing); a
+judge-based arena should still
+wait for stage 2 first — that's
+where the real savings are.
 
 1. **Data-quality gate.** Before
    any eval touches the
@@ -44,9 +52,7 @@ doesn't run.
    prevent), and scan for label
    noise. A checkpoint trained on
    leaked goldens invalidates
-   every later stage — this isn't
-   optional preflight, it's why
-   stages 2–4 mean anything.
+   every later stage.
 2. **Held-out + frozen
    capability-drift suite.**
    Re-run `eval-harness-first`'s
@@ -60,7 +66,14 @@ doesn't run.
 3. **Paired arena vs. base.**
    Position-randomized judge,
    checkpoint vs. base model, same
-   prompts. **A holdout win that
+   prompts — or the deterministic
+   paired-comparison variant in
+   `references/gate-templates.md`
+   when every grader in the
+   harness is deterministic (no
+   LLM-judge; position
+   randomization N/A there).
+   **A holdout win that
    loses the live arena does not
    ship** — stage-2 numbers and
    stage-3 judgments must agree; a
@@ -69,16 +82,13 @@ doesn't run.
    real signal, not a discrepancy
    to explain away.
 4. **Canary.** 5–10% stratified
-   rollout with auto-rollback,
-   documented as a required step
-   for any checkpoint reaching
+   rollout with auto-rollback for
+   any checkpoint reaching
    production traffic. **Local-only
    users stop at stage 3** —
-   there's no production traffic
-   to canary against, and skipping
-   stage 4 for a local deployment
-   isn't a shortcut, it's the
-   correct stopping point.
+   skipping stage 4 for a local
+   deployment is the correct
+   stopping point, not a shortcut.
 
 ### Drift Budget
 
@@ -96,20 +106,27 @@ capability still fails here —
 task improvement never buys back
 a drift-budget breach.
 
+**Item count derives from the
+budget, not convenience:** score
+a benchmark here only once its
+95% CI half-width sits under
+half the hard-fail threshold
+(n≥200 for the 5pt budget above
+— n=50 carries ~±13pt of noise).
+Math and a 5-run cautionary
+example: `references/gate-templates.md`.
+
 **RERUN is not a verdict.** A
 2–5pt drift only ever produces a
 `PROMOTE` or `REJECT` after the
 seed-variation rerun completes —
-`PROMOTE` requires the rerun to
-land back at ≤1pt (noise); any
-rerun result still >1pt — whether
-it stays in the 2–5pt band or
-breaches >5pt — resolves stage 2
-to a hard `REJECT`, same as a
-rerun that never happens. No
-report may reach the Verdict
-section with stage 2 still
-showing `RERUN`.
+`PROMOTE` requires landing back
+at ≤1pt (noise); any rerun still
+>1pt — 2–5pt band or >5pt breach
+alike — resolves stage 2 to a
+hard `REJECT`. No report may
+reach the Verdict section with
+stage 2 still showing `RERUN`.
 
 ## Catastrophic Forgetting
 
@@ -127,28 +144,64 @@ stage 2 is what catches it:
   disciplined case.
 - **10–30% general-data replay
   mix is the standard
-  mitigation** — blend that
-  fraction of general-domain data
-  back into training rather than
-  training on target-task data
+  mitigation** — blend general-
+  domain data into training
+  rather than target-task data
   alone.
 
 If a checkpoint hits the >5pt
-hard fail in stage 2, the single
-top remediation is almost always
-**raise the replay fraction
-toward 30%**, not a different
-fix. If replay is already in
-that range and drift still
-exceeds budget, escalate in this
-order: **lower the learning
-rate, then fewer epochs, then a
-smaller LoRA rank** — the same
-rank/LR levers `lora-qlora-recipes`
-and `preference-optimization`
-tune for the training run in the
-first place, applied here in
-reverse.
+hard fail in stage 2, work this
+escalation ladder in order — the
+one canonical order this skill
+and `references/gate-templates.md`
+both point to:
+
+1. **Adjust the replay-mix
+   fraction — swap rows, don't
+   add them** (adding confounds
+   fraction with total optimizer
+   steps). Dose is not monotonic
+   at small-run scale (<~100
+   steps) — re-check drift after
+   any swap.
+2. **Lower the learning rate.**
+3. **Fewer epochs.**
+4. **A smaller LoRA rank** — the
+   same rank/LR levers
+   `lora-qlora-recipes` and
+   `preference-optimization` tune
+   for the training run, applied
+   here in reverse.
+
+This order is a default, not a
+law: **remediation guidance from
+a single before/after run pair
+is a hypothesis** — label it
+low-confidence once any lever
+produces a reversal, and prefer
+a seed-variation repeat over
+trusting the next rung blindly.
+A lever that clears the drift
+breach but drops a
+success-criterion metric below
+target is a two-sided tradeoff
+for a human, not a reason to
+keep descending the ladder. Full
+reasoning and the 5-run
+trajectory behind both caveats:
+`references/gate-templates.md`.
+
+**Disclose drift-suite
+instruction reuse.** A replay row
+copying the drift harness's exact
+instruction phrasing (not just
+disjoint source items) makes that
+benchmark's post-replay score an
+upper bound — flag it
+instruction-familiar, or re-probe
+with a paraphrase, before
+treating a near-budget pass as
+clean.
 
 ## The Verdict
 
@@ -173,33 +226,30 @@ suite dropped 6.2pt (threshold:
 >5pt hard fail) despite +8pt on
 the target task.
 
-Top remediation: raise the
+Top remediation: swap the
 replay-mix fraction from 10%
-toward 30%.
+toward 20%, holding step count
+constant.
 ```
 
 - **REJECT is a result, not an
   error.** A checkpoint that
   fails stage 2's drift budget or
   stage 3's arena comparison did
-  its job — the gate caught
-  something real. Don't treat a
-  REJECT as a failed run needing
-  a rerun of this skill; it's the
-  correct output of a working
-  gate.
+  its job. Don't treat a REJECT
+  as a failed run needing a rerun
+  of this skill; it's the correct
+  output of a working gate.
 - **One remediation, not a
   menu.** Evidence sections may
   list everything observed; the
   verdict section names the
-  single highest-leverage fix —
-  raise replay, drop LR, rerun
-  with seed variation, whatever
-  stage produced the failure
-  implies. A report that hedges
-  across three possible fixes
-  hasn't done the prioritization
-  this skill exists to do.
+  single highest-leverage fix per
+  the escalation ladder above. A
+  report that hedges across three
+  possible fixes hasn't done the
+  prioritization this skill
+  exists to do.
 - **No auto-retraining.** This
   skill produces a verdict and a
   report, not a re-triggered
@@ -207,31 +257,30 @@ toward 30%.
   the remediation back to a human
   decision at
   `finetuning-method-selection` or
-  the relevant training skill —
-  this skill does not loop back
-  into training on its own.
+  the relevant training skill.
 
 ## Related Skills
 
 - `eval-harness-first` — owns the
   drift suite and baseline this
   skill re-runs and diffs
-  against; a checkpoint arriving
-  without `baseline-<model>.json`
-  has nothing to gate against.
+  against; no `baseline-<model>.json`
+  means nothing to gate against.
 - `quantized-export` — the only
   valid next step after a
-  `PROMOTE` verdict; a `REJECT`ed
-  checkpoint never reaches
-  export.
+  `PROMOTE` verdict.
 - `preference-optimization` and
   `lora-qlora-recipes` — own the
-  LR and rank levers named in the
+  LR and rank levers in the
   Catastrophic Forgetting
   escalation path; this skill
-  diagnoses a drift-budget
-  breach, those skills own the
-  config that caused it.
+  diagnoses the breach, those
+  skills own the config that
+  caused it.
+- `dataset-curation` — owns the
+  replay-mix construction recipe
+  the escalation ladder's first
+  rung applies.
 
 Complete `promotion-report.md`
 template with all four stages,

--- a/plugins/llm-finetuning/skills/checkpoint-promotion/SKILL.md
+++ b/plugins/llm-finetuning/skills/checkpoint-promotion/SKILL.md
@@ -107,14 +107,19 @@ task improvement never buys back
 a drift-budget breach.
 
 **Item count derives from the
-budget, not convenience:** score
-a benchmark here only once its
-95% CI half-width sits under
-half the hard-fail threshold
-(n≥200 for the 5pt budget above
-— n=50 carries ~±13pt of noise).
-Math and a 5-run cautionary
-example: `references/gate-templates.md`.
+budget, not convenience:** the
+strict n for a half-width under
+half the 5pt hard-fail threshold
+is ~1,300 at typical accuracy
+(p≈0.7); n=200 is a pragmatic
+floor (±6pt half-width at that
+same p, n=50 ±13pt) — report the
+half-width with every verdict,
+and treat a margin smaller than
+it as `REJECT (uncertain)`, not
+PASS/HARD FAIL. Full math and a
+5-run cautionary example:
+`references/gate-templates.md`.
 
 **RERUN is not a verdict.** A
 2–5pt drift only ever produces a

--- a/plugins/llm-finetuning/skills/checkpoint-promotion/SKILL.md
+++ b/plugins/llm-finetuning/skills/checkpoint-promotion/SKILL.md
@@ -96,6 +96,21 @@ capability still fails here —
 task improvement never buys back
 a drift-budget breach.
 
+**RERUN is not a verdict.** A
+2–5pt drift only ever produces a
+`PROMOTE` or `REJECT` after the
+seed-variation rerun completes —
+`PROMOTE` requires the rerun to
+land back at ≤1pt (noise); any
+rerun result still >1pt — whether
+it stays in the 2–5pt band or
+breaches >5pt — resolves stage 2
+to a hard `REJECT`, same as a
+rerun that never happens. No
+report may reach the Verdict
+section with stage 2 still
+showing `RERUN`.
+
 ## Catastrophic Forgetting
 
 Unmanaged LoRA fine-tuning loses

--- a/plugins/llm-finetuning/skills/checkpoint-promotion/SKILL.md
+++ b/plugins/llm-finetuning/skills/checkpoint-promotion/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: checkpoint-promotion
+description: Gate fine-tuned checkpoints with drift budgets, paired comparison, and forgetting checks before promotion. Use after a training run produces a checkpoint, when deciding whether a tuned model ships, or when a promoted model needs re-gating against updated goldens.
+---
+
+# Checkpoint Promotion
+
+The Phase 5 gate for the whole
+plugin: a checkpoint that trains
+cleanly and beats its task metric
+still doesn't ship without
+clearing all four stages below.
+`eval-harness-first` built the
+suite being re-run here — this
+skill is where that suite's
+baseline actually decides
+something.
+
+**Input:** a trained checkpoint,
+`eval/baseline-<model>.json` from
+`eval-harness-first`, and the
+frozen `eval/drift-suite.yaml`.
+**Output format:**
+`promotion-report.md` — the
+four-stage evidence plus a
+terminal `PROMOTE` or `REJECT`
+verdict that `/finetune` Phase 5
+and `/promote-checkpoint` consume
+directly.
+
+## The Four-Stage Gate
+
+Each stage gates the next — a
+failure at stage 2 means stage 3
+doesn't run.
+
+1. **Data-quality gate.** Before
+   any eval touches the
+   checkpoint: dedup the training
+   set, check for eval-goldens
+   leakage (the exact failure
+   `trace-to-training-data`'s
+   Hygiene section exists to
+   prevent), and scan for label
+   noise. A checkpoint trained on
+   leaked goldens invalidates
+   every later stage — this isn't
+   optional preflight, it's why
+   stages 2–4 mean anything.
+2. **Held-out + frozen
+   capability-drift suite.**
+   Re-run `eval-harness-first`'s
+   `eval/drift-suite.yaml` —
+   MMLU/GSM8K/IFEval plus 200–500
+   domain-adjacent items — against
+   the checkpoint and diff against
+   `baseline-<model>.json` per
+   benchmark against the Drift
+   Budget table below.
+3. **Paired arena vs. base.**
+   Position-randomized judge,
+   checkpoint vs. base model, same
+   prompts. **A holdout win that
+   loses the live arena does not
+   ship** — stage-2 numbers and
+   stage-3 judgments must agree; a
+   win on frozen goldens and a
+   loss in paired comparison is a
+   real signal, not a discrepancy
+   to explain away.
+4. **Canary.** 5–10% stratified
+   rollout with auto-rollback,
+   documented as a required step
+   for any checkpoint reaching
+   production traffic. **Local-only
+   users stop at stage 3** —
+   there's no production traffic
+   to canary against, and skipping
+   stage 4 for a local deployment
+   isn't a shortcut, it's the
+   correct stopping point.
+
+### Drift Budget
+
+| Drift (pts) | Verdict |
+|---|---|
+| ≤1 | Noise — proceed |
+| 2–5 | Rerun with seed variation before deciding |
+| >5 | **HARD FAIL** — no exception for task gains |
+
+The >5pt row governs regardless
+of the others: a checkpoint that
+gained 8 points on the target
+task and lost 6 points of general
+capability still fails here —
+task improvement never buys back
+a drift-budget breach.
+
+## Catastrophic Forgetting
+
+Unmanaged LoRA fine-tuning loses
+real general capability, and
+stage 2 is what catches it:
+
+- **~43% knowledge loss
+  unmanaged** — no replay, no
+  regularization.
+- **~10% with basic management**
+  — some replay or a conservative
+  LR.
+- **~3% with replay + EWC** — the
+  disciplined case.
+- **10–30% general-data replay
+  mix is the standard
+  mitigation** — blend that
+  fraction of general-domain data
+  back into training rather than
+  training on target-task data
+  alone.
+
+If a checkpoint hits the >5pt
+hard fail in stage 2, the single
+top remediation is almost always
+**raise the replay fraction
+toward 30%**, not a different
+fix. If replay is already in
+that range and drift still
+exceeds budget, escalate in this
+order: **lower the learning
+rate, then fewer epochs, then a
+smaller LoRA rank** — the same
+rank/LR levers `lora-qlora-recipes`
+and `preference-optimization`
+tune for the training run in the
+first place, applied here in
+reverse.
+
+## The Verdict
+
+`promotion-report.md` covers all
+four stages as sections and
+**must end with a terminal
+verdict: `PROMOTE` or `REJECT`**,
+the evidence that produced it,
+and exactly one top remediation
+when the verdict is `REJECT`.
+Template: `references/gate-templates.md`.
+The terminal contract other
+skills parse:
+
+```
+## Verdict
+
+REJECT
+
+Evidence: domain-adjacent drift
+suite dropped 6.2pt (threshold:
+>5pt hard fail) despite +8pt on
+the target task.
+
+Top remediation: raise the
+replay-mix fraction from 10%
+toward 30%.
+```
+
+- **REJECT is a result, not an
+  error.** A checkpoint that
+  fails stage 2's drift budget or
+  stage 3's arena comparison did
+  its job — the gate caught
+  something real. Don't treat a
+  REJECT as a failed run needing
+  a rerun of this skill; it's the
+  correct output of a working
+  gate.
+- **One remediation, not a
+  menu.** Evidence sections may
+  list everything observed; the
+  verdict section names the
+  single highest-leverage fix —
+  raise replay, drop LR, rerun
+  with seed variation, whatever
+  stage produced the failure
+  implies. A report that hedges
+  across three possible fixes
+  hasn't done the prioritization
+  this skill exists to do.
+- **No auto-retraining.** This
+  skill produces a verdict and a
+  report, not a re-triggered
+  training run. A `REJECT` hands
+  the remediation back to a human
+  decision at
+  `finetuning-method-selection` or
+  the relevant training skill —
+  this skill does not loop back
+  into training on its own.
+
+## Related Skills
+
+- `eval-harness-first` — owns the
+  drift suite and baseline this
+  skill re-runs and diffs
+  against; a checkpoint arriving
+  without `baseline-<model>.json`
+  has nothing to gate against.
+- `quantized-export` — the only
+  valid next step after a
+  `PROMOTE` verdict; a `REJECT`ed
+  checkpoint never reaches
+  export.
+- `preference-optimization` and
+  `lora-qlora-recipes` — own the
+  LR and rank levers named in the
+  Catastrophic Forgetting
+  escalation path; this skill
+  diagnoses a drift-budget
+  breach, those skills own the
+  config that caused it.
+
+Complete `promotion-report.md`
+template with all four stages,
+the drift-suite scoring table,
+the paired-arena protocol (item
+count, position randomization,
+win-rate threshold), and a
+replay-mix configuration example:
+`references/gate-templates.md`.

--- a/plugins/llm-finetuning/skills/checkpoint-promotion/references/gate-templates.md
+++ b/plugins/llm-finetuning/skills/checkpoint-promotion/references/gate-templates.md
@@ -1,0 +1,173 @@
+Last verified: 2026-07-13
+
+# Gate Templates
+
+Complete `promotion-report.md` template, the
+drift-suite scoring table, the paired-arena
+protocol, and a replay-mix configuration example
+referenced from `SKILL.md`. `BASE_MODEL` and
+`CHECKPOINT` are placeholders throughout — no base
+model family names appear in this file. Benchmark
+names (MMLU, GSM8K, IFEval) are not model names and
+are used freely in the drift-scoring table.
+
+## promotion-report.md Template
+
+Every promotion run produces exactly one of these,
+committed alongside the checkpoint it evaluates.
+All four stages get a section regardless of where
+the run stopped — a stage the run never reached is
+marked `NOT RUN`, not omitted, so a REJECT report
+still documents the full gate.
+
+```markdown
+# Promotion Report: CHECKPOINT
+
+**Run date:** YYYY-MM-DD
+**Baseline:** eval/baseline-BASE_MODEL.json
+**Drift suite:** eval/drift-suite.yaml (frozen)
+
+## Stage 1: Data Quality
+
+- Dedup: PASS/FAIL — N duplicate rows removed
+- Goldens leakage check: PASS/FAIL — N overlapping
+  IDs found (must be 0 to pass)
+- Label noise scan: PASS/FAIL — sample size, flagged
+  rate
+
+## Stage 2: Capability Drift
+
+| Benchmark | Baseline | Checkpoint | Delta | Budget verdict |
+|---|---|---|---|---|
+| mmlu-subset | 68.2 | 67.5 | -0.7 | noise |
+| gsm8k-subset | 81.0 | 78.4 | -2.6 | rerun-seed |
+| ifeval | 74.1 | 74.3 | +0.2 | noise |
+| domain-adjacent | 62.0 | 55.8 | -6.2 | HARD FAIL |
+
+**Stage verdict:** PASS / RERUN / HARD FAIL
+(worst-benchmark delta governs — one HARD FAIL
+row fails the whole stage regardless of the
+others, and regardless of any task-metric gain
+reported elsewhere in this document)
+
+## Stage 3: Paired Arena
+
+- Items: N (see Paired-Arena Protocol below)
+- Position randomization: applied
+- Checkpoint win rate: XX% (95% CI: [XX%, XX%])
+- Threshold: 50% + margin
+- **Stage verdict:** PASS / FAIL
+- Cross-check: does this agree with Stage 2? A
+  Stage 2 PASS plus a Stage 3 FAIL means REJECT
+  regardless of Stage 2 — do not average the two
+  stages into a blended pass.
+
+## Stage 4: Canary
+
+- Applicable: yes (production target) / no
+  (local-only — stopped at Stage 3)
+- Rollout: 5-10% stratified traffic
+- Rollback trigger: defined / not yet defined
+- **Stage verdict:** PASS / FAIL / NOT RUN
+
+## Verdict
+
+**PROMOTE** / **REJECT**
+
+Evidence: one-paragraph summary citing the
+specific stage and number that decided the
+verdict.
+
+Top remediation (REJECT only): single highest-
+leverage fix — do not list more than one.
+```
+
+## Drift-Suite Scoring Table
+
+The frozen benchmark set and the drift budget it's
+scored against — matches `eval-harness-first`'s
+`references/grader-templates.md` `drift-suite.yaml`
+example exactly, so a report generated here diffs
+against the same frozen numbers that skill's
+baseline file recorded:
+
+```yaml
+# scored against eval/drift-suite.yaml
+drift_budget:
+  noise_tolerance_pts: 1        # <=1pt: noise, proceed
+  rerun_seed_variation_pts: [2, 5]   # 2-5pt: rerun before deciding
+  hard_fail_threshold_pts: 5    # >5pt: HARD FAIL, no exceptions
+```
+
+Score every row in the frozen suite (general
+benchmarks plus the 200-500 domain-adjacent items)
+against this budget independently — a single
+domain-adjacent item breaching >5pt fails Stage 2
+even if every general benchmark stayed within
+noise, and even if the checkpoint's target-task
+metric improved substantially in the same run.
+
+## Paired-Arena Protocol
+
+- **N items:** 200 minimum, drawn from the same
+  domain-adjacent pool used in Stage 2 (not the
+  training set, not the goldens used to build the
+  checkpoint) — fewer than 200 pairs produces a win
+  rate too noisy to separate from chance at the 50%
+  + margin threshold below.
+- **Position randomization:** for each item, flip a
+  coin on which of {CHECKPOINT, BASE_MODEL} appears
+  first in the judge's prompt; log the raw
+  assignment. A judge with any positional bias
+  otherwise inflates whichever model is shown
+  first, independent of quality.
+- **Judge:** pinned snapshot, calibrated per
+  `eval-harness-first`'s
+  `references/judge-calibration.md` — an
+  uncalibrated judge here invalidates the whole
+  stage.
+- **Win-rate threshold:** checkpoint must win
+  **50% + margin** (5 points is a reasonable
+  starting margin) with the 95% CI excluding 50% —
+  a checkpoint sitting at 51% with a CI spanning
+  44-58% has not demonstrated a win, it has
+  demonstrated a tie.
+- **Tie handling:** judge ties count as half a win
+  for each side in the win-rate calculation, not as
+  excluded items — excluding ties inflates the
+  apparent win rate.
+
+```python
+def paired_arena_verdict(wins: int, ties: int, losses: int,
+                          margin_pts: float = 5.0) -> str:
+    n = wins + ties + losses
+    win_rate = (wins + 0.5 * ties) / n
+    # bootstrap or Wilson CI in practice; shown here as a stub
+    ci_low, ci_high = bootstrap_ci(wins, ties, losses)
+    threshold = 0.5 + margin_pts / 100
+    if win_rate >= threshold and ci_low > 0.5:
+        return "PASS"
+    return "FAIL"
+```
+
+## Replay-Mix Configuration Example
+
+The standard catastrophic-forgetting mitigation
+from `SKILL.md` — general-domain data blended into
+the target-task training set at 10-30%:
+
+```yaml
+# training data composition
+target_task_fraction: 0.80   # 80% target-task rows
+replay_fraction: 0.20         # 20% general-domain replay
+replay_source: general-instruct-pool-v3
+replay_sampling: stratified   # match replay topic mix to
+                               # general-domain eval coverage
+```
+
+Start at 20% when no prior forgetting data exists
+for the task; move toward 30% if Stage 2 still
+shows a >5pt domain-adjacent drop at 20%, and only
+drop toward 10% once a run at 20% clears Stage 2
+with headroom (all deltas comfortably inside the
+noise band, not just under the hard-fail line).

--- a/plugins/llm-finetuning/skills/checkpoint-promotion/references/gate-templates.md
+++ b/plugins/llm-finetuning/skills/checkpoint-promotion/references/gate-templates.md
@@ -125,34 +125,55 @@ even if every general benchmark stayed within
 noise, and even if the checkpoint's target-task
 metric improved substantially in the same run.
 
-### Sizing the Suite: Item Count From the Budget, Not Convenience
+### Sizing the Suite: The Honest Math, Then the Pragmatic Floor
 
-The rule stated in `SKILL.md`'s Drift Budget
-section, worked in full: pick n so the benchmark's
-95% CI half-width sits comfortably under half the
-hard-fail threshold. For a binomial accuracy metric,
-half-width ≈ `1.96 * sqrt(p*(1-p)/n)`; at `p≈0.5`
-(worst case, widest CI) that's ≈ `0.98/sqrt(n)`.
+The exact formula for a binomial accuracy metric's
+95% CI half-width: `n ≈ 1.96² · p(1-p) / h²`, where
+`h` is the target half-width (as a fraction, e.g.
+0.025 for 2.5pt) and `p` is the benchmark's expected
+accuracy. `SKILL.md`'s Drift Budget section calls for
+sizing `n` so the half-width sits comfortably under
+half the hard-fail threshold — for the 5pt budget
+here, `h=2.5pt` (0.025). Worked at a typical
+GSM8K-style accuracy of `p≈0.7`:
 
-| Hard-fail budget | Half-width target | Minimum n |
-|---|---|---|
-| 5pt (0.05) | <0.025 | ~1600 naive; ~200 in practice at typical accuracy skew away from 0.5 |
-| 1pt (0.01) | <0.005 | ~40,000 naive — essentially never hit a 1pt budget with a benchmark-sized suite |
+```
+n ≈ 1.96² × 0.7×0.3 / 0.025² ≈ 3.8416 × 0.21 / 0.000625 ≈ 1,290
+```
 
-In practice, most drift benchmarks (GSM8K, MMLU
-subsets) sit well away from `p=0.5`, so the
-200-item floor already used by this file's own
-domain-adjacent range and `eval-harness-first`'s
-`references/grader-templates.md` example
-(`n_items: 250`, `n_items: 500`) is the right
-order of magnitude for a 5pt budget — **n=50 is
-not**: at `p≈0.7-0.8` (typical GSM8K accuracy),
-n=50 still carries a Wilson-interval half-width
-around ±13pt, wider than the entire hard-fail
-band. Treat 200 as a floor to derive from the
-budget, never as a fixed constant to copy — a
-tighter budget than 5pt needs the formula
-re-run, not the same 200.
+**The strict n for a 2.5pt half-width at p≈0.7 is
+~1,300 — not 200.** A 200-item suite at that same `p`
+only achieves:
+
+```
+half-width = 1.96 × sqrt(0.7×0.3 / 200) ≈ 1.96 × 0.0324 ≈ 6.3pt
+```
+
+**n=200 is a pragmatic floor, not a suite that meets
+the strict 2.5pt target.** Use it when a ~1,300-item
+domain-adjacent pool doesn't exist for the task (the
+common case), but with three rules attached:
+
+- **Report the actual CI half-width alongside every
+  Stage 2 verdict** — at n=200, p≈0.7 that's ≈±6pt;
+  recompute per benchmark since `p` varies row to row.
+- **A hard-fail margin smaller than the reported CI
+  half-width makes the verdict `REJECT (uncertain)`,
+  never PASS or HARD FAIL.** A delta that clears or
+  breaches the 5pt budget by less than the half-width
+  has not actually been distinguished from noise at
+  200 items. Resolve `REJECT (uncertain)` with either
+  a larger suite (build the domain-adjacent pool
+  toward the ~1,300-item strict number) or a
+  same-config seed-repeat (worked example below)
+  before promoting — do not round an uncertain result
+  to whichever verdict is more convenient.
+- **200 is a floor to derive from the budget, never a
+  fixed constant to copy.** A tighter hard-fail
+  threshold than 5pt needs the formula re-run at the
+  new `h`, and n=50 is well below even the pragmatic
+  floor: at `p≈0.7-0.8`, n=50 carries a half-width
+  around ±13pt, wider than the entire hard-fail band.
 
 ### Cautionary Worked Example: A Real 5-Run Trajectory That Was Mostly Noise
 
@@ -197,13 +218,20 @@ until a same-config seed pair confirms it.
 - **N items:** 200 minimum, drawn from the same
   domain-adjacent pool used in Stage 2 (not the
   training set, not the goldens used to build the
-  checkpoint) — fewer than 200 pairs produces a win
-  rate too noisy to separate from chance at the 50%
-  + margin threshold below. **This 200-item minimum
-  is for the LLM-judge protocol.** The deterministic
-  variant below has its own, smaller floor because
-  it isn't subject to judge noise on top of sampling
-  noise.
+  checkpoint). **This is the same pragmatic floor as
+  Stage 2's sizing rule above, not a suite proven to
+  resolve the margin below at 95% CI:** near the 50%
+  boundary, n=200's half-width is `1.96 ×
+  sqrt(0.25/200) ≈ 6.9pt`, wider than the 5pt margin
+  threshold. Report the CI half-width alongside the
+  win rate; if the margin is smaller than the
+  reported half-width, the stage verdict is `REJECT
+  (uncertain)` — same rule as Stage 2 — resolved with
+  a larger arena or a same-config seed-repeat before
+  promoting. **This 200-item minimum is for the
+  LLM-judge protocol.** The deterministic variant
+  below has its own, smaller floor because it isn't
+  subject to judge noise on top of sampling noise.
 
 ### Deterministic Variant (No LLM-Judge)
 

--- a/plugins/llm-finetuning/skills/checkpoint-promotion/references/gate-templates.md
+++ b/plugins/llm-finetuning/skills/checkpoint-promotion/references/gate-templates.md
@@ -26,6 +26,8 @@ still documents the full gate.
 **Run date:** YYYY-MM-DD
 **Baseline:** eval/baseline-BASE_MODEL.json
 **Drift suite:** eval/drift-suite.yaml (frozen)
+**Goldens fingerprint:** <sha256 of eval/goldens.jsonl, first 12 hex chars>
+<!-- re-gates compare this field to detect goldens changes since this gate -->
 
 ## Stage 1: Data Quality
 

--- a/plugins/llm-finetuning/skills/checkpoint-promotion/references/gate-templates.md
+++ b/plugins/llm-finetuning/skills/checkpoint-promotion/references/gate-templates.md
@@ -1,4 +1,4 @@
-Last verified: 2026-07-13
+Last verified: 2026-07-14
 
 # Gate Templates
 
@@ -96,6 +96,12 @@ leverage fix — do not list more than one.
 
 ## Drift-Suite Scoring Table
 
+**Units: "pts" throughout this file and `SKILL.md`'s
+Drift Budget table mean percentage points (absolute
+accuracy difference, e.g. 78% → 46% is 32pts), never
+relative percent change.** State this explicitly in
+every report rather than leaving it implicit.
+
 The frozen benchmark set and the drift budget it's
 scored against — matches `eval-harness-first`'s
 `references/grader-templates.md` `drift-suite.yaml`
@@ -119,6 +125,73 @@ even if every general benchmark stayed within
 noise, and even if the checkpoint's target-task
 metric improved substantially in the same run.
 
+### Sizing the Suite: Item Count From the Budget, Not Convenience
+
+The rule stated in `SKILL.md`'s Drift Budget
+section, worked in full: pick n so the benchmark's
+95% CI half-width sits comfortably under half the
+hard-fail threshold. For a binomial accuracy metric,
+half-width ≈ `1.96 * sqrt(p*(1-p)/n)`; at `p≈0.5`
+(worst case, widest CI) that's ≈ `0.98/sqrt(n)`.
+
+| Hard-fail budget | Half-width target | Minimum n |
+|---|---|---|
+| 5pt (0.05) | <0.025 | ~1600 naive; ~200 in practice at typical accuracy skew away from 0.5 |
+| 1pt (0.01) | <0.005 | ~40,000 naive — essentially never hit a 1pt budget with a benchmark-sized suite |
+
+In practice, most drift benchmarks (GSM8K, MMLU
+subsets) sit well away from `p=0.5`, so the
+200-item floor already used by this file's own
+domain-adjacent range and `eval-harness-first`'s
+`references/grader-templates.md` example
+(`n_items: 250`, `n_items: 500`) is the right
+order of magnitude for a 5pt budget — **n=50 is
+not**: at `p≈0.7-0.8` (typical GSM8K accuracy),
+n=50 still carries a Wilson-interval half-width
+around ±13pt, wider than the entire hard-fail
+band. Treat 200 as a floor to derive from the
+budget, never as a fixed constant to copy — a
+tighter budget than 5pt needs the formula
+re-run, not the same 200.
+
+### Cautionary Worked Example: A Real 5-Run Trajectory That Was Mostly Noise
+
+From a dogfood run gating LoRA checkpoints on a
+frozen n=50 GSM8K drift slice, then re-measuring
+the same checkpoints at n=200 once the pattern
+looked suspicious:
+
+| Run | Config change | GSM8K@n=50 | GSM8K@n=200 |
+|---|---|---|---|
+| r1 | 0% replay (baseline config) | 46 | — |
+| r2 | +20% replay (swapped) | 64 | 60.0 |
+| r3 | r2 + lower LR | 72 | — |
+| r4 | r2 + 30% replay (added, not swapped) | 46 | — |
+| r5 | r2 exact config, seed repeat | 56 | 58.5 |
+
+Read at n=50, this trajectory looks like real
+signal: replay helps (+18pt), LR helps further
+(+8pt), more replay hurts (-26pt) — a story
+worth writing a remediation note about. Read at
+n=200 for the two points actually re-measured
+(r2 and r5, same config, different seed): 60.0
+vs 58.5, **overlapping Wilson CIs** — statistically
+indistinguishable, against a base-model score
+this run family never got within ~23pt of at
+either n. The entire 46→64→72→46 shape at n=50
+was sampling noise riding on top of one
+consistently large true drift. Two lessons this
+motivates in `SKILL.md`'s escalation-ladder
+caveats: (1) a per-checkpoint verdict at n=50 is
+still a fact about that checkpoint on those 50
+items, but (2) the run-to-run remediation
+trajectory built from a sequence of n=50 verdicts
+is not a reliable guide to which lever worked —
+re-run the suite at budget-derived n before
+trusting a multi-run remediation story, and treat
+single-seed lever attribution as a hypothesis
+until a same-config seed pair confirms it.
+
 ## Paired-Arena Protocol
 
 - **N items:** 200 minimum, drawn from the same
@@ -126,7 +199,39 @@ metric improved substantially in the same run.
   training set, not the goldens used to build the
   checkpoint) — fewer than 200 pairs produces a win
   rate too noisy to separate from chance at the 50%
-  + margin threshold below.
+  + margin threshold below. **This 200-item minimum
+  is for the LLM-judge protocol.** The deterministic
+  variant below has its own, smaller floor because
+  it isn't subject to judge noise on top of sampling
+  noise.
+
+### Deterministic Variant (No LLM-Judge)
+
+When every grader in the harness is deterministic
+(code-based, no judge anywhere), Stage 3 collapses
+to a per-golden paired comparison instead of a
+judge-scored arena:
+
+- **Pairing:** for each item in `eval/goldens.jsonl`,
+  compare the checkpoint's graded verdict against the
+  baseline's verdict on the identical prompt (from
+  `runs/baseline/results.json`, paired by `task_id`).
+  Win = checkpoint passed where baseline failed; loss
+  = the reverse; tie = same verdict either way.
+- **N items:** every golden, not a 200-item minimum —
+  the goldens set itself is the population, not a
+  sample drawn from a larger pool. If the goldens set
+  is small (dogfood scale, <100 items), say so in the
+  report and treat the resulting CI width as evidence
+  quality, not grounds to pad the count with
+  unrelated items.
+- **Position randomization:** N/A — deterministic
+  grading is order-independent, so there's no position
+  bias to correct for.
+- **Judge calibration:** N/A — no judge in this path.
+- **Tie handling and win-rate threshold:** same as the
+  judge protocol below (ties count half a win each;
+  50% + margin, CI excludes 50%).
 - **Position randomization:** for each item, flip a
   coin on which of {CHECKPOINT, BASE_MODEL} appears
   first in the judge's prompt; log the raw
@@ -168,9 +273,13 @@ def paired_arena_verdict(wins: int, ties: int, losses: int,
 
 ## Replay-Mix Configuration Example
 
-The standard catastrophic-forgetting mitigation
-from `SKILL.md` — general-domain data blended into
-the target-task training set at 10-30%:
+The standard catastrophic-forgetting mitigation —
+general-domain data blended into the target-task
+training set at 10-30%. **The escalation order
+(when and how far to move this fraction) is owned
+by `SKILL.md`'s Catastrophic Forgetting section —
+this file gives the config shape and the
+swap-not-add mechanic, not a competing order.**
 
 ```yaml
 # training data composition
@@ -182,8 +291,23 @@ replay_sampling: stratified   # match replay topic mix to
 ```
 
 Start at 20% when no prior forgetting data exists
-for the task; move toward 30% if Stage 2 still
-shows a >5pt domain-adjacent drop at 20%, and only
-drop toward 10% once a run at 20% clears Stage 2
-with headroom (all deltas comfortably inside the
-noise band, not just under the hard-fail line).
+for the task. When a later run needs to move this
+fraction, **swap rows rather than adding them** —
+drop target-task rows out of the mix as replay rows
+go in, so total row/step count holds constant
+between runs. Adding replay rows on top of the
+existing set changes replay fraction and total
+optimizer steps in the same move, which makes it
+impossible to attribute a drift-score change to
+either variable alone — see `dataset-curation`'s
+replay-mix construction recipe
+(`references/synthetic-data.md`) for the full
+swap procedure. Do not assume the dose-response is
+monotonic: a documented dogfood run saw 30.4%
+replay (added, not swapped) score 18 points *worse*
+on the replayed capability than 20% replay at
+otherwise-identical config, because the added rows
+also raised total steps 50→58. Only drop toward 10%
+once a run at 20% clears Stage 2 with headroom (all
+deltas comfortably inside the noise band, not just
+under the hard-fail line).

--- a/plugins/llm-finetuning/skills/checkpoint-promotion/references/gate-templates.md
+++ b/plugins/llm-finetuning/skills/checkpoint-promotion/references/gate-templates.md
@@ -52,6 +52,16 @@ row fails the whole stage regardless of the
 others, and regardless of any task-metric gain
 reported elsewhere in this document)
 
+RERUN is a mid-report state, not a terminal one —
+`## Verdict` below may never show `PROMOTE` or
+`REJECT` while this line still reads `RERUN`.
+Complete the seed-variation rerun first, then
+overwrite this line with the outcome: PASS (rerun
+landed ≤1pt) or HARD FAIL (rerun still >1pt, in
+either the 2–5pt band or beyond) — this stage
+resolves to PASS or HARD FAIL, never RERUN, before
+the report reaches a verdict.
+
 ## Stage 3: Paired Arena
 
 - Items: N (see Paired-Arena Protocol below)
@@ -142,7 +152,11 @@ metric improved substantially in the same run.
 ```python
 def paired_arena_verdict(wins: int, ties: int, losses: int,
                           margin_pts: float = 5.0) -> str:
+    if wins < 0 or ties < 0 or losses < 0:
+        raise ValueError("paired_arena_verdict: counts must be non-negative")
     n = wins + ties + losses
+    if n == 0:
+        raise ValueError("paired_arena_verdict: no arena results (wins+ties+losses == 0)")
     win_rate = (wins + 0.5 * ties) / n
     # bootstrap or Wilson CI in practice; shown here as a stub
     ci_low, ci_high = bootstrap_ci(wins, ties, losses)

--- a/plugins/llm-finetuning/skills/dataset-curation/SKILL.md
+++ b/plugins/llm-finetuning/skills/dataset-curation/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: dataset-curation
+description: Prepare, format, and validate datasets for supervised fine-tuning and preference training. Use when converting raw data into training format, applying chat templates, configuring sequence packing, generating synthetic training data, or writing a dataset card before a run.
+---
+
+# Dataset Curation
+
+This skill assumes `finetuning-method-selection`
+already routed here because the next step is
+preparing data, not choosing a training method.
+What follows: format selection by target method,
+the template/packing mechanics behind the most
+common silent training failures, rules for mixing
+in synthetic data without collapse, and the dataset
+card that closes out Phase 2 before a run starts.
+
+**Input:** raw examples (demonstrations, preference
+judgments, or task prompts) plus a routing decision
+from `finetuning-method-selection`.
+**Output format:** a formatted, packed, validated
+JSONL dataset plus a completed dataset card — the
+Phase 2 artifact `/finetune` checks for before
+launching training.
+
+## Format Selection
+
+| Method | Shape | Rows |
+|---|---|---|
+| SFT, single-turn | Instruct (`instruction`/`response` or `prompt`/`completion`) | ~1,000+ recommended floor |
+| SFT, multi-turn | Conversation / ChatML `messages` list | ~1,000+ recommended floor |
+| DPO / ORPO | Preference pair (`prompt`, `chosen`, `rejected`) | Method-dependent, see `preference-optimization` |
+| KTO | Unpaired (`prompt`, `completion`, `label`) | Method-dependent, see `preference-optimization` |
+| GRPO / RLVR | Prompt-only (`prompt` + verifier metadata) | Method-dependent, see `grpo-rlvr-training` |
+
+- **~1,000+ rows is the recommended floor for SFT**,
+  not a target. Below it, a handful of low-quality
+  or duplicate examples can dominate the gradient;
+  above it, **quality over quantity** — a smaller
+  verified, deduplicated set consistently
+  outperforms a larger noisy one on the same task.
+- One row of the ChatML shape, for orientation —
+  the remaining four formats (instruct, DPO pair,
+  KTO unpaired, GRPO prompt-only) plus a
+  ShareGPT→role/content conversion note live in
+  `references/formats-and-templates.md`:
+
+  ```json
+  {"messages": [
+    {"role": "user", "content": "..."},
+    {"role": "assistant", "content": "..."}
+  ]}
+  ```
+
+## Chat Templates and Loss Masking
+
+Apply the target model's chat template **before**
+any concatenation or packing, never after. Packing
+raw text and templating the packed blob afterward
+corrupts turn boundaries — role markers land in the
+wrong place relative to where each example starts
+and ends.
+
+- **Train on assistant responses only.** Mask the
+  loss (`-100` in the labels tensor) over system and
+  user turns and the template's own role markers —
+  only assistant-turn content tokens should
+  contribute to the loss.
+- **Template/tokenizer mismatches are a top silent
+  failure mode.** A model trained against one chat
+  template but served (or evaluated) with a
+  different one degrades without erroring. Verify
+  the same template string used in training is the
+  one applied at inference and eval time.
+- Full template-application and loss-masking code
+  sketch with the current TRL API (`processing_class`,
+  not `tokenizer=`): `references/formats-and-templates.md`.
+  Sanity-check the mask before training:
+
+  ```python
+  assert (labels[loss_mask] != -100).all()  # assistant spans only
+  ```
+
+## Packing
+
+**Without packing, 40–70% of compute is spent on
+padding** — variable-length examples batched at a
+fixed sequence length waste the gap between each
+example's real length and the batch's max length.
+Packing concatenates multiple examples into one
+sequence up to the max length, eliminating most of
+that waste.
+
+- **Packing changes batch semantics.** A packed
+  sequence is not the same unit as an example — one
+  packed sequence can contain several original
+  examples, so "steps per epoch" and any LR
+  schedule keyed to example count shift once packing
+  is on. Recompute schedule milestones against
+  packed-sequence count, not raw example count.
+- **MANDATORY validation step: decode and manually
+  inspect 5–10 packed sequences before scaling to a
+  full run.** Pull 5–10 packed sequences, decode
+  them back to text, and confirm: example boundaries
+  land where expected, template markers are intact
+  per sub-example, and the loss mask still covers
+  assistant turns only within each packed sequence.
+  Not optional — packing bugs are silent (the run
+  trains, the loss curve looks normal) and only
+  surface in eval quality, hours later:
+
+  ```python
+  for seq in packed_dataset.select(range(10)):
+      print(tokenizer.decode(seq["input_ids"]))
+  ```
+
+## Synthetic Data Rules
+
+- **Keep ≥25% real data as a collapse guard.**
+  Training on a growing share of model-generated
+  data without a real-data floor drives measurable
+  quality collapse over successive generations —
+  25% real is the minimum that holds the line, not
+  a target to trend toward.
+- **Magpie and rejection sampling are the
+  workhorses.** Magpie extracts prompts from the
+  target model's own template prior (no seed prompt
+  needed); rejection sampling generates several
+  candidates per prompt and keeps only the ones a
+  filter or verifier passes. Both beat naive
+  single-shot generation at the same budget.
+- **Targeted, student-aware generation beats static
+  generation by 1.3–2x sample efficiency.** Aiming
+  generation at the current student model's actual
+  failure modes, instead of a fixed prompt set, hits
+  a quality bar with 1.3–2x fewer filtered examples.
+- **Typical accept rates after filtering run
+  10–30%.** Plan generation volume accordingly — a
+  10,000-row target at 15% accept needs roughly
+  65,000+ raw generations, not 10,000.
+- Full generation-method ranking, the filter funnel,
+  and the teacher→student distillation pattern:
+  `references/synthetic-data.md`.
+
+## The Dataset Card
+
+Every dataset that reaches training gets a dataset
+card — the required Phase 2 artifact `/finetune`
+checks for before launching a run. The card is not
+free-form documentation; it MUST carry these fields:
+
+- **Provenance** — where every row came from (real
+  source(s), synthetic method(s), or both),
+  traceable to `trace-to-training-data` output.
+- **Counts** — total rows, and rows per split
+  (train/eval/held-out) if split.
+- **Synthetic/real ratio** — the measured ratio,
+  checked against the ≥25% real floor above.
+- **Dedup method** — exact-match, semantic
+  (embedding-similarity threshold), or both; see
+  the filter funnel in `references/synthetic-data.md`.
+- **Template used** — the exact chat template
+  string/identifier, the same one Chat Templates
+  and Loss Masking requires stays consistent
+  through inference and eval — this is what ties an
+  `eval-harness-first` run back to the checkpoint.
+- **Packing config** — whether packing was used,
+  max sequence length, and confirmation the
+  5–10-sequence manual inspection above was done.
+
+A dataset missing any of these six fields isn't
+ready for `/finetune` — treat the card as a gate,
+not a summary written after the fact.
+
+## References
+
+- `references/formats-and-templates.md` — JSONL
+  examples for every format above, current-TRL
+  template-application code, and the
+  ShareGPT→role/content conversion note.
+- `references/synthetic-data.md` — generation-method
+  ranking, filter funnel, and teacher→student
+  distillation pattern.
+
+Related skills: `finetuning-method-selection` routes
+here; `lora-qlora-recipes`, `vision-sft`, and
+`preference-optimization` consume the datasets this
+skill produces, for SFT, VLM SFT, and preference
+training respectively; `trace-to-training-data` is
+the upstream provenance source for graded-trajectory
+datasets; `eval-harness-first` grades the resulting
+checkpoint and expects the card's template field to
+match what it applies at inference.

--- a/plugins/llm-finetuning/skills/dataset-curation/SKILL.md
+++ b/plugins/llm-finetuning/skills/dataset-curation/SKILL.md
@@ -6,28 +6,28 @@ description: Prepare, format, and validate datasets for supervised fine-tuning a
 # Dataset Curation
 
 This skill assumes `finetuning-method-selection`
-already routed here because the next step is
-preparing data, not choosing a training method.
-What follows: format selection by target method,
-the template/packing mechanics behind the most
-common silent training failures, rules for mixing
-in synthetic data without collapse, and the dataset
-card that closes out Phase 2 before a run starts.
+already routed here — the next step is preparing
+data, not choosing a method. What follows: format
+selection by target method, the template/packing
+mechanics behind the most common silent training
+failures, rules for mixing in synthetic data
+without collapse, and the dataset card that closes
+out Phase 2 before a run starts.
 
 **Input:** raw examples (demonstrations, preference
 judgments, or task prompts) plus a routing decision
 from `finetuning-method-selection`.
 **Output format:** a formatted, packed, validated
 JSONL dataset plus a completed dataset card — the
-Phase 2 artifact `/finetune` checks for before
-launching training.
+Phase 2 artifact `/finetune` checks before launching
+training.
 
 ## Format Selection
 
 | Method | Shape | Rows |
 |---|---|---|
-| SFT, single-turn | Instruct (`instruction`/`response` or `prompt`/`completion`) | ~1,000+ recommended floor |
-| SFT, multi-turn | Conversation / ChatML `messages` list | ~1,000+ recommended floor |
+| SFT, single-turn | Instruct (`instruction`/`response` or `prompt`/`completion`) | ~1,000+ floor |
+| SFT, multi-turn | Conversation / ChatML `messages` list | ~1,000+ floor |
 | DPO / ORPO | Preference pair (`prompt`, `chosen`, `rejected`) | Method-dependent, see `preference-optimization` |
 | KTO | Unpaired (`prompt`, `completion`, `label`) | Method-dependent, see `preference-optimization` |
 | GRPO / RLVR | Prompt-only (`prompt` + verifier metadata) | Method-dependent, see `grpo-rlvr-training` |
@@ -37,10 +37,8 @@ launching training.
   or duplicate examples can dominate the gradient;
   above it, **quality over quantity** — a smaller
   verified, deduplicated set beats a larger noisy one.
-- The ChatML shape, for orientation; the other
-  four formats (instruct, DPO pair, KTO unpaired,
-  GRPO prompt-only) plus a ShareGPT conversion
-  note live in
+- The ChatML shape, for orientation; the other four
+  formats plus a ShareGPT conversion note live in
   `references/formats-and-templates.md`:
 
   ```json
@@ -53,32 +51,29 @@ launching training.
 ## Chat Templates and Loss Masking
 
 Apply the target model's chat template **before**
-any concatenation or packing, never after. Packing
+any concatenation or packing, never after — packing
 raw text and templating the packed blob afterward
-corrupts turn boundaries — role markers land in the
-wrong place relative to where each example starts
-and ends.
+corrupts turn boundaries, landing role markers in
+the wrong place relative to each example.
 
 - **Train on assistant responses only.** Mask the
-  loss (`-100` in the labels tensor) over system and
-  user turns and the template's own role markers —
-  only assistant-turn content tokens should
-  contribute to the loss.
+  loss (`-100` in the labels tensor) over system/user
+  turns and the template's own role markers — only
+  assistant-turn content tokens contribute to loss.
 - **Template/tokenizer mismatches are a top silent
   failure mode.** A model trained against one chat
-  template but served (or evaluated) with a
-  different one degrades without erroring. Verify
-  the same template string used in training is the
-  one applied at inference and eval time.
+  template but served or evaluated with a different
+  one degrades without erroring. Verify the same
+  template string used in training is applied at
+  inference and eval time.
 - **Keep the dataset in `messages` shape** and let
   the trainer template and mask it
   (`assistant_only_loss=True` in current TRL) —
   pre-rendering to a flat text field destroys the
   turn boundaries masking needs. Full code sketch:
-  `references/formats-and-templates.md`.
-  Sanity-check before training — decode only the
-  unmasked positions; you should see only
-  assistant text:
+  `references/formats-and-templates.md`. Sanity-check
+  before training — decode only unmasked positions;
+  expect only assistant text:
 
   ```python
   keep = batch["labels"][0] != -100
@@ -90,27 +85,23 @@ and ends.
 **Without packing, 40–70% of compute is spent on
 padding** — variable-length examples batched at a
 fixed sequence length waste the gap between each
-example's real length and the batch's max.
-Packing concatenates multiple examples into one
-sequence up to the max length, cutting most of
-that waste.
+example's length and the batch's max. Packing
+concatenates multiple examples into one sequence
+up to the max length, cutting most of that waste.
 
 - **Packing changes batch semantics.** A packed
-  sequence is not the same unit as an example — one
-  packed sequence can contain several original
-  examples, so "steps per epoch" and any LR
-  schedule keyed to example count shift once packing
-  is on. Recompute schedule milestones against
-  packed-sequence count, not raw example count.
-- **MANDATORY validation step: decode and manually
-  inspect 5–10 packed sequences before scaling to a
-  full run.** Decode them back to text and confirm:
-  example boundaries land where expected, template
-  markers are intact per sub-example, and the loss
-  mask is still assistant-only within each packed
-  sequence. Not optional — packing bugs are silent
-  (the loss curve looks normal) and only surface in
-  eval quality, hours later:
+  sequence can contain several original examples, so
+  "steps per epoch" and any LR schedule keyed to
+  example count shift once packing is on — recompute
+  schedule milestones against packed-sequence count.
+- **MANDATORY: decode and manually inspect 5–10
+  packed sequences before scaling to a full run.**
+  Confirm example boundaries land where expected,
+  template markers are intact per sub-example, and
+  the loss mask is still assistant-only within each
+  packed sequence. Not optional — packing bugs are
+  silent (the loss curve looks normal) and only
+  surface in eval quality, hours later:
 
   ```python
   for seq in packed_dataset.select(range(10)):
@@ -124,30 +115,42 @@ that waste.
   data without a real-data floor drives measurable
   quality collapse over successive generations —
   25% real is the minimum that holds the line.
+  **General-domain replay rows
+  count toward this floor** —
+  "real" means "not generated
+  for this task from this
+  student," not "human-authored."
+  An all-synthetic-by-construction
+  dataset can meet the ≥25% floor
+  through replay alone (see
+  `references/synthetic-data.md`'s
+  Replay-Mix Construction recipe);
+  state which rows count as "real"
+  in the dataset card rather than
+  leaving the floor structurally
+  unmeetable.
 - **Magpie and rejection sampling are the
   workhorses.** Magpie extracts prompts from the
-  target model's own template prior (no seed prompt
-  needed); rejection sampling generates several
-  candidates per prompt and keeps only the ones a
-  filter or verifier passes. Both beat naive
-  single-shot generation at the same budget.
+  model's own template prior; rejection sampling
+  generates several candidates per prompt and keeps
+  only the ones a filter passes. Both beat naive
+  single-shot generation.
 - **Targeted, student-aware generation beats static
-  generation by 1.3–2x sample efficiency.** Aiming
-  generation at the current student model's actual
-  failure modes, instead of a fixed prompt set, hits
-  a quality bar with 1.3–2x fewer filtered examples.
+  generation by 1.3–2x sample efficiency** — aiming
+  at the student's actual failure modes hits a
+  quality bar with fewer filtered examples.
 - **Typical accept rates after filtering run
-  10–30%.** Plan generation volume accordingly — a
-  10,000-row target at 15% accept needs roughly
-  65,000+ raw generations, not 10,000.
-- Generation-method ranking, filter funnel, and
-  distillation pattern: `references/synthetic-data.md`.
+  10–30%.** Plan volume accordingly — a 10,000-row
+  target at 15% accept needs ~65,000+ raw generations.
+- Generation-method ranking, filter funnel, replay-
+  mix construction, and distillation pattern:
+  `references/synthetic-data.md`.
 
 ## The Dataset Card
 
 Every dataset that reaches training gets a card —
 the required Phase 2 artifact `/finetune` checks
-before launching a run. The card is not free-form
+before launching. The card is not free-form
 documentation; it MUST carry these fields:
 
 - **Provenance** — where every row came from (real
@@ -158,27 +161,26 @@ documentation; it MUST carry these fields:
 - **Synthetic/real ratio** — the measured ratio,
   checked against the ≥25% real floor above.
 - **Dedup method** — exact-match, semantic
-  (embedding-similarity threshold), or both; see
-  the filter funnel in `references/synthetic-data.md`.
+  (embedding threshold), or both; see the filter
+  funnel in `references/synthetic-data.md`.
 - **Template used** — the exact chat template
   string/identifier, kept consistent through
-  inference and eval per Chat Templates and Loss
-  Masking above — this is what ties an
+  inference and eval — this is what ties an
   `eval-harness-first` run back to the checkpoint.
 - **Packing config** — whether packing was used,
   max sequence length, and confirmation the
   5–10-sequence manual inspection above was done.
 
 A dataset missing any of these six fields isn't
-ready for `/finetune` — treat the card as a gate,
-not a summary written after the fact.
+ready for `/finetune` — the card is a gate, not a
+summary written after the fact.
 
 ### Phase 2 Exit Checklist
 
 Before handing off to `/finetune`, confirm:
 
 1. Format matches the method (table above).
-2. Template applied before any concatenation.
+2. Template applied before concatenation.
 3. Loss masked to assistant turns only.
 4. 5–10 packed sequences decoded and read.
 5. ≥25% real data in the final mix.
@@ -187,17 +189,15 @@ Before handing off to `/finetune`, confirm:
 ## References
 
 - `references/formats-and-templates.md` — JSONL
-  examples for every format above, current-TRL
-  masking code, and the ShareGPT conversion note.
+  examples per format, current-TRL masking code,
+  and the ShareGPT conversion note.
 - `references/synthetic-data.md` — generation-method
-  ranking, filter funnel, and teacher→student
-  distillation pattern.
+  ranking, filter funnel, replay-mix construction,
+  and teacher→student distillation pattern.
 
 Related skills: `finetuning-method-selection` routes
 here; `lora-qlora-recipes`, `vision-sft`, and
 `preference-optimization` consume the datasets this
 skill produces; `trace-to-training-data` is the
 provenance source for graded-trajectory datasets;
-`eval-harness-first` grades the resulting checkpoint
-and expects the card's template field to match what
-it applies at inference.
+`eval-harness-first` grades the resulting checkpoint.

--- a/plugins/llm-finetuning/skills/dataset-curation/SKILL.md
+++ b/plugins/llm-finetuning/skills/dataset-curation/SKILL.md
@@ -36,12 +36,11 @@ launching training.
   not a target. Below it, a handful of low-quality
   or duplicate examples can dominate the gradient;
   above it, **quality over quantity** — a smaller
-  verified, deduplicated set consistently
-  outperforms a larger noisy one on the same task.
-- One row of the ChatML shape, for orientation —
-  the remaining four formats (instruct, DPO pair,
-  KTO unpaired, GRPO prompt-only) plus a
-  ShareGPT→role/content conversion note live in
+  verified, deduplicated set beats a larger noisy one.
+- The ChatML shape, for orientation; the other
+  four formats (instruct, DPO pair, KTO unpaired,
+  GRPO prompt-only) plus a ShareGPT conversion
+  note live in
   `references/formats-and-templates.md`:
 
   ```json
@@ -71,13 +70,19 @@ and ends.
   different one degrades without erroring. Verify
   the same template string used in training is the
   one applied at inference and eval time.
-- Full template-application and loss-masking code
-  sketch with the current TRL API (`processing_class`,
-  not `tokenizer=`): `references/formats-and-templates.md`.
-  Sanity-check the mask before training:
+- **Keep the dataset in `messages` shape** and let
+  the trainer template and mask it
+  (`assistant_only_loss=True` in current TRL) —
+  pre-rendering to a flat text field destroys the
+  turn boundaries masking needs. Full code sketch:
+  `references/formats-and-templates.md`.
+  Sanity-check before training — decode only the
+  unmasked positions; you should see only
+  assistant text:
 
   ```python
-  assert (labels[loss_mask] != -100).all()  # assistant spans only
+  keep = batch["labels"][0] != -100
+  print(tokenizer.decode(batch["input_ids"][0][keep]))
   ```
 
 ## Packing
@@ -85,9 +90,9 @@ and ends.
 **Without packing, 40–70% of compute is spent on
 padding** — variable-length examples batched at a
 fixed sequence length waste the gap between each
-example's real length and the batch's max length.
+example's real length and the batch's max.
 Packing concatenates multiple examples into one
-sequence up to the max length, eliminating most of
+sequence up to the max length, cutting most of
 that waste.
 
 - **Packing changes batch semantics.** A packed
@@ -99,14 +104,13 @@ that waste.
   packed-sequence count, not raw example count.
 - **MANDATORY validation step: decode and manually
   inspect 5–10 packed sequences before scaling to a
-  full run.** Pull 5–10 packed sequences, decode
-  them back to text, and confirm: example boundaries
-  land where expected, template markers are intact
-  per sub-example, and the loss mask still covers
-  assistant turns only within each packed sequence.
-  Not optional — packing bugs are silent (the run
-  trains, the loss curve looks normal) and only
-  surface in eval quality, hours later:
+  full run.** Decode them back to text and confirm:
+  example boundaries land where expected, template
+  markers are intact per sub-example, and the loss
+  mask is still assistant-only within each packed
+  sequence. Not optional — packing bugs are silent
+  (the loss curve looks normal) and only surface in
+  eval quality, hours later:
 
   ```python
   for seq in packed_dataset.select(range(10)):
@@ -119,8 +123,7 @@ that waste.
   Training on a growing share of model-generated
   data without a real-data floor drives measurable
   quality collapse over successive generations —
-  25% real is the minimum that holds the line, not
-  a target to trend toward.
+  25% real is the minimum that holds the line.
 - **Magpie and rejection sampling are the
   workhorses.** Magpie extracts prompts from the
   target model's own template prior (no seed prompt
@@ -137,16 +140,15 @@ that waste.
   10–30%.** Plan generation volume accordingly — a
   10,000-row target at 15% accept needs roughly
   65,000+ raw generations, not 10,000.
-- Full generation-method ranking, the filter funnel,
-  and the teacher→student distillation pattern:
-  `references/synthetic-data.md`.
+- Generation-method ranking, filter funnel, and
+  distillation pattern: `references/synthetic-data.md`.
 
 ## The Dataset Card
 
-Every dataset that reaches training gets a dataset
-card — the required Phase 2 artifact `/finetune`
-checks for before launching a run. The card is not
-free-form documentation; it MUST carry these fields:
+Every dataset that reaches training gets a card —
+the required Phase 2 artifact `/finetune` checks
+before launching a run. The card is not free-form
+documentation; it MUST carry these fields:
 
 - **Provenance** — where every row came from (real
   source(s), synthetic method(s), or both),
@@ -159,9 +161,9 @@ free-form documentation; it MUST carry these fields:
   (embedding-similarity threshold), or both; see
   the filter funnel in `references/synthetic-data.md`.
 - **Template used** — the exact chat template
-  string/identifier, the same one Chat Templates
-  and Loss Masking requires stays consistent
-  through inference and eval — this is what ties an
+  string/identifier, kept consistent through
+  inference and eval per Chat Templates and Loss
+  Masking above — this is what ties an
   `eval-harness-first` run back to the checkpoint.
 - **Packing config** — whether packing was used,
   max sequence length, and confirmation the
@@ -171,12 +173,22 @@ A dataset missing any of these six fields isn't
 ready for `/finetune` — treat the card as a gate,
 not a summary written after the fact.
 
+### Phase 2 Exit Checklist
+
+Before handing off to `/finetune`, confirm:
+
+1. Format matches the method (table above).
+2. Template applied before any concatenation.
+3. Loss masked to assistant turns only.
+4. 5–10 packed sequences decoded and read.
+5. ≥25% real data in the final mix.
+6. Dataset card complete — all six fields.
+
 ## References
 
 - `references/formats-and-templates.md` — JSONL
   examples for every format above, current-TRL
-  template-application code, and the
-  ShareGPT→role/content conversion note.
+  masking code, and the ShareGPT conversion note.
 - `references/synthetic-data.md` — generation-method
   ranking, filter funnel, and teacher→student
   distillation pattern.
@@ -184,9 +196,8 @@ not a summary written after the fact.
 Related skills: `finetuning-method-selection` routes
 here; `lora-qlora-recipes`, `vision-sft`, and
 `preference-optimization` consume the datasets this
-skill produces, for SFT, VLM SFT, and preference
-training respectively; `trace-to-training-data` is
-the upstream provenance source for graded-trajectory
-datasets; `eval-harness-first` grades the resulting
-checkpoint and expects the card's template field to
-match what it applies at inference.
+skill produces; `trace-to-training-data` is the
+provenance source for graded-trajectory datasets;
+`eval-harness-first` grades the resulting checkpoint
+and expects the card's template field to match what
+it applies at inference.

--- a/plugins/llm-finetuning/skills/dataset-curation/references/formats-and-templates.md
+++ b/plugins/llm-finetuning/skills/dataset-curation/references/formats-and-templates.md
@@ -106,7 +106,7 @@ tokenizer = AutoTokenizer.from_pretrained(BASE_MODEL)
 
 sft_args = SFTConfig(
     output_dir="./outputs-sft",
-    max_seq_length=2048,
+    max_length=2048,
     packing=True,               # see SKILL.md Packing section before enabling
     assistant_only_loss=True,   # mask loss to assistant turns
 )

--- a/plugins/llm-finetuning/skills/dataset-curation/references/formats-and-templates.md
+++ b/plugins/llm-finetuning/skills/dataset-curation/references/formats-and-templates.md
@@ -25,9 +25,9 @@ pick one and use it consistently across the dataset:
 
 ## ChatML Conversation (SFT, Multi-Turn)
 
-A `messages` list per row — this is the shape
-`SFTTrainer` expects natively once a chat template
-is applied:
+A `messages` list per row — the shape `SFTTrainer`
+templates and loss-masks natively (see Applying the
+Chat Template below):
 
 ```json
 {"messages": [
@@ -87,51 +87,70 @@ requirement before a GRPO run.
 
 ## Applying the Chat Template (Current TRL API)
 
-Apply the template once, at dataset-prep time,
-before any packing:
+**Keep the dataset in `messages` shape and let
+`SFTTrainer` apply the template.** Do not
+pre-render conversations to a flat text field —
+flattening destroys the message boundaries TRL
+needs to mask loss to assistant turns. Given a
+`messages`-shaped dataset, current TRL applies
+the tokenizer's chat template per example (before
+any packing concatenation, satisfying `SKILL.md`'s
+template-before-concatenation rule) and masks loss
+to assistant spans when `assistant_only_loss=True`:
 
 ```python
 from transformers import AutoTokenizer
+from trl import SFTConfig, SFTTrainer
 
 tokenizer = AutoTokenizer.from_pretrained(BASE_MODEL)
-
-def apply_template(example):
-    text = tokenizer.apply_chat_template(
-        example["messages"],
-        tokenize=False,
-        add_generation_prompt=False,
-    )
-    return {"text": text}
-
-dataset = dataset.map(apply_template)
-```
-
-`SFTTrainer` in current TRL takes the templated
-dataset directly and handles loss masking over
-non-assistant spans internally when given a
-`messages`-shaped dataset and
-`processing_class=tokenizer` (not `tokenizer=` —
-see `lora-qlora-recipes`'s
-`references/unsloth-trl-mapping.md` for the full
-Unsloth↔TRL kwarg mapping):
-
-```python
-from trl import SFTConfig, SFTTrainer
 
 sft_args = SFTConfig(
     output_dir="./outputs-sft",
     max_seq_length=2048,
-    packing=True,              # see SKILL.md Packing section before enabling
-    dataset_text_field="text",
+    packing=True,               # see SKILL.md Packing section before enabling
+    assistant_only_loss=True,   # mask loss to assistant turns
 )
 
 trainer = SFTTrainer(
     model=BASE_MODEL,
     args=sft_args,
-    train_dataset=dataset,
-    processing_class=tokenizer,
+    train_dataset=dataset,       # messages-shaped — no pre-rendered text field
+    processing_class=tokenizer,  # current TRL — not tokenizer=
 )
 ```
+
+(`processing_class`, not `tokenizer=` — see
+`lora-qlora-recipes`'s
+`references/unsloth-trl-mapping.md` for the full
+Unsloth↔TRL kwarg mapping.)
+
+`assistant_only_loss=True` requires the tokenizer's
+chat template to mark assistant spans (the
+`{% generation %}` keyword). If the template lacks
+it, TRL raises rather than silently training on
+everything — fix the template, don't fall back to
+flat text.
+
+`apply_chat_template(..., tokenize=False)` is still
+the right tool for *inspecting* what the template
+produces — decode-and-read checks like the packing
+inspection in `SKILL.md` — just not for building
+the training dataset.
+
+### The Flat-Text Path Does NOT Mask
+
+The older pattern — pre-rendering each conversation
+with `apply_chat_template(..., tokenize=False)`
+into a `text` column and pointing
+`SFTConfig(dataset_text_field="text")` at it —
+still runs, but computes loss over the **entire
+sequence**, user turns and template markers
+included. That is exactly the silent
+train-on-everything failure `SKILL.md`'s Chat
+Templates and Loss Masking section warns about.
+It is only appropriate when full-sequence loss is
+actually intended (CPT-style continued pretraining
+on raw text), never for conversational SFT.
 
 ## ShareGPT → role/content Conversion
 

--- a/plugins/llm-finetuning/skills/dataset-curation/references/formats-and-templates.md
+++ b/plugins/llm-finetuning/skills/dataset-curation/references/formats-and-templates.md
@@ -1,0 +1,162 @@
+# Dataset Formats and Template Application
+
+Concrete JSONL examples for every format in
+`SKILL.md`'s Format Selection table, a
+template-application code sketch using current TRL
+conventions, and the ShareGPT→role/content
+conversion note. Base models are never named here —
+every code example uses a `BASE_MODEL` placeholder;
+see `finetuning-method-selection`'s
+`references/model-catalog.md` for which actual
+checkpoint to load.
+
+## Instruct (SFT, Single-Turn)
+
+One JSONL row per example. Either key pair works;
+pick one and use it consistently across the dataset:
+
+```json
+{"instruction": "Summarize the following text in one sentence.", "input": "Q3 revenue grew 14% year-over-year, driven primarily by...", "output": "Q3 revenue grew 14% YoY on strong core-segment demand."}
+```
+
+```json
+{"prompt": "Summarize the following text in one sentence: Q3 revenue grew 14%...", "completion": "Q3 revenue grew 14% YoY on strong core-segment demand."}
+```
+
+## ChatML Conversation (SFT, Multi-Turn)
+
+A `messages` list per row — this is the shape
+`SFTTrainer` expects natively once a chat template
+is applied:
+
+```json
+{"messages": [
+  {"role": "system", "content": "You are a concise technical assistant."},
+  {"role": "user", "content": "What does a KV cache do?"},
+  {"role": "assistant", "content": "It stores attention keys/values from prior tokens so decoding doesn't recompute them each step."},
+  {"role": "user", "content": "Does it grow with context length?"},
+  {"role": "assistant", "content": "Yes, linearly — that's why long-context serving is memory-bound on cache size, not compute."}
+]}
+```
+
+Only the final two `assistant` turns' content
+tokens should carry loss after masking — see
+`SKILL.md`'s Chat Templates and Loss Masking
+section.
+
+## DPO / ORPO — Chosen/Rejected Pair
+
+```json
+{"prompt": "Explain why the sky is blue.", "chosen": "Sunlight scatters off air molecules; shorter (blue) wavelengths scatter more, so blue dominates what reaches your eyes from all directions.", "rejected": "Because the sky reflects the ocean."}
+```
+
+`chosen` and `rejected` are both full responses to
+the same `prompt` — not a diff or a ranking score.
+See `preference-optimization`'s Pair Construction
+section for how to select `rejected` from a graded
+trajectory set (μ−2σ of the reward distribution,
+not the naive minimum).
+
+## KTO — Unpaired Binary Feedback
+
+```json
+{"prompt": "Draft a one-line commit message for a null-check fix.", "completion": "Fix null pointer exception in user lookup", "label": true}
+```
+
+```json
+{"prompt": "Draft a one-line commit message for a null-check fix.", "completion": "misc changes", "label": false}
+```
+
+No pairing between rows is required or expected —
+`label: true` marks desirable, `label: false`
+undesirable. A healthy KTO dataset needs both
+labels represented across the set.
+
+## GRPO / RLVR — Prompt-Only
+
+```json
+{"prompt": "Solve: 17 * 24 = ?", "answer": "408", "verifier": "exact_match"}
+```
+
+No response is stored — GRPO samples completions
+from the policy at train time and scores them
+against `answer` via the named verifier (or a
+reward function). See `grpo-rlvr-training` for
+reward-function design and the manual-inspection
+requirement before a GRPO run.
+
+## Applying the Chat Template (Current TRL API)
+
+Apply the template once, at dataset-prep time,
+before any packing:
+
+```python
+from transformers import AutoTokenizer
+
+tokenizer = AutoTokenizer.from_pretrained(BASE_MODEL)
+
+def apply_template(example):
+    text = tokenizer.apply_chat_template(
+        example["messages"],
+        tokenize=False,
+        add_generation_prompt=False,
+    )
+    return {"text": text}
+
+dataset = dataset.map(apply_template)
+```
+
+`SFTTrainer` in current TRL takes the templated
+dataset directly and handles loss masking over
+non-assistant spans internally when given a
+`messages`-shaped dataset and
+`processing_class=tokenizer` (not `tokenizer=` —
+see `lora-qlora-recipes`'s
+`references/unsloth-trl-mapping.md` for the full
+Unsloth↔TRL kwarg mapping):
+
+```python
+from trl import SFTConfig, SFTTrainer
+
+sft_args = SFTConfig(
+    output_dir="./outputs-sft",
+    max_seq_length=2048,
+    packing=True,              # see SKILL.md Packing section before enabling
+    dataset_text_field="text",
+)
+
+trainer = SFTTrainer(
+    model=BASE_MODEL,
+    args=sft_args,
+    train_dataset=dataset,
+    processing_class=tokenizer,
+)
+```
+
+## ShareGPT → role/content Conversion
+
+Older datasets often ship in ShareGPT's
+`conversations` shape (`from`/`value` keys, `human`/
+`gpt` roles) rather than the `messages`
+(`role`/`content`) shape current TRL expects.
+Convert before templating, not during:
+
+```python
+ROLE_MAP = {"human": "user", "gpt": "assistant", "system": "system"}
+
+def sharegpt_to_messages(example):
+    messages = [
+        {"role": ROLE_MAP[turn["from"]], "content": turn["value"]}
+        for turn in example["conversations"]
+    ]
+    return {"messages": messages}
+
+dataset = dataset.map(sharegpt_to_messages, remove_columns=["conversations"])
+```
+
+Run this conversion — and spot-check a handful of
+converted rows — before the Chat Templates section's
+"apply before concatenation" rule applies; a
+ShareGPT dataset that gets packed or templated
+still in `from`/`value` shape produces malformed
+turns that a template call won't error on.

--- a/plugins/llm-finetuning/skills/dataset-curation/references/synthetic-data.md
+++ b/plugins/llm-finetuning/skills/dataset-curation/references/synthetic-data.md
@@ -1,0 +1,136 @@
+Last verified: 2026-07-13
+
+# Synthetic Data: Generation, Filtering, Distillation
+
+Full detail backing `SKILL.md`'s Synthetic Data
+Rules section: the generation-method ranking, the
+filter funnel candidate generations pass through
+before joining the training set, and the
+teacher→student distillation pattern. Base models
+are never named as recommendations here — `TEACHER`
+and `STUDENT` are placeholders for whichever
+checkpoints a given run uses; see
+`finetuning-method-selection`'s
+`references/model-catalog.md` for actual model
+choice.
+
+## Generation-Method Ranking
+
+Methods below are ordered roughly weakest to
+strongest for sample efficiency and downstream
+quality at the same generation budget. Each level
+subsumes the previous — a rejection-sampling
+pipeline typically generates its candidates with
+Magpie or persona-conditioned prompts underneath,
+rather than replacing them:
+
+1. **Self-Instruct** — bootstrap new prompts from a
+   small seed set by having a model paraphrase and
+   extend them. Cheapest, weakest: prompt diversity
+   plateaus quickly and quality tracks the seed set
+   closely.
+2. **Evol-Instruct** — iteratively rewrite prompts
+   to increase complexity (add constraints, deepen
+   reasoning, broaden scope) across generations.
+   Improves difficulty coverage over Self-Instruct
+   but still seed-dependent.
+3. **Magpie** — extract prompts directly from the
+   target model's own chat-template prior by
+   sampling from the template's user-turn position
+   with no seed prompt at all. Removes seed-set bias
+   entirely; this is why it's a workhorse rather
+   than a niche technique.
+4. **Persona-conditioned generation** — condition
+   prompt generation on a sampled persona/role
+   description to broaden style and topic coverage
+   beyond what a single generation policy produces
+   unconditioned.
+5. **Rejection sampling / verifier-filtered** —
+   generate multiple candidate completions per
+   prompt and keep only those a filter, verifier, or
+   judge accepts. This is the other workhorse from
+   `SKILL.md`, and it composes with any of the
+   prompt-generation methods above — it's a
+   completion-side filter, not a prompt-generation
+   method by itself.
+
+**Targeted, student-aware generation** — steering
+prompt or persona selection toward the current
+student model's actual failure modes rather than
+sampling uniformly — layers on top of any method
+above and is what delivers the 1.3–2x sample
+efficiency gain cited in `SKILL.md`. It requires an
+eval signal on the student to know what its failure
+modes currently are; without that signal, generation
+defaults to untargeted/static.
+
+## Filter Funnel
+
+Apply filters in this order — each stage is
+cheaper than the next, so cheap stages should
+eliminate volume before expensive stages run on
+what's left:
+
+1. **Exact dedup.** Hash-based exact-match removal
+   of identical or near-identical rows. Cheapest
+   stage, run first, removes generation-loop repeats
+   before anything downstream sees them.
+2. **Semantic dedup (~0.92 similarity threshold).**
+   Embed each candidate and drop rows whose
+   nearest-neighbor cosine similarity to an
+   already-kept row exceeds ~0.92. Catches
+   paraphrase-level duplicates exact dedup misses.
+3. **Length filter.** Drop candidates below a
+   minimum or above a maximum token length for the
+   task — too-short responses are usually degenerate,
+   too-long ones are usually rambling or off-task.
+4. **Language ID filter.** Drop candidates that
+   fail a language-ID check against the target
+   language(s) — generation occasionally drifts
+   language, especially from multilingual base
+   models on under-specified prompts.
+5. **Score-based top-30% filter.** Score remaining
+   candidates (reward model, heuristic, or
+   self-consistency score) and keep roughly the
+   top 30% — this is a coarse quality cut before the
+   most expensive stage runs.
+6. **Judge ≥ threshold.** Run the most expensive
+   check last, on the smallest remaining set: an
+   LLM-judge or human-equivalent quality check
+   against a fixed threshold. Rows that fail here
+   are dropped regardless of how they scored
+   upstream.
+
+The **10–30% typical accept rate** from `SKILL.md`
+is the funnel's end-to-end yield across all six
+stages, not any single stage's pass rate — budget
+raw generation volume against the full-funnel yield,
+not against any one stage's rate.
+
+## Teacher→Student Distillation Pattern
+
+1. **Generate teacher traces.** Sample completions
+   (with reasoning traces, where applicable) from
+   `TEACHER` against the target task's prompt
+   distribution.
+2. **Verify.** Run the traces through the Filter
+   Funnel above — a distillation set is a synthetic
+   dataset like any other and still needs the
+   ≥25% real-data floor from `SKILL.md` respected
+   in the final training mix, plus the same dedup
+   and quality stages.
+3. **SFT the student.** Train `STUDENT` on the
+   verified traces using the standard SFT format
+   and template rules from `SKILL.md` and
+   `references/formats-and-templates.md` — a
+   distillation dataset is not a special format,
+   it's a provenance label on an otherwise-ordinary
+   instruct or ChatML dataset.
+
+Record `TEACHER` identity and generation
+configuration (sampling temperature, prompt
+template used to elicit traces) in the dataset
+card's provenance field — "distilled from `TEACHER`"
+is a provenance fact `/finetune` and downstream
+audits both expect to find there, not something to
+leave implicit.

--- a/plugins/llm-finetuning/skills/dataset-curation/references/synthetic-data.md
+++ b/plugins/llm-finetuning/skills/dataset-curation/references/synthetic-data.md
@@ -273,6 +273,21 @@ this confound has produced misleading run-to-run
 trajectories in practice, so treat swap-not-add as a
 hard rule for this recipe, not a style preference.
 
+**Row count is not token count.** Swapping rows
+1-for-1 holds the *row* count constant, but replay
+rows and target-task rows are rarely the same length —
+a swap can still shift total training tokens (and
+therefore `max_steps` under a fixed batch size and
+sequence-packing scheme) even though the row count
+didn't move. Hold total training tokens, or `max_steps`
+directly, constant between the old and new run — not
+just row count — and record the packed-token count
+for each run (not just the row count) in the dataset
+card before attributing a drift-score change to the
+replay-fraction change alone. A run that swapped rows
+but grew packed tokens 10% has the same attribution
+problem as one that added rows outright.
+
 ## Synthetic-Only Datasets and the ≥25% Real Floor
 
 `SKILL.md`'s Synthetic Data Rules require ≥25% real

--- a/plugins/llm-finetuning/skills/dataset-curation/references/synthetic-data.md
+++ b/plugins/llm-finetuning/skills/dataset-curation/references/synthetic-data.md
@@ -1,4 +1,4 @@
-Last verified: 2026-07-13
+Last verified: 2026-07-14
 
 # Synthetic Data: Generation, Filtering, Distillation
 
@@ -135,3 +135,167 @@ card's provenance field — "distilled from `TEACHER`"
 is a provenance fact `/finetune` and downstream
 audits both expect to find there, not something to
 leave implicit.
+
+## Replay-Mix Construction
+
+The implementation recipe behind
+`checkpoint-promotion`'s catastrophic-forgetting
+escalation ladder (`SKILL.md`'s owning document for
+*when* and *how far* to move the replay fraction —
+this section covers *how to build the rows*, the
+single most common REJECT remediation and the part
+most often improvised ad hoc under time pressure).
+Five decisions, in the order they come up:
+
+### 1. General-Domain Source Selection
+
+Pick a source that is genuinely general-domain for
+the capability being protected, not a narrow slice
+that happens to be convenient. Two failure modes to
+avoid:
+
+- **Don't teach to the gate.** If the replay source
+  is drawn from the exact same distribution as the
+  drift suite's benchmarks (e.g. the same GSM8K
+  train split the drift suite's test split comes
+  from), the resulting drift score partially
+  measures "did this model see similar items in
+  training," not "did fine-tuning preserve the
+  underlying capability." This is not automatically
+  disallowed — see `checkpoint-promotion`'s
+  instruction-reuse disclosure rule — but it must be
+  disclosed, and a broader source (not scoped to the
+  drift suite's own benchmarks) is the more
+  defensible default when one exists.
+- **Match the source to the forgetting signature.**
+  If error analysis on the failing checkpoint shows
+  a specific lost capability (e.g. chain-of-thought
+  math reasoning, not general knowledge), a replay
+  source targeting that capability recovers it
+  faster than a generic instruct-tuning mix — but
+  narrows the "general-domain" claim; state in the
+  dataset card which capability the replay mix
+  targets and why.
+
+### 2. Prompt Shape
+
+Decide what shape replay rows take in the
+messages-shaped SFT set — this is a real choice,
+not a detail:
+
+- **Natural instruction** — however the source
+  data's own prompts are phrased. Lowest effort,
+  least targeted.
+- **The drift harness's exact phrasing** — matches
+  the eval's instruction wording. Most directly
+  addresses an instruction-following forgetting
+  signature (e.g. "ignores the show-your-work
+  instruction"), but triggers the instruction-reuse
+  disclosure rule in `checkpoint-promotion` and
+  inflates the post-replay score on that specific
+  benchmark.
+- **Bare input, no instruction wrapper** — closest
+  to raw continued-pretraining signal; weakest at
+  restoring instruction-following specifically.
+
+Pick based on the forgetting signature from error
+analysis, not by default — and disclose the choice
+in the dataset card regardless of which one.
+
+### 3. Answer Reformatting
+
+Decide whether replay reference answers get
+reformatted toward the target task's output
+convention, or kept in the source format as-is.
+Example: rewriting a math dataset's `#### N`
+final-answer terminator to match the target
+task's own extraction convention. This is a
+judgment call that changes what the model learns
+to emit on replay-domain prompts — record the
+exact transformation applied (or "none — kept
+source format") in the dataset card, since it
+changes what a downstream error-analysis pass
+should expect to see.
+
+### 4. Val-Split Treatment
+
+Decide whether the validation split gains replay
+rows or stays task-only:
+
+- **Task-only val split** keeps `eval_loss` directly
+  comparable across runs that only differ in replay
+  fraction — the training loop has zero visibility
+  into replay fit, and replay recovery is only
+  measurable at the next Phase 5 re-gate.
+- **Replay rows in val too** gives in-loop visibility
+  into replay fit, at the cost of `eval_loss` no
+  longer being an apples-to-apples comparison against
+  a prior run's task-only val split.
+
+Neither is universally correct; state which was
+chosen and why in the dataset card, and don't
+compare `eval_loss` across runs that made different
+choices here without noting the confound.
+
+### 5. Disjointness Verification
+
+Before training, verify replay rows don't overlap
+the drift suite or the goldens set — required, not
+optional, regardless of which source was picked in
+step 1:
+
+- **Split-level separation** — draw replay rows only
+  from a source split (e.g. a train split) disjoint
+  from whatever split the drift suite's items are
+  drawn from.
+- **Exact-match text filter** — normalize and
+  exact-match replay row question/prompt text
+  against the drift suite's selected items and
+  `eval/goldens.jsonl`; drop any hit. Record the
+  overlap count found (expect 0) in the dataset card
+  — a nonzero count found and silently dropped is
+  still worth recording, since it signals the source
+  pool needs a tighter split boundary next time.
+
+### When a Later Run Changes the Replay Fraction: Swap, Don't Add
+
+If a checkpoint-promotion gate calls for moving the
+replay fraction (see `checkpoint-promotion`'s
+escalation ladder), implement the change by **swapping
+rows, not adding them**: drop target-task rows out of
+the training set as replay rows go in, so the total
+row/step count holds constant between the old and new
+run. Adding replay rows on top of the existing set
+changes replay fraction and total optimizer steps in
+the same move, making it impossible to attribute a
+later drift-score change to either variable alone —
+this confound has produced misleading run-to-run
+trajectories in practice, so treat swap-not-add as a
+hard rule for this recipe, not a style preference.
+
+## Synthetic-Only Datasets and the ≥25% Real Floor
+
+`SKILL.md`'s Synthetic Data Rules require ≥25% real
+data as a collapse guard. When a training set is
+100% synthetic by construction (a greenfield task
+with no real-data pool to draw from at all — not
+merely a lot of synthetic augmentation on top of a
+real base), that floor is unmeetable by definition
+unless something in the mix counts as "real."
+
+**Resolution: general-domain replay rows count
+toward the ≥25% floor.** "Real" in this rule means
+"not generated for this specific task from this
+specific student model" — a replay row pulled from
+an existing general-instruct dataset (human-authored
+or otherwise pre-existing, not freshly generated by
+the student or its teacher for this run) satisfies
+that definition even though the target-task rows
+around it are 100% synthetic. Build the replay mix
+per the five decisions above, then compute the
+synthetic/real ratio the dataset card requires
+treating replay rows as the "real" share — and state
+explicitly in the card that this is how the ratio
+was met, so a later audit doesn't misread an
+all-synthetic-target-data run as having silently
+skipped the collapse guard.

--- a/plugins/llm-finetuning/skills/dataset-curation/references/synthetic-data.md
+++ b/plugins/llm-finetuning/skills/dataset-curation/references/synthetic-data.md
@@ -72,9 +72,10 @@ eliminate volume before expensive stages run on
 what's left:
 
 1. **Exact dedup.** Hash-based exact-match removal
-   of identical or near-identical rows. Cheapest
-   stage, run first, removes generation-loop repeats
-   before anything downstream sees them.
+   of identical rows (after normalization —
+   whitespace/casing collapsed before hashing).
+   Cheapest stage, run first, removes generation-loop
+   repeats before anything downstream sees them.
 2. **Semantic dedup (~0.92 similarity threshold).**
    Embed each candidate and drop rows whose
    nearest-neighbor cosine similarity to an

--- a/plugins/llm-finetuning/skills/eval-harness-first/SKILL.md
+++ b/plugins/llm-finetuning/skills/eval-harness-first/SKILL.md
@@ -14,8 +14,8 @@ the data-curation engine. The same labeled traces
 that build the goldens become the training set.
 
 **Input:** production/agent traces if they exist, or
-a task spec if they don't, plus human labelers
-willing to grade ≥100 examples.
+a task spec if they don't, plus labelers willing to
+grade ≥100 examples.
 **Output format:** the `eval/` directory below —
 goldens, graders, a drift suite, and a base-model
 baseline that later phases check for before they
@@ -146,16 +146,16 @@ finding.
 
 ```
 eval/
-├── goldens.jsonl          # labeled traces + synthetic goldens, versioned like code
+├── goldens.jsonl          # labeled traces + synthetic goldens, versioned
 ├── graders/                # one module per failure bucket
 │   ├── schema_compliance.py
 │   ├── exact_match.py
 │   └── rubric_judge.py
 ├── drift-suite.yaml        # frozen benchmarks + 200-500 domain-adjacent items
-└── baseline-<model>.json   # gate token: harness + drift suite run against the base model
+└── baseline-<model>.json   # gate token: harness + drift suite vs the base model
 runs/
 └── <run-id>/
-    └── results.json         # per-run harness output, re-run each checkpoint
+    └── results.json         # per-run harness output, one per checkpoint
 ```
 
 `eval/` persists across runs and lives outside
@@ -164,6 +164,21 @@ artifact. `runs/` is disposable and re-creatable;
 `eval/` is not. Never let a run script write into
 `eval/` — only goldens curation, grader edits, and a
 baseline refresh should touch it.
+
+### Phase 0 Exit Checklist
+
+Before `finetuning-method-selection`, confirm:
+
+1. ≥100 traces open-coded; 4–8 failure buckets.
+2. `eval/goldens.jsonl` committed and versioned.
+3. One grader per bucket, deterministic first.
+4. Judges calibrated — TPR/TNR from a sealed split,
+   snapshot pinned, different family.
+5. `eval/drift-suite.yaml` frozen.
+6. `eval/baseline-<model>.json` written.
+
+Missing any of the six? Not Phase 0 complete —
+`/finetune` checks the baseline file before a run.
 
 ## Related Skills
 

--- a/plugins/llm-finetuning/skills/eval-harness-first/SKILL.md
+++ b/plugins/llm-finetuning/skills/eval-harness-first/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: eval-harness-first
-description: Build the evaluation harness that gates every fine-tuning run — golden sets, per-failure-mode graders, judge calibration, and base-model baselines. Use when starting a fine-tuning effort (before any training config), when converting traces into an eval set, or when a judge needs calibration against human labels.
+description: Build the evaluation harness that gates every fine-tuning run — golden sets, per-failure-mode graders, judge calibration, and base-model baselines. Use when starting a fine-tuning effort, when converting traces into an eval set, or when calibrating a judge against human labels.
 ---
 
 # Eval Harness First
@@ -9,17 +9,16 @@ The Phase 0 gate for the whole plugin:
 `finetuning-method-selection` and every downstream
 skill assume this harness exists before a training
 config gets written. The harness is not a run-end
-side artifact — it is the data-curation engine.
-The same labeled traces that build the goldens feed
-training data too, minus an explicit holdout.
+side artifact — it is the data-curation engine. The
+same labeled traces that build the goldens feed
+training data, minus an explicit holdout.
 
 **Input:** production/agent traces if they exist, or
 a task spec if they don't, plus labelers willing to
 grade ≥100 examples.
 **Output format:** the `eval/` directory below —
-goldens, graders, drift suite, and the
-base-model baseline that later phases
-gate on.
+goldens, graders, drift suite, and the base-model
+baseline that later phases gate on.
 
 ## The Gate
 
@@ -28,27 +27,22 @@ config and there is nothing to measure against,
 nothing to catch regressions, and no labeled data
 to train on. The flywheel:
 
-1. **Collect traces** — production or agent spans
-   (OTel/OpenInference), or synthetic tasks if none
-   exist yet.
+1. **Collect traces** — production/agent spans, or
+   synthetic tasks if none exist yet.
 2. **Error analysis** — open coding on ≥100 traces,
-   then axial coding into 4–8 failure buckets.
+   axial coding into 4–8 failure buckets.
 3. **One grader per bucket** — deterministic first;
-   calibrated LLM-judge only where the criterion is
-   genuinely subjective.
-4. **Prioritize** by frequency × severity × value —
-   not every bucket gets fixed first.
+   calibrated LLM-judge only for genuinely
+   subjective criteria.
+4. **Prioritize** by frequency × severity × value.
 5. **The labeled traces feed dataset curation, minus
    an explicit holdout.** Every `eval/goldens.jsonl`
-   ID stays excluded from training data by ID; only
-   the non-held-out traces flow through
-   `trace-to-training-data`.
+   ID stays excluded from training data by ID.
 6. **Train.**
 7. **Re-run the same harness** on the checkpoint —
    not a different, looser one.
 8. **Drift detection feeds back to step 2** — new
-   production failure modes re-open error
-   analysis.
+   production failure modes re-open error analysis.
 
 Steps 2–4 build the harness; steps 5–8 are why it
 must exist first — it is both the training data
@@ -61,19 +55,21 @@ source and the checkpoint's exit gate.
   them, tag failures in your own words, no fixed
   taxonomy yet), then axial coding to collapse those
   tags into 4–8 named failure buckets. Fewer than 4
-  means the coding pass was too shallow; more than
-  8 means buckets need merging.
+  means the coding pass was too shallow; more than 8
+  means buckets need merging. **Exception:**
+  single-failure-surface tasks (e.g. strict-schema
+  extraction) may land at 1–2 buckets with per-field
+  sub-metrics inside one grader — don't invent
+  artificial splits with no evidence behind them.
 - **Synthetic, when traces don't exist yet:**
   dimension-based generation — enumerate the axes
   that matter (task type, difficulty, edge case,
-  persona) and sample the cross-product —
-  free-generated prompts cluster around whatever's
+  persona) and sample the cross-product; free-
+  generated prompts cluster around whatever's
   easiest to write.
 - **Goldens are versioned like code** — commit
   `eval/goldens.jsonl`, diff it in review, tag it per
-  release. It doubles as the CI regression suite:
-  every checkpoint and every prompt change re-runs
-  against it, not just the run that motivated it.
+  release. It doubles as the CI regression suite.
 
 ## Graders
 
@@ -82,21 +78,21 @@ not one for the whole eval set. A single blended
 score hides which bucket regressed.
 
 - **Deterministic first.** Regex, schema validation,
-  or execution-based checks (run the code or the
-  tests) are cheaper, reproducible, and need no
-  calibration. Reach for one before writing a
-  judge prompt.
+  or execution checks are cheaper, reproducible, and
+  need no calibration.
 - **LLM-judge only for genuinely subjective
-  criteria** — tone, faithfulness to a source,
-  "which response is better" — where no deterministic
-  check can express it. A judge grading what a
-  regex could check is wasted latency and
-  calibration burden.
+  criteria** — tone, faithfulness, "which response
+  is better" — where no deterministic check can
+  express it.
 - **Binary pass/fail over Likert.** A 1–5 or 1–10
-  scale looks more informative but is noisier to
-  calibrate and harder to apply consistently;
-  collapse the criterion to a pass/fail line.
-  Templates for all four grader shapes:
+  scale is noisier to calibrate and harder to apply
+  consistently; collapse to pass/fail.
+- **Drift-suite MMLU-style scoring: prefer logprob
+  over generate-and-extract** — a tight token budget
+  makes generate-and-extract parse-brittle for models
+  that preamble, conflating format compliance with
+  the knowledge being measured. Templates for all
+  four grader shapes and this scoring note:
   `references/grader-templates.md`.
 
 ## Judge Calibration Is a Prerequisite
@@ -104,45 +100,39 @@ score hides which bucket regressed.
 Any bucket routed to an LLM-judge needs calibration
 before its verdicts count for anything beyond
 exploration — a hard prerequisite, not a
-nice-to-have.
+nice-to-have. **N/A when no bucket routes to a
+judge** — an all-deterministic harness has nothing
+to calibrate; state that rather than leaving this
+section unaddressed.
 
-- Label ≥100 items, split **train** (few-shot
-  examples for the judge prompt) / **dev** (iterate
-  the prompt) / **sealed test** (report once, no
-  re-touching after).
-- Report **TPR and TNR** against the human labels,
-  not one blended accuracy number — a judge can hit
-  90% by always saying "pass" on a skewed set;
-  TPR/TNR tell the real story.
-- **Pin the judge to a fixed model snapshot.** An
-  unpinned judge that auto-upgrades silently shifts
-  what "pass" means between runs.
-- **Recalibrate on judge-model change, and quarterly
-  regardless** — drift happens without a swap
-  too.
+- Label ≥100 items, split **train**/**dev**/**sealed
+  test** (report once, no re-touching after).
+- Report **TPR and TNR**, not one blended accuracy
+  number — a judge can hit 90% by always saying
+  "pass" on a skewed set.
+- **Pin the judge to a fixed model snapshot** and
+  recalibrate on judge-model change, quarterly
+  regardless.
 - **The judge must come from a different model family
-  than the model under test** — a judge evaluating
-  its own family's outputs is a biased grader.
-- A judge that can't hit the agreed TPR/TNR bar ships
-  **advisory-only**: flag candidates for human review,
-  but don't gate a checkpoint promotion or count
-  toward a pass rate. Full protocol, bias correction,
-  and the recalibration checklist:
+  than the model under test.**
+- A judge that misses the agreed TPR/TNR bar ships
+  **advisory-only** — flags for human review, never
+  gates a promotion. Full protocol, bias correction,
+  and recalibration checklist:
   `references/judge-calibration.md`.
 
 ## The Baseline
 
 Before Phase 1 (method selection) starts, run the
 full harness — goldens plus the capability-drift
-suite — against the unmodified base model. This
-is the number every later checkpoint gets
-compared against.
+suite — against the unmodified base model. This is
+the number every later checkpoint gets compared
+against.
 
 `eval/baseline-<model>.json` is the gate token. No
 baseline file, no comparison basis for
 `checkpoint-promotion` — a checkpoint that "looks
-better" against nothing measured isn't a
-finding.
+better" against nothing measured isn't a finding.
 
 ## Directory Contract
 
@@ -163,52 +153,57 @@ runs/
 `eval/` persists across runs and lives outside
 `runs/` — the fixed measuring stick, not a run
 artifact. `runs/` is disposable; `eval/` is not.
-Never let a run script write into `eval/` — only
-goldens curation, grader edits, and a baseline
-refresh should touch it.
+Never let a run script write into `eval/`. **Canonical
+location:** every per-trace `results.json` — the
+Phase 0 baseline included — lives at
+`runs/<run-id>/results.json`, never under
+`eval/runs/...`; an instruction requesting the
+latter is wrong, not this contract.
 
 ### Phase 0 Exit Checklist
 
 Before `finetuning-method-selection`, confirm:
 
-1. ≥100 traces open-coded; 4–8 failure buckets.
+1. ≥100 traces open-coded; 4–8 failure buckets (N/A
+   floor for synthetic goldens on a single-failure-
+   surface task — see the Building Goldens exception;
+   bucket count then comes from post-baseline error
+   analysis instead).
 2. `eval/goldens.jsonl` committed and versioned.
 3. One grader per bucket, deterministic first.
-4. Judges calibrated — TPR/TNR from a sealed split,
-   snapshot pinned, different family.
+4. Judges calibrated — TPR/TNR, snapshot pinned,
+   different family (**N/A when no bucket routes to
+   an LLM-judge**; state that explicitly).
 5. `eval/drift-suite.yaml` frozen.
 6. `eval/baseline-<model>.json` written.
 
-Missing any of the six? Not Phase 0 complete —
-`/finetune` checks the baseline file before a run.
+Missing any of the six (or its stated N/A)? Not
+Phase 0 complete — `/finetune` checks the baseline
+file before a run.
 
 ## Related Skills
 
-General-purpose evaluation guidance (metrics
-dashboards, A/B testing, non-fine-tuning harnesses)
-lives in the `llm-application-dev` plugin's
-`llm-evaluation` skill — this skill covers only
-the fine-tuning coupling: goldens that double as
-training data, and the baseline that gates a
-checkpoint.
+General-purpose evaluation guidance (dashboards, A/B
+testing, non-fine-tuning harnesses) lives in the
+`llm-application-dev` plugin's `llm-evaluation`
+skill — this skill covers only the fine-tuning
+coupling: goldens that double as training data, and
+the baseline that gates a checkpoint.
 
-- `finetuning-method-selection` — routes here first;
-  won't proceed without this harness.
-- `dataset-curation` — formats the same labeled
-  traces this skill produces into training rows.
+- `finetuning-method-selection` — routes here first.
+- `dataset-curation` — formats these traces into
+  training rows.
 - `trace-to-training-data` — turns graded traces into
   training examples.
 - `checkpoint-promotion` — consumes
-  `baseline-<model>.json`, re-runs this harness
-  on each candidate checkpoint.
+  `baseline-<model>.json`, re-runs this harness on
+  each candidate checkpoint.
 
 ## References
 
-- `references/grader-templates.md` — runnable
-  schema-compliance, exact-match, execution-based,
-  and LLM-judge grader examples, plus a
-  `drift-suite.yaml` example.
+- `references/grader-templates.md` — runnable grader
+  examples per shape, plus a `drift-suite.yaml`
+  example and MMLU logprob-scoring note.
 - `references/judge-calibration.md` — the
-  calibration protocol: splits, TPR/TNR, bias
-  correction, snapshot pinning, and the
-  recalibration schedule.
+  calibration protocol, including the all-
+  deterministic N/A path.

--- a/plugins/llm-finetuning/skills/eval-harness-first/SKILL.md
+++ b/plugins/llm-finetuning/skills/eval-harness-first/SKILL.md
@@ -10,8 +10,8 @@ The Phase 0 gate for the whole plugin:
 skill assume this harness exists before a training
 config gets written. The harness is not a run-end
 side artifact — it is the data-curation engine.
-The same labeled traces that build the goldens
-become the training set.
+The same labeled traces that build the goldens feed
+training data too, minus an explicit holdout.
 
 **Input:** production/agent traces if they exist, or
 a task spec if they don't, plus labelers willing to
@@ -38,9 +38,11 @@ to train on. The flywheel:
    genuinely subjective.
 4. **Prioritize** by frequency × severity × value —
    not every bucket gets fixed first.
-5. **The same labeled traces become the training
-   set.** The coupling this skill enforces —
-   see `trace-to-training-data`.
+5. **The labeled traces feed dataset curation, minus
+   an explicit holdout.** Every `eval/goldens.jsonl`
+   ID stays excluded from training data by ID; only
+   the non-held-out traces flow through
+   `trace-to-training-data`.
 6. **Train.**
 7. **Re-run the same harness** on the checkpoint —
    not a different, looser one.

--- a/plugins/llm-finetuning/skills/eval-harness-first/SKILL.md
+++ b/plugins/llm-finetuning/skills/eval-harness-first/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: eval-harness-first
+description: Build the evaluation harness that gates every fine-tuning run — golden sets, per-failure-mode graders, judge calibration, and base-model baselines. Use when starting a fine-tuning effort (before any training config), when converting traces into an eval set, or when a judge needs calibration against human labels.
+---
+
+# Eval Harness First
+
+This is the Phase 0 gate for the whole plugin:
+`finetuning-method-selection` and every downstream
+skill assume this harness already exists before a
+training config gets written. The harness is not a
+side artifact checked at the end of a run — it is
+the data-curation engine. The same labeled traces
+that build the goldens become the training set.
+
+**Input:** production/agent traces if they exist, or
+a task spec if they don't, plus human labelers
+willing to grade ≥100 examples.
+**Output format:** the `eval/` directory below —
+goldens, graders, a drift suite, and a base-model
+baseline that later phases check for before they
+proceed.
+
+## The Gate
+
+No eval harness, no fine-tune. Skip straight to a
+training config and there is nothing to measure
+improvement against, nothing to catch regressions,
+and no labeled data to train on. The flywheel:
+
+1. **Collect traces** — production or agent spans
+   (OTel/OpenInference), or synthetic tasks if none
+   exist yet.
+2. **Error analysis** — open coding on ≥100 traces,
+   then axial coding into 4–8 failure buckets.
+3. **One grader per bucket** — deterministic first;
+   calibrated LLM-judge only where the criterion is
+   genuinely subjective.
+4. **Prioritize** by frequency × severity × value —
+   not every bucket gets fixed first.
+5. **The same labeled traces become the training
+   set.** This is the coupling this skill exists to
+   enforce — see `trace-to-training-data`.
+6. **Train.**
+7. **Re-run the same harness** on the resulting
+   checkpoint — not a different, looser one.
+8. **Drift detection feeds back to step 2** — new
+   failure modes found in production re-open error
+   analysis.
+
+Steps 2–4 build the harness; steps 5–8 are why the
+harness has to exist first — it is both the training
+data source and the checkpoint's exit gate.
+
+## Building Goldens
+
+- **From traces, when they exist:** run error
+  analysis — open coding on ≥100 real traces (read
+  them, tag failures in your own words, no fixed
+  taxonomy yet), then axial coding to collapse those
+  tags into 4–8 named failure buckets. Fewer than 4
+  usually means the coding pass was too shallow; more
+  than 8 usually means buckets need merging.
+- **Synthetic, when traces don't exist yet:**
+  dimension-based generation — enumerate the axes
+  that matter (task type, difficulty, edge case,
+  persona) and sample the cross-product rather than
+  free-generating prompts, which clusters around
+  whatever's easiest to write.
+- **Goldens are versioned like code** — commit
+  `eval/goldens.jsonl`, diff it in review, tag it per
+  release. It doubles as the CI regression suite:
+  every checkpoint and every prompt change re-runs
+  against it, not just the run that motivated it.
+
+## Graders
+
+One grader per failure bucket from error analysis —
+not one grader for the whole eval set. A single
+blended score hides which bucket regressed.
+
+- **Deterministic first.** Regex, schema validation,
+  or execution-based checks (run the code, run the
+  tests) are cheaper, reproducible, and need no
+  calibration. Reach for one before writing a judge
+  prompt.
+- **LLM-judge only for genuinely subjective
+  criteria** — tone, faithfulness to a source,
+  "which response is better" — where no deterministic
+  check can express it. A judge grading something a
+  regex could check is wasted latency and calibration
+  burden.
+- **Binary pass/fail over Likert.** A 1–5 or 1–10
+  scale looks more informative but is noisier to
+  calibrate and harder to apply consistently; collapse
+  the criterion to a pass/fail line instead. Templates
+  for all four grader shapes:
+  `references/grader-templates.md`.
+
+## Judge Calibration Is a Prerequisite
+
+Any bucket routed to an LLM-judge needs calibration
+before its verdicts count for anything beyond
+exploration — this is a hard prerequisite, not a
+nice-to-have.
+
+- Label ≥100 items, split **train** (few-shot
+  examples for the judge prompt) / **dev** (iterate
+  the prompt) / **sealed test** (report once, no
+  re-touching after).
+- Report **TPR and TNR** against the human labels,
+  not one blended accuracy number — a judge can hit
+  90% accuracy by always saying "pass" on a skewed
+  set while its TPR/TNR tell the real story.
+- **Pin the judge to a fixed model snapshot.** An
+  unpinned judge that auto-upgrades silently shifts
+  what "pass" means between runs.
+- **Recalibrate on judge-model change, and quarterly
+  regardless** — drift happens without an explicit
+  swap too.
+- **The judge must come from a different model family
+  than the model under test** — a judge evaluating
+  its own family's outputs is a biased grader.
+- A judge that can't hit the agreed TPR/TNR bar ships
+  **advisory-only**: flag candidates for human review,
+  but don't gate a checkpoint promotion or count
+  toward a pass rate. Full protocol, bias correction,
+  and the recalibration checklist:
+  `references/judge-calibration.md`.
+
+## The Baseline
+
+Before Phase 1 (method selection) starts, run the
+full harness — goldens plus the capability-drift
+suite — against the unmodified base model. Not
+optional scaffolding: it's the number every later
+checkpoint gets compared against.
+
+`eval/baseline-<model>.json` is the gate token. No
+baseline file, no comparison basis for
+`checkpoint-promotion` — a checkpoint that "looks
+better" with nothing to compare against isn't a
+finding.
+
+## Directory Contract
+
+```
+eval/
+├── goldens.jsonl          # labeled traces + synthetic goldens, versioned like code
+├── graders/                # one module per failure bucket
+│   ├── schema_compliance.py
+│   ├── exact_match.py
+│   └── rubric_judge.py
+├── drift-suite.yaml        # frozen benchmarks + 200-500 domain-adjacent items
+└── baseline-<model>.json   # gate token: harness + drift suite run against the base model
+runs/
+└── <run-id>/
+    └── results.json         # per-run harness output, re-run each checkpoint
+```
+
+`eval/` persists across runs and lives outside
+`runs/` — it's the fixed measuring stick, not a run
+artifact. `runs/` is disposable and re-creatable;
+`eval/` is not. Never let a run script write into
+`eval/` — only goldens curation, grader edits, and a
+baseline refresh should touch it.
+
+## Related Skills
+
+General-purpose evaluation guidance (metrics
+dashboards, A/B testing, non-fine-tuning harnesses)
+lives in the `llm-application-dev` plugin's
+`llm-evaluation` skill — this skill covers only the
+fine-tuning-specific coupling: goldens that double
+as training data, and the baseline that gates a
+checkpoint.
+
+- `finetuning-method-selection` — routes here first;
+  won't proceed without this harness.
+- `dataset-curation` — formats the same labeled
+  traces this skill produces into training rows.
+- `trace-to-training-data` — turns graded traces into
+  training examples.
+- `checkpoint-promotion` — consumes
+  `baseline-<model>.json`, re-runs this harness
+  against each candidate checkpoint.
+
+## References
+
+- `references/grader-templates.md` — runnable
+  schema-compliance, exact-match, execution-based,
+  and LLM-judge grader examples, plus a
+  `drift-suite.yaml` example.
+- `references/judge-calibration.md` — the full
+  calibration protocol: splits, TPR/TNR, bias
+  correction, snapshot pinning, and the
+  recalibration schedule.

--- a/plugins/llm-finetuning/skills/eval-harness-first/SKILL.md
+++ b/plugins/llm-finetuning/skills/eval-harness-first/SKILL.md
@@ -5,28 +5,28 @@ description: Build the evaluation harness that gates every fine-tuning run — g
 
 # Eval Harness First
 
-This is the Phase 0 gate for the whole plugin:
+The Phase 0 gate for the whole plugin:
 `finetuning-method-selection` and every downstream
-skill assume this harness already exists before a
-training config gets written. The harness is not a
-side artifact checked at the end of a run — it is
-the data-curation engine. The same labeled traces
-that build the goldens become the training set.
+skill assume this harness exists before a training
+config gets written. The harness is not a run-end
+side artifact — it is the data-curation engine.
+The same labeled traces that build the goldens
+become the training set.
 
 **Input:** production/agent traces if they exist, or
 a task spec if they don't, plus labelers willing to
 grade ≥100 examples.
 **Output format:** the `eval/` directory below —
-goldens, graders, a drift suite, and a base-model
-baseline that later phases check for before they
-proceed.
+goldens, graders, drift suite, and the
+base-model baseline that later phases
+gate on.
 
 ## The Gate
 
-No eval harness, no fine-tune. Skip straight to a
-training config and there is nothing to measure
-improvement against, nothing to catch regressions,
-and no labeled data to train on. The flywheel:
+No eval harness, no fine-tune. Skip to a training
+config and there is nothing to measure against,
+nothing to catch regressions, and no labeled data
+to train on. The flywheel:
 
 1. **Collect traces** — production or agent spans
    (OTel/OpenInference), or synthetic tasks if none
@@ -39,18 +39,18 @@ and no labeled data to train on. The flywheel:
 4. **Prioritize** by frequency × severity × value —
    not every bucket gets fixed first.
 5. **The same labeled traces become the training
-   set.** This is the coupling this skill exists to
-   enforce — see `trace-to-training-data`.
+   set.** The coupling this skill enforces —
+   see `trace-to-training-data`.
 6. **Train.**
-7. **Re-run the same harness** on the resulting
-   checkpoint — not a different, looser one.
+7. **Re-run the same harness** on the checkpoint —
+   not a different, looser one.
 8. **Drift detection feeds back to step 2** — new
-   failure modes found in production re-open error
+   production failure modes re-open error
    analysis.
 
-Steps 2–4 build the harness; steps 5–8 are why the
-harness has to exist first — it is both the training
-data source and the checkpoint's exit gate.
+Steps 2–4 build the harness; steps 5–8 are why it
+must exist first — it is both the training data
+source and the checkpoint's exit gate.
 
 ## Building Goldens
 
@@ -59,14 +59,14 @@ data source and the checkpoint's exit gate.
   them, tag failures in your own words, no fixed
   taxonomy yet), then axial coding to collapse those
   tags into 4–8 named failure buckets. Fewer than 4
-  usually means the coding pass was too shallow; more
-  than 8 usually means buckets need merging.
+  means the coding pass was too shallow; more than
+  8 means buckets need merging.
 - **Synthetic, when traces don't exist yet:**
   dimension-based generation — enumerate the axes
   that matter (task type, difficulty, edge case,
-  persona) and sample the cross-product rather than
-  free-generating prompts, which clusters around
-  whatever's easiest to write.
+  persona) and sample the cross-product —
+  free-generated prompts cluster around whatever's
+  easiest to write.
 - **Goldens are versioned like code** — commit
   `eval/goldens.jsonl`, diff it in review, tag it per
   release. It doubles as the CI regression suite:
@@ -76,32 +76,32 @@ data source and the checkpoint's exit gate.
 ## Graders
 
 One grader per failure bucket from error analysis —
-not one grader for the whole eval set. A single
-blended score hides which bucket regressed.
+not one for the whole eval set. A single blended
+score hides which bucket regressed.
 
 - **Deterministic first.** Regex, schema validation,
-  or execution-based checks (run the code, run the
+  or execution-based checks (run the code or the
   tests) are cheaper, reproducible, and need no
-  calibration. Reach for one before writing a judge
-  prompt.
+  calibration. Reach for one before writing a
+  judge prompt.
 - **LLM-judge only for genuinely subjective
   criteria** — tone, faithfulness to a source,
   "which response is better" — where no deterministic
-  check can express it. A judge grading something a
-  regex could check is wasted latency and calibration
-  burden.
+  check can express it. A judge grading what a
+  regex could check is wasted latency and
+  calibration burden.
 - **Binary pass/fail over Likert.** A 1–5 or 1–10
   scale looks more informative but is noisier to
-  calibrate and harder to apply consistently; collapse
-  the criterion to a pass/fail line instead. Templates
-  for all four grader shapes:
+  calibrate and harder to apply consistently;
+  collapse the criterion to a pass/fail line.
+  Templates for all four grader shapes:
   `references/grader-templates.md`.
 
 ## Judge Calibration Is a Prerequisite
 
 Any bucket routed to an LLM-judge needs calibration
 before its verdicts count for anything beyond
-exploration — this is a hard prerequisite, not a
+exploration — a hard prerequisite, not a
 nice-to-have.
 
 - Label ≥100 items, split **train** (few-shot
@@ -110,14 +110,14 @@ nice-to-have.
   re-touching after).
 - Report **TPR and TNR** against the human labels,
   not one blended accuracy number — a judge can hit
-  90% accuracy by always saying "pass" on a skewed
-  set while its TPR/TNR tell the real story.
+  90% by always saying "pass" on a skewed set;
+  TPR/TNR tell the real story.
 - **Pin the judge to a fixed model snapshot.** An
   unpinned judge that auto-upgrades silently shifts
   what "pass" means between runs.
 - **Recalibrate on judge-model change, and quarterly
-  regardless** — drift happens without an explicit
-  swap too.
+  regardless** — drift happens without a swap
+  too.
 - **The judge must come from a different model family
   than the model under test** — a judge evaluating
   its own family's outputs is a biased grader.
@@ -132,14 +132,14 @@ nice-to-have.
 
 Before Phase 1 (method selection) starts, run the
 full harness — goldens plus the capability-drift
-suite — against the unmodified base model. Not
-optional scaffolding: it's the number every later
-checkpoint gets compared against.
+suite — against the unmodified base model. This
+is the number every later checkpoint gets
+compared against.
 
 `eval/baseline-<model>.json` is the gate token. No
 baseline file, no comparison basis for
 `checkpoint-promotion` — a checkpoint that "looks
-better" with nothing to compare against isn't a
+better" against nothing measured isn't a
 finding.
 
 ## Directory Contract
@@ -159,11 +159,11 @@ runs/
 ```
 
 `eval/` persists across runs and lives outside
-`runs/` — it's the fixed measuring stick, not a run
-artifact. `runs/` is disposable and re-creatable;
-`eval/` is not. Never let a run script write into
-`eval/` — only goldens curation, grader edits, and a
-baseline refresh should touch it.
+`runs/` — the fixed measuring stick, not a run
+artifact. `runs/` is disposable; `eval/` is not.
+Never let a run script write into `eval/` — only
+goldens curation, grader edits, and a baseline
+refresh should touch it.
 
 ### Phase 0 Exit Checklist
 
@@ -185,9 +185,9 @@ Missing any of the six? Not Phase 0 complete —
 General-purpose evaluation guidance (metrics
 dashboards, A/B testing, non-fine-tuning harnesses)
 lives in the `llm-application-dev` plugin's
-`llm-evaluation` skill — this skill covers only the
-fine-tuning-specific coupling: goldens that double
-as training data, and the baseline that gates a
+`llm-evaluation` skill — this skill covers only
+the fine-tuning coupling: goldens that double as
+training data, and the baseline that gates a
 checkpoint.
 
 - `finetuning-method-selection` — routes here first;
@@ -198,7 +198,7 @@ checkpoint.
   training examples.
 - `checkpoint-promotion` — consumes
   `baseline-<model>.json`, re-runs this harness
-  against each candidate checkpoint.
+  on each candidate checkpoint.
 
 ## References
 
@@ -206,7 +206,7 @@ checkpoint.
   schema-compliance, exact-match, execution-based,
   and LLM-judge grader examples, plus a
   `drift-suite.yaml` example.
-- `references/judge-calibration.md` — the full
+- `references/judge-calibration.md` — the
   calibration protocol: splits, TPR/TNR, bias
   correction, snapshot pinning, and the
   recalibration schedule.

--- a/plugins/llm-finetuning/skills/eval-harness-first/references/grader-templates.md
+++ b/plugins/llm-finetuning/skills/eval-harness-first/references/grader-templates.md
@@ -1,4 +1,4 @@
-Last verified: 2026-07-13
+Last verified: 2026-07-14
 
 # Grader Templates
 
@@ -245,3 +245,50 @@ drift_budget:
   rerun_seed_variation_pts: [2, 5]
   hard_fail_threshold_pts: 5   # >5pt drop is a hard fail regardless of task-metric gains
 ```
+
+**Minimum viable drift suite for a small/dogfood run:** the
+500/250/300 general-benchmark sizes and the 200-500
+`domain_adjacent` range above are scoped for production-scale
+runs and can be hours of wall-clock at greedy single-stream
+decode on modest hardware. Scope down deliberately rather than
+silently truncating — pick n per benchmark using
+`checkpoint-promotion`'s item-count-from-budget rule (95% CI
+half-width comfortably under half the hard-fail threshold), and
+document the scoped-down suite inline in `drift-suite.yaml`
+(a comment naming the budget it was sized against). The
+`domain_adjacent` block itself is **optional when the golden
+set is small and already fully consumed by the task harness** —
+if `eval/goldens.jsonl` has no separate drift-suite-tagged
+holdout because every golden is already spoken for by the task
+grader, omit the block rather than fabricating a slice with
+nothing behind it; the frozen general benchmarks alone still
+provide a capability-drift signal.
+
+## Drift-Suite MMLU-Style Scoring: Logprob Over Generate-and-Extract
+
+"Letter-choice logprob or generate-and-extract" are not
+equivalent scoring methods, though earlier guidance in this
+plugin implied they were interchangeable:
+
+- **Generate-and-extract** (sample a completion, extract the
+  first A–D letter from a tight token budget) is **parse-brittle**
+  for models that preamble before answering. Observed on a real
+  drift run: a near-base checkpoint hit 9/100 unparsed-scored-
+  as-wrong items (all prose restarts like "The energy levels
+  of...") on a `max_new_tokens=8` budget, versus 0–1 unparsed
+  for other checkpoints in the same series — this conflates
+  answer-format compliance with the knowledge MMLU is supposed
+  to measure, and can hard-fail a checkpoint on formatting alone.
+- **Logprob scoring** (compare the model's log-probability on
+  each of the four answer-letter tokens directly, no generation
+  or parsing involved) is robust to this failure mode entirely —
+  there is nothing to parse, so a verbose or preambling model
+  scores on its actual answer distribution.
+
+**Prefer logprob scoring whenever the harness has logit access**
+(local inference, not a hosted API that only returns text). When
+logit access isn't available and generate-and-extract is the
+only option, use a generous token budget and retry with a longer
+budget on any unparsed output before scoring it as wrong — don't
+let a tight budget silently convert "the model reasoned before
+answering" into "the model failed the benchmark."

--- a/plugins/llm-finetuning/skills/eval-harness-first/references/grader-templates.md
+++ b/plugins/llm-finetuning/skills/eval-harness-first/references/grader-templates.md
@@ -76,32 +76,79 @@ def grade_exact_match(completion: str, ground_truth: str) -> bool:
 For buckets where correctness means "the code runs
 and does the right thing" — the strongest signal
 available when applicable, since it needs no
-normalization or judgment call:
+normalization or judgment call.
+
+**WARNING — this grader executes model-generated
+code and REQUIRES an isolated environment:** a
+network-disabled container, gVisor/firejail, or a
+dedicated CI sandbox, with **no secrets or
+credentials in the environment** — no HF tokens,
+experiment-tracker keys, cloud credentials, or SSH
+keys. Never run it directly on a host holding
+credentials. The timeout below protects grading-loop
+liveness only — **it is NOT a security boundary**;
+isolation comes entirely from `sandbox_cmd`.
 
 ```python
+import logging
 import subprocess
 import tempfile
 from pathlib import Path
 
-def grade_execution(completion: str, test_code: str) -> bool:
+logger = logging.getLogger(__name__)
+
+def grade_execution(completion: str, test_code: str, sandbox_cmd: list[str]) -> bool:
     """Write the completion plus a pytest test file to
-    a scratch dir, run pytest, and pass only on a
-    clean exit code. Timeouts and non-zero exits are
-    both failures — never treat a hung process as a
-    pass by default.
+    a scratch dir, run pytest via `sandbox_cmd`, and
+    pass only on a clean exit code. Timeouts and
+    non-zero exits are both failures — never treat a
+    hung process as a pass by default.
+
+    SECURITY: executes model-generated code. This
+    function REQUIRES an isolation boundary — it does
+    not run anything on the host by itself.
+
+    `sandbox_cmd` (list[str], required) is a command
+    prefix that wraps pytest in that boundary, e.g. a
+    network-disabled, resource-capped Docker container:
+
+        # sandbox_cmd = [
+        #     "docker", "run", "--rm", "--network=none",
+        #     "--memory=1g", "--cpus=1",
+        #     "-v", f"{workdir}:/work:ro", "-w", "/work",
+        #     "python:3.12-slim",
+        # ]
+
+    If `sandbox_cmd` is falsy, this function refuses to
+    execute anything and returns False — it never falls
+    back to running pytest on the host. The subprocess
+    environment is scrubbed to a minimal PATH.
     """
+    if not sandbox_cmd:
+        logger.warning(
+            "grade_execution: no sandbox boundary provided "
+            "— refusing to execute model-generated code"
+        )
+        return False
+
+    scrubbed_env = {"PATH": "/usr/bin:/bin"}
     with tempfile.TemporaryDirectory() as tmp:
         solution = Path(tmp) / "solution.py"
         test_file = Path(tmp) / "test_solution.py"
         solution.write_text(completion)
         test_file.write_text(test_code)
-        result = subprocess.run(
-            ["pytest", str(test_file), "-q"],
-            cwd=tmp,
-            capture_output=True,
-            timeout=30,
-        )
-        return result.returncode == 0
+        try:
+            result = subprocess.run(
+                [*sandbox_cmd, "python", "-m", "pytest",
+                 str(test_file), "-q"],
+                cwd=tmp,
+                capture_output=True,
+                timeout=30,
+                env=scrubbed_env,
+            )
+            return result.returncode == 0
+        except subprocess.TimeoutExpired:
+            return False
 ```
 
 ## LLM-Judge Template

--- a/plugins/llm-finetuning/skills/eval-harness-first/references/grader-templates.md
+++ b/plugins/llm-finetuning/skills/eval-harness-first/references/grader-templates.md
@@ -1,0 +1,190 @@
+Last verified: 2026-07-13
+
+# Grader Templates
+
+Runnable examples for the four grader shapes named
+in `SKILL.md`'s Graders section: schema-compliance,
+exact-match with normalization, execution-based, and
+LLM-judge. Every grader returns a binary pass/fail —
+never a Likert score — per the plugin-wide rule.
+Wire each one to exactly one failure bucket from
+error analysis; don't blend buckets into one grader.
+
+## Schema Compliance
+
+For buckets where the failure mode is "the output
+isn't shaped right" — tool calls, structured
+extraction, JSON responses:
+
+```python
+import json
+from jsonschema import validate, ValidationError
+
+RESPONSE_SCHEMA = {
+    "type": "object",
+    "required": ["action", "arguments"],
+    "properties": {
+        "action": {"type": "string"},
+        "arguments": {"type": "object"},
+    },
+    "additionalProperties": False,
+}
+
+def grade_schema_compliance(completion: str) -> bool:
+    """Binary pass/fail: does the completion parse as
+    JSON and match RESPONSE_SCHEMA? Malformed JSON is
+    an automatic fail, not an exception to handle
+    upstream — the grader owns that decision.
+    """
+    try:
+        payload = json.loads(completion)
+    except json.JSONDecodeError:
+        return False
+    try:
+        validate(instance=payload, schema=RESPONSE_SCHEMA)
+    except ValidationError:
+        return False
+    return True
+```
+
+## Exact Match with Normalization
+
+For buckets with a single ground-truth string (math
+final answers, extracted entities, classification
+labels) where naive `==` fails on formatting noise:
+
+```python
+import re
+
+def normalize(text: str) -> str:
+    """Lowercase, collapse whitespace, strip
+    punctuation and surrounding markup — apply the
+    identical normalization to both prediction and
+    ground truth so neither side gets an unfair pass.
+    """
+    text = text.strip().lower()
+    text = re.sub(r"[^\w\s.]", "", text)
+    text = re.sub(r"\s+", " ", text)
+    return text
+
+def grade_exact_match(completion: str, ground_truth: str) -> bool:
+    return normalize(completion) == normalize(ground_truth)
+```
+
+## Execution-Based
+
+For buckets where correctness means "the code runs
+and does the right thing" — the strongest signal
+available when applicable, since it needs no
+normalization or judgment call:
+
+```python
+import subprocess
+import tempfile
+from pathlib import Path
+
+def grade_execution(completion: str, test_code: str) -> bool:
+    """Write the completion plus a pytest test file to
+    a scratch dir, run pytest, and pass only on a
+    clean exit code. Timeouts and non-zero exits are
+    both failures — never treat a hung process as a
+    pass by default.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        solution = Path(tmp) / "solution.py"
+        test_file = Path(tmp) / "test_solution.py"
+        solution.write_text(completion)
+        test_file.write_text(test_code)
+        result = subprocess.run(
+            ["pytest", str(test_file), "-q"],
+            cwd=tmp,
+            capture_output=True,
+            timeout=30,
+        )
+        return result.returncode == 0
+```
+
+## LLM-Judge Template
+
+Only for buckets that failed the deterministic-first
+check in `SKILL.md` — genuinely subjective criteria.
+Few-shot slots and a binary output contract are both
+mandatory; a judge without few-shot anchors drifts
+toward its own prior instead of the calibrated
+labels.
+
+```python
+JUDGE_PROMPT = """You are grading whether a response
+meets the following criterion: {criterion}
+
+Examples of PASS:
+{few_shot_pass_examples}
+
+Examples of FAIL:
+{few_shot_fail_examples}
+
+Now grade this response. Output exactly one word,
+PASS or FAIL, with no other text.
+
+Task: {task}
+Response: {response}
+Verdict:"""
+
+def grade_llm_judge(task: str, response: str, criterion: str,
+                     few_shot_pass: str, few_shot_fail: str,
+                     judge_client) -> bool:
+    prompt = JUDGE_PROMPT.format(
+        criterion=criterion,
+        few_shot_pass_examples=few_shot_pass,
+        few_shot_fail_examples=few_shot_fail,
+        task=task,
+        response=response,
+    )
+    # judge_client is pinned to a fixed snapshot per
+    # SKILL.md's Judge Calibration section — never an
+    # unpinned "latest" alias.
+    verdict = judge_client.complete(prompt, temperature=0).strip().upper()
+    return verdict == "PASS"
+```
+
+Do not treat any output other than exactly `PASS` or
+`FAIL` as a pass by default — log it as a parse
+failure and re-run or route to human review instead
+of defaulting either direction.
+
+## drift-suite.yaml Example
+
+Frozen general-capability benchmarks plus a
+domain-adjacent slice, per `SKILL.md`'s Directory
+Contract. Benchmark subsets are frozen at a fixed
+seed/split so re-runs are comparable run over run:
+
+```yaml
+# eval/drift-suite.yaml
+frozen_benchmarks:
+  - name: mmlu-subset
+    source: mmlu
+    split: test
+    n_items: 500
+    seed: 42
+  - name: gsm8k-subset
+    source: gsm8k
+    split: test
+    n_items: 250
+    seed: 42
+  - name: ifeval
+    source: ifeval
+    split: test
+    n_items: 300
+    seed: 42
+
+domain_adjacent:
+  path: eval/goldens.jsonl
+  filter: "tag == 'drift-suite'"
+  n_items_range: [200, 500]
+
+drift_budget:
+  noise_tolerance_pts: 1
+  rerun_seed_variation_pts: [2, 5]
+  hard_fail_threshold_pts: 5   # >5pt drop is a hard fail regardless of task-metric gains
+```

--- a/plugins/llm-finetuning/skills/eval-harness-first/references/grader-templates.md
+++ b/plugins/llm-finetuning/skills/eval-harness-first/references/grader-templates.md
@@ -177,6 +177,13 @@ Task: {task}
 Response: {response}
 Verdict:"""
 
+class JudgeParseError(Exception):
+    """Raised when the judge returns anything other than
+    exactly PASS or FAIL — a transport or format failure,
+    not a grading verdict. Never caught and coerced to
+    False; the caller retries the judge call or routes the
+    item to human review."""
+
 def grade_llm_judge(task: str, response: str, criterion: str,
                      few_shot_pass: str, few_shot_fail: str,
                      judge_client) -> bool:
@@ -191,13 +198,16 @@ def grade_llm_judge(task: str, response: str, criterion: str,
     # SKILL.md's Judge Calibration section — never an
     # unpinned "latest" alias.
     verdict = judge_client.complete(prompt, temperature=0).strip().upper()
+    if verdict not in ("PASS", "FAIL"):
+        raise JudgeParseError(f"unparseable judge verdict: {verdict!r}")
     return verdict == "PASS"
 ```
 
-Do not treat any output other than exactly `PASS` or
-`FAIL` as a pass by default — log it as a parse
-failure and re-run or route to human review instead
-of defaulting either direction.
+The grader's return value stays binary pass/fail per this
+file's plugin-wide rule — `JudgeParseError` is not a third
+grading state, it's an operational failure. Never catch it
+and coerce to `False`; log it and re-run the judge call or
+route the item to human review instead.
 
 ## drift-suite.yaml Example
 

--- a/plugins/llm-finetuning/skills/eval-harness-first/references/judge-calibration.md
+++ b/plugins/llm-finetuning/skills/eval-harness-first/references/judge-calibration.md
@@ -49,14 +49,30 @@ def tpr_tnr(judge_verdicts: list[bool], human_labels: list[bool]) -> tuple[float
     A single blended accuracy number hides which
     direction the judge is biased toward — always
     report both, never accuracy alone.
+
+    Raises ValueError on empty or mismatched-length
+    input, or if the sealed test split lacks either
+    class — a `zip()` over unequal lists silently
+    drops the extra items, which can produce
+    apparently valid metrics from a partial or
+    miscollected split.
     """
+    if not judge_verdicts or not human_labels:
+        raise ValueError("tpr_tnr: judge_verdicts and human_labels must be non-empty")
+    if len(judge_verdicts) != len(human_labels):
+        raise ValueError(
+            f"tpr_tnr: length mismatch ({len(judge_verdicts)} verdicts vs "
+            f"{len(human_labels)} labels) — check the split for a collection bug"
+        )
     tp = sum(j and h for j, h in zip(judge_verdicts, human_labels))
     fn = sum((not j) and h for j, h in zip(judge_verdicts, human_labels))
     tn = sum((not j) and (not h) for j, h in zip(judge_verdicts, human_labels))
     fp = sum(j and (not h) for j, h in zip(judge_verdicts, human_labels))
-    tpr = tp / (tp + fn) if (tp + fn) else float("nan")
-    tnr = tn / (tn + fp) if (tn + fp) else float("nan")
-    return tpr, tnr
+    if (tp + fn) == 0:
+        raise ValueError("tpr_tnr: no positive-labeled items in this split — TPR undefined")
+    if (tn + fp) == 0:
+        raise ValueError("tpr_tnr: no negative-labeled items in this split — TNR undefined")
+    return tp / (tp + fn), tn / (tn + fp)
 ```
 
 Agree on a TPR/TNR bar with whoever owns the eval

--- a/plugins/llm-finetuning/skills/eval-harness-first/references/judge-calibration.md
+++ b/plugins/llm-finetuning/skills/eval-harness-first/references/judge-calibration.md
@@ -1,4 +1,4 @@
-Last verified: 2026-07-13
+Last verified: 2026-07-14
 
 # Judge Calibration Protocol
 
@@ -7,6 +7,22 @@ Calibration Is a Prerequisite" section. Any grader
 routed to an LLM-judge follows this before its
 verdicts count toward a pass rate or a checkpoint
 promotion decision.
+
+## N/A Path: All-Deterministic Harness
+
+If error analysis produced zero buckets that route to
+an LLM-judge — every grader is regex, schema, or
+execution-based — this entire protocol is N/A for the
+run, not an unsatisfiable checklist item. Phase 0
+Exit Checklist item 4 in `SKILL.md` is satisfied by
+stating this explicitly (e.g. "Judge calibration:
+N/A — all N graded criteria are deterministic") rather
+than leaving it blank or blocking Phase 0 completion
+on a judge that was never going to exist. This is
+common on a greenfield strict-schema or exact-match
+task with synthetic goldens — don't invent a
+subjective criterion just to have something to
+calibrate.
 
 ## 1. Label
 

--- a/plugins/llm-finetuning/skills/eval-harness-first/references/judge-calibration.md
+++ b/plugins/llm-finetuning/skills/eval-harness-first/references/judge-calibration.md
@@ -1,0 +1,141 @@
+Last verified: 2026-07-13
+
+# Judge Calibration Protocol
+
+The full procedure behind `SKILL.md`'s "Judge
+Calibration Is a Prerequisite" section. Any grader
+routed to an LLM-judge follows this before its
+verdicts count toward a pass rate or a checkpoint
+promotion decision.
+
+## 1. Label
+
+Collect human labels for **≥100 items** covering the
+failure bucket the judge will grade. Use the same
+labelers (or a labeling rubric tight enough to be
+interchangeable) that produced the axial-coding
+buckets in `SKILL.md`'s Building Goldens section —
+a judge calibrated against a different notion of
+"pass" than the one used to build goldens will
+silently diverge from what the harness is supposed
+to measure.
+
+## 2. Split
+
+Divide the labeled set three ways and keep the
+splits separate for the whole calibration cycle:
+
+| Split | Purpose | Size |
+|---|---|---|
+| train | Few-shot examples embedded in the judge prompt | ~20-30% |
+| dev | Iterate the prompt, catch obvious misses | ~30-40% |
+| sealed test | Report TPR/TNR once; never re-touch after | ~30-40% |
+
+The sealed-test split is sealed: if a dev-split
+iteration cycle causes the reported test-split
+number to move, that number is no longer a valid
+generalization estimate — re-seal a fresh test split
+instead of re-running against the same one.
+
+## 3. Compute TPR/TNR
+
+Run the judge (with train-split few-shot examples in
+the prompt) against the sealed test split and compute:
+
+```python
+def tpr_tnr(judge_verdicts: list[bool], human_labels: list[bool]) -> tuple[float, float]:
+    """True Positive Rate (sensitivity) and True
+    Negative Rate (specificity) against human labels.
+    A single blended accuracy number hides which
+    direction the judge is biased toward — always
+    report both, never accuracy alone.
+    """
+    tp = sum(j and h for j, h in zip(judge_verdicts, human_labels))
+    fn = sum((not j) and h for j, h in zip(judge_verdicts, human_labels))
+    tn = sum((not j) and (not h) for j, h in zip(judge_verdicts, human_labels))
+    fp = sum(j and (not h) for j, h in zip(judge_verdicts, human_labels))
+    tpr = tp / (tp + fn) if (tp + fn) else float("nan")
+    tnr = tn / (tn + fp) if (tn + fp) else float("nan")
+    return tpr, tnr
+```
+
+Agree on a TPR/TNR bar with whoever owns the eval
+harness before running this step — a common starting
+bar is ≥0.85 on both, tightened per bucket based on
+how costly a false pass or false fail is downstream.
+
+## 4. Bias-Correct Reported Rates
+
+A judge with unequal TPR/TNR does not report the true
+pass rate of the model under test — it reports a
+rate skewed by its own asymmetric error pattern.
+Correct the observed pass rate before publishing it:
+
+```python
+def bias_corrected_pass_rate(observed_pass_rate: float, tpr: float, tnr: float) -> float:
+    """Rogan-Gladen style correction: recovers the
+    true pass rate from the judge's observed rate and
+    its TPR/TNR, rather than reporting the judge's raw
+    output as if it were ground truth.
+    """
+    denom = tpr + tnr - 1
+    if denom <= 0:
+        raise ValueError("Judge is at or below chance — do not correct, recalibrate")
+    return (observed_pass_rate + tnr - 1) / denom
+```
+
+If `tpr + tnr - 1` is small (judge close to chance),
+the correction blows up and becomes unreliable — that
+is itself a signal the judge needs a prompt rewrite,
+not a correction formula.
+
+## 5. Pin the Snapshot
+
+Record the exact judge model snapshot/version used
+for calibration alongside the TPR/TNR numbers. An
+unpinned judge (a "latest" alias that moves under
+you) invalidates the calibration the moment the
+underlying model changes — the TPR/TNR numbers stop
+describing the judge actually in use.
+
+## 6. Recalibrate
+
+Two triggers, either one is sufficient:
+
+- **Judge-model change** — any change to the pinned
+  snapshot, intentional or forced (deprecation).
+- **Quarterly, regardless** — schedule recalibration
+  even with no judge change, since the underlying
+  task distribution (what "hard" cases look like)
+  drifts as the model under test improves and error
+  analysis surfaces new failure modes.
+
+Recalibration reruns steps 1-4 in full — it is not a
+partial refresh of just the test split.
+
+## 7. Miscalibration Fallback
+
+If the judge cannot hit the agreed TPR/TNR bar after
+prompt iteration on the dev split:
+
+- The judge ships **advisory-only**: its verdicts
+  surface in review tooling for a human to consider,
+  but do not gate a checkpoint promotion and are not
+  counted into a reported pass rate.
+- Do not lower the TPR/TNR bar to make an
+  uncalibrated judge "pass" — that defeats the point
+  of calibrating in the first place.
+- Prefer routing the bucket to a deterministic grader
+  if the criterion can be reframed as one (see
+  `SKILL.md`'s Graders section) over shipping a
+  permanently advisory-only judge.
+
+## Different Model Family, Always
+
+The judge model must come from a different model
+family than the model under test, for every
+calibration cycle and every recalibration — a judge
+evaluating outputs from its own family is a biased
+grader, and this cannot be corrected away with the
+TPR/TNR formula above since the bias is systematic
+rather than random.

--- a/plugins/llm-finetuning/skills/finetuning-method-selection/SKILL.md
+++ b/plugins/llm-finetuning/skills/finetuning-method-selection/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: finetuning-method-selection
+description: Decide whether to fine-tune at all, and route to the right method (SFT, DPO/ORPO/KTO, GRPO/RLVR, continued pretraining) and base model. Use when starting any fine-tuning effort, when unsure whether RAG or prompting would suffice, or when choosing between preference-optimization and reinforcement methods.
+---
+
+# Fine-Tuning Method Selection
+
+This is the router skill for the fine-tuning
+lifecycle: it decides whether fine-tuning is the
+right tool at all, and if so, which method and
+which base-model size class. Every other skill
+in this plugin assumes this routing already
+happened — start here before opening
+`lora-qlora-recipes`, `preference-optimization`,
+or `grpo-rlvr-training`.
+
+## When to Use This Skill
+
+- Starting any fine-tuning effort, before a
+  framework or base model has been chosen.
+- Unsure whether RAG or prompt engineering would
+  solve the problem more cheaply than training.
+- Choosing between preference optimization (DPO
+  family) and a reinforcement method (GRPO/RLVR)
+  for the same underlying task.
+- Sizing a candidate model/method combination
+  before committing to a run.
+
+## Quick Reference
+
+| Situation | Route |
+|---|---|
+| Facts change often (prices, docs, news) | RAG, not fine-tuning |
+| Desired behavior still being figured out | Prompt engineering |
+| Stable domain knowledge, ≥500MB text | CPT then SFT — see Off-Ramps First |
+| Have input/output demonstrations | SFT — see `lora-qlora-recipes` |
+| Have preference pairs or thumbs-up/down | DPO/ORPO/KTO — see `preference-optimization` |
+| Have a verifiable pass/fail signal | GRPO+RLVR — see `grpo-rlvr-training` |
+| No eval harness yet | Stop — see `eval-harness-first` |
+
+## Off-Ramps First
+
+Most requests that sound like "fine-tune this"
+are served better and cheaper elsewhere. Check
+these off-ramps before opening a training run:
+
+- **Knowledge-bound and volatile** (the gap is
+  facts that change — prices, docs, current
+  events): route to RAG, not fine-tuning. A
+  fine-tuned model bakes in a snapshot; volatile
+  facts go stale immediately.
+- **Behavior-bound and shifting** (the desired
+  behavior is still being figured out, or
+  changes per request): route to prompt
+  engineering. Fine-tuning locks in a behavior;
+  don't lock in one that hasn't stabilized yet.
+- **Stable, dense domain knowledge**: this is
+  where continued pretraining (CPT) enters, sized
+  by how much domain text exists:
+
+| Domain text volume | Route |
+|---|---|
+| <10MB | RAG only |
+| 10MB–500MB | RAG + fine-tune |
+| 500MB–10GB | CPT, then SFT |
+| >10GB | CPT required |
+
+CPT learning rate ≈ **10% of the pretraining
+LR**. CPT is guidance-only in this plugin —
+sizing and LR guidance live here, but this
+plugin does not execute a CPT run.
+
+## Method Router
+
+Once the off-ramps are ruled out, this is the
+full decision tree (verbatim from the research
+this plugin is built on):
+
+```
+New FACTS?  volatile → RAG | stable+dense → CPT (LR ~10% of pretrain) → SFT
+New BEHAVIOR? shifting → prompt-engineering | stable:
+  demos → SFT (LoRA/QLoRA, all-linear, α=2r)
+  preference pairs → DPO (SimPO if length-bias, ORPO if memory-bound)
+  unpaired 👍/👎 → KTO
+  verifiable success → RLVR + GRPO (DAPO/GSPO/Dr.GRPO per failure mode)
+Deploy: FP8 (Hopper+) | NVFP4 (Blackwell scale) | AWQ (older) | GGUF+imatrix (edge)
+BEFORE ANY OF THIS: the eval harness must exist first.
+```
+
+Read the tree top-down: answer "new facts or new
+behavior," then follow the branch that matches
+the data shape in hand (demos, preference pairs,
+thumbs up/down, or verifiable success/failure).
+The data shape picks the method — not the other
+way around.
+
+### Worked Routing Examples
+
+- *"Users want the assistant to follow our
+  support macros exactly."* Behavior is stable
+  and demonstrable from transcripts → demos →
+  **SFT**.
+- *"We have pairs of good/bad responses from
+  reviewer thumbs-up/down, unpaired."* → unpaired
+  signal → **KTO**, not DPO (DPO needs paired
+  preferences).
+- *"The model can already solve some of these
+  math problems and we can grade correctness
+  automatically."* → verifiable success signal →
+  **GRPO+RLVR**, and only after confirming the
+  model succeeds at least sometimes (see Key
+  Routing Facts below).
+- *"We want the model to know this week's
+  pricing page."* → volatile facts → **RAG**, no
+  training run at all.
+
+## Key Routing Facts
+
+- **Loss-function choice is low-leverage.** A
+  240-H100-run study found method choice worth
+  ~1 percentage point versus ~50 points for model
+  scale, and zero of 20 DPO variants beat vanilla
+  DPO. Don't spend a routing decision agonizing
+  over DPO-variant selection — spend it on
+  getting the data shape and scale right.
+- **DPO is for taste, GRPO+RLVR is for
+  reasoning.** Preference pairs that encode a
+  subjective judgment (tone, style, "which answer
+  is better") route to DPO. Tasks with a
+  verifiable pass/fail signal (math, code, tool
+  calls) route to GRPO+RLVR instead.
+- **RL is not the fix for a model that never
+  succeeds.** GRPO and other RL methods sharpen
+  an existing capability — they don't teach one
+  from zero. If the model doesn't yet understand
+  the task or output format, run SFT first; only
+  bring in RL once the model succeeds at least
+  sometimes.
+
+### Common Routing Mistakes
+
+- Reaching for fine-tuning to fix facts that
+  change weekly — that's a RAG problem, and
+  fine-tuning will just go stale faster than the
+  source data does.
+- Picking a DPO variant before checking whether
+  the actual bottleneck is data quality or model
+  scale — variant choice is the ~1pp lever, not
+  the ~50pp one.
+- Starting an RL run on a model that fails every
+  rollout — route to SFT first so RL has
+  something to sharpen.
+- Treating CPT as the default for "the model
+  doesn't know our domain" — check the data
+  volume thresholds first; under 500MB, RAG or
+  RAG+fine-tune iterates faster than a CPT run.
+
+## Model Selection
+
+Base-model choice is size-class first, family
+second, and it goes stale fast — so it lives in
+exactly one place: `references/model-catalog.md`.
+That file is the only place in this plugin (and
+in the DGX Spark ops plugin) that names a base
+model family. Neither this skill nor
+`references/memory-math.md` names one; both
+describe models by size class only (for example,
+"8B-class LoRA," not a model name).
+
+The catalog is dated on purpose — model rankings
+turn over quarterly. It carries a "last verified"
+date and a refresh checklist. Before trusting a
+row, check that date; if stale, work the refresh
+checklist in the catalog before recommending a
+model from it.
+
+## Memory Feasibility
+
+Before committing to a method, size it: total
+memory ≈ **params × dtype bytes + optimizer
+state + gradients + activations**. Work each
+term for the chosen dtype and method (full
+fine-tune, LoRA, or QLoRA) — worked worksheets
+and size-class examples live in
+`references/memory-math.md`.
+
+On DGX Spark specifically, unified-memory
+behavior breaks the naive estimate (transient
+load peaks, `nvidia-smi` underreporting, thermal
+throttling on long runs). Once the
+`dgx-spark-ops` plugin is installed, defer
+Spark-specific feasibility calls to its
+`spark-memory-thermal-ops` skill rather than
+re-deriving them here.
+
+## Related Skills
+
+Once this skill has picked a method, hand off to
+the skill that executes it:
+
+- `lora-qlora-recipes` — SFT via LoRA/QLoRA
+- `preference-optimization` — DPO, ORPO, KTO
+- `grpo-rlvr-training` — GRPO with verifiable
+  rewards
+
+No method is selected before the eval harness
+exists — see `eval-harness-first`.

--- a/plugins/llm-finetuning/skills/finetuning-method-selection/SKILL.md
+++ b/plugins/llm-finetuning/skills/finetuning-method-selection/SKILL.md
@@ -174,6 +174,13 @@ row, check that date; if stale, work the refresh
 checklist in the catalog before recommending a
 model from it.
 
+**Precedence when the catalog and a method skill
+disagree:** the catalog's per-row Notes column
+states hardware/size-class *feasibility*, not a
+method recommendation — `lora-qlora-recipes`'s
+LoRA vs QLoRA vs Full FT table (routed by task
+shape) governs the actual method choice.
+
 ## Memory Feasibility
 
 Before committing to a method, size it: total

--- a/plugins/llm-finetuning/skills/finetuning-method-selection/references/memory-math.md
+++ b/plugins/llm-finetuning/skills/finetuning-method-selection/references/memory-math.md
@@ -32,10 +32,15 @@ parameter count and dtype, then sum.
 | int8 | 1 |
 | int4 (QLoRA NF4) | 0.5 |
 
-This term dominates for full fine-tuning and is
-the same regardless of method — it's what's
-loaded before any training-specific overhead is
-added.
+This term dominates for full fine-tuning, and the
+calculation (`params × bytes/param`) is the same
+formula regardless of method — but the dtype, and
+so the result, is not: bf16 LoRA loads weights at
+2 bytes/param while int4 QLoRA loads the same
+parameter count at 0.5 bytes/param, a 4x gap.
+Reuse the formula across methods; never reuse the
+resulting weight-memory number from one method's
+dtype for another's.
 
 ### 2. Optimizer states
 
@@ -80,8 +85,10 @@ levers matter more than exact estimation:
 ### 5. LoRA/QLoRA adapter overhead
 
 A rank-`r` adapter on a linear layer adds
-`2 × r × (in + out)` parameters. At normal rank
-sizes (1–32 for RL, up to ~256 for SFT-at-scale),
+`r × (in + out)` parameters — `A` is `r×in` and `B`
+is `out×r`, so together they contribute
+`r·in + r·out`. At normal rank sizes (1–32 for RL,
+up to ~256 for SFT-at-scale),
 this is a small fraction of a percent of base
 model size — round it to zero in the worksheet
 unless an unusually high rank is in play.
@@ -133,15 +140,18 @@ total_gb = weights_gb + adapter_gb  # + activations
 print(f"{total_gb:.0f}GB before activations")
 ```
 
-Weights alone land near the **≈40GB anchor** —
-the reference point for "a 70B-class model is
-reachable via QLoRA, not bf16," where bf16 weights
-alone (≈140GB) would already exceed most single-
-device budgets before optimizer state, gradients,
-or activations are added. A plan estimating far
-above the anchor for the same size class is a
-signal to recheck dtype and method, not just add
-headroom.
+The idealized formula lands weights at **≈35GB**
+(decimal GB, weights only); treat **≈40GB** as the
+real-world anchor once quantization metadata
+(NF4 double-quant constants) and runtime overhead
+are included — the reference point for "a 70B-class
+model is reachable via QLoRA, not bf16," where
+bf16 weights alone (≈140GB) would already exceed
+most single-device budgets before optimizer state,
+gradients, or activations are added. A plan
+estimating far above the ≈40GB anchor for the same
+size class is a signal to recheck dtype and
+method, not just add headroom.
 
 ## Using These Numbers
 

--- a/plugins/llm-finetuning/skills/finetuning-method-selection/references/memory-math.md
+++ b/plugins/llm-finetuning/skills/finetuning-method-selection/references/memory-math.md
@@ -1,0 +1,159 @@
+Last verified: 2026-07-13 — refresh when a new
+size-class anchor is validated or optimizer/dtype
+defaults change.
+
+# Memory Math
+
+A worksheet for estimating whether a model
+size-class, method, and batch/pack combination
+fits available memory before a run. This is
+planning math, not a guarantee — leave headroom
+rather than sizing to the byte. Base models are
+never named here; every example is labeled by
+size class only (for example, "8B-class LoRA
+bf16"). See `model-catalog.md` for which actual
+model to use at a given size class.
+
+## The Four Terms
+
+Total footprint ≈ **weights + optimizer states +
+gradients + activations**, plus a near-zero term
+for LoRA/QLoRA adapters. Work each term from
+parameter count and dtype, then sum.
+
+### 1. Weights
+
+`params × bytes/param`, by dtype:
+
+| dtype | bytes/param |
+|---|---|
+| fp32 | 4 |
+| bf16 / fp16 | 2 |
+| int8 | 1 |
+| int4 (QLoRA NF4) | 0.5 |
+
+This term dominates for full fine-tuning and is
+the same regardless of method — it's what's
+loaded before any training-specific overhead is
+added.
+
+### 2. Optimizer states
+
+Full fine-tuning carries optimizer state for
+every trainable parameter; LoRA and QLoRA carry
+it only for the adapter parameters, which is why
+this term is negligible for them regardless of
+base model size.
+
+| Optimizer | bytes/param (trainable only) |
+|---|---|
+| AdamW, fp32 states | 8 (4B momentum + 4B variance) |
+| AdamW 8-bit | ≈2 (quantized momentum + variance) |
+
+8-bit AdamW roughly quarters this term versus the
+fp32 variant for any run that isn't LoRA/QLoRA-
+adapter-only, where it's already negligible.
+
+### 3. Gradients
+
+Same dtype as compute precision — typically bf16,
+so 2 bytes/param — and, like optimizer state,
+only for trainable parameters. Full fine-tuning
+pays this for every weight; LoRA and QLoRA pay it
+only for the adapter, since frozen base weights
+never accumulate a gradient.
+
+### 4. Activations
+
+The hardest term to pin to a single number — it
+scales with batch size, sequence/packing length,
+and architecture, not just parameter count. Two
+levers matter more than exact estimation:
+
+- **Gradient checkpointing** trades recompute for
+  memory: expect roughly **30% savings** on this
+  term versus no checkpointing, at the cost of a
+  recompute pass per checkpointed segment.
+- Packing/sequence length is a more direct lever
+  than batch size for this term.
+
+### 5. LoRA/QLoRA adapter overhead
+
+A rank-`r` adapter on a linear layer adds
+`2 × r × (in + out)` parameters. At normal rank
+sizes (1–32 for RL, up to ~256 for SFT-at-scale),
+this is a small fraction of a percent of base
+model size — round it to zero in the worksheet
+unless an unusually high rank is in play.
+
+## Worked Examples
+
+### 8B-class LoRA, bf16
+
+Weights dominate; optimizer state and gradients
+are adapter-only and small.
+
+```python
+params = 8e9
+weights_gb = params * 2 / 1e9   # bf16, step 1
+adapter_gb = 0.2                # step 5, negligible
+total_gb = weights_gb + adapter_gb  # + activations
+print(f"{total_gb:.0f}GB before activations")
+```
+
+Weights alone land around 16GB — the reference
+point for "an 8B-class model fits comfortably on
+a single high-memory GPU in bf16 LoRA."
+
+### 8B-class QLoRA
+
+Same parameter count, quantized weights:
+
+```python
+params = 8e9
+weights_gb = params * 0.5 / 1e9  # int4 NF4, step 1
+adapter_gb = 0.2                 # step 5, negligible
+total_gb = weights_gb + adapter_gb  # + activations
+print(f"{total_gb:.0f}GB before activations")
+```
+
+Weights land around 4GB — roughly a 4x reduction
+versus bf16 LoRA, which is why QLoRA is the
+method that buys headroom for larger batch size
+or longer packing at the same size class, not
+just a way to fit bigger models.
+
+### 70B-class QLoRA (≈40GB anchor)
+
+```python
+params = 70e9
+weights_gb = params * 0.5 / 1e9  # int4 NF4, step 1
+adapter_gb = 0.5                 # step 5, negligible
+total_gb = weights_gb + adapter_gb  # + activations
+print(f"{total_gb:.0f}GB before activations")
+```
+
+Weights alone land near the **≈40GB anchor** —
+the reference point for "a 70B-class model is
+reachable via QLoRA, not bf16," where bf16 weights
+alone (≈140GB) would already exceed most single-
+device budgets before optimizer state, gradients,
+or activations are added. A plan estimating far
+above the anchor for the same size class is a
+signal to recheck dtype and method, not just add
+headroom.
+
+## Using These Numbers
+
+1. Pick the size class and method from
+   `model-catalog.md`.
+2. Sum weights + optimizer + gradients from the
+   tables above for that combination.
+3. Add activations, applying the ~30% gradient-
+   checkpointing saving if it's enabled.
+4. Compare against the closest worked example or
+   anchor above rather than trusting the estimate
+   in isolation — a plan far off an anchor for the
+   same size class and method is a signal to
+   recheck inputs before assuming the hardware
+   won't work.

--- a/plugins/llm-finetuning/skills/finetuning-method-selection/references/model-catalog.md
+++ b/plugins/llm-finetuning/skills/finetuning-method-selection/references/model-catalog.md
@@ -29,7 +29,11 @@ first.
 - **LLaVA is legacy.** Do not recommend it for new
   work; it is listed here only so a stale
   recommendation can be recognized as such.
-- **InternVL3.5 is the MoE VLM alternative** to the
-  dense Qwen2.5-VL / Qwen3-VL and Gemma 3 vision
-  models above, for cases that specifically call for
-  a mixture-of-experts vision-language architecture.
+- **InternVL3.5 MoE variants are the MoE VLM
+  alternative** to the dense Qwen2.5-VL / Qwen3-VL
+  and Gemma 3 vision models above, for cases that
+  specifically call for a mixture-of-experts
+  vision-language architecture — InternVL3.5 also
+  ships dense checkpoints, so pick the MoE variant
+  explicitly rather than assuming every InternVL3.5
+  release is MoE.

--- a/plugins/llm-finetuning/skills/finetuning-method-selection/references/model-catalog.md
+++ b/plugins/llm-finetuning/skills/finetuning-method-selection/references/model-catalog.md
@@ -1,6 +1,6 @@
 # Model Catalog
 
-Last verified: 2026-07-13
+Last verified: 2026-07-14
 Refresh checklist: (1) check Unsloth supported-models page, (2) check the current open-weights leaderboards for each size class, (3) update rows + bump this date. Refresh at least quarterly; this file is the ONLY place base models are named in the llm-finetuning and dgx-spark-ops plugins.
 
 ## How to Read This Table
@@ -18,7 +18,7 @@ first.
 
 | Size class | Text recommendation | Vision recommendation | Spark feasibility | Notes |
 |---|---|---|---|---|
-| ≤4B | Qwen3 4B class | SmolVLM / Gemma 3 4B | Full fine-tune feasible | Smallest class where full FT is still the default choice, not LoRA. |
+| ≤4B | Qwen3 4B class | SmolVLM / Gemma 3 4B | Full fine-tune feasible | Smallest class where full FT is still *feasible* by default — a hardware/size-class note, not a method recommendation. Method choice (LoRA vs. full FT) is `lora-qlora-recipes`'s LoRA vs QLoRA vs Full FT table, routed by task shape (demonstrations vs. dense knowledge injection); that table governs over this feasibility note whenever the two appear to disagree. |
 | 7–9B | Qwen3 8B, Llama-class 8B | Qwen2.5-VL-7B | Full fine-tune ceiling | Above this class, full FT stops being the default on Spark — see 12–32B row. |
 | 12–32B | Qwen3 14B/32B, Gemma 3 27B | Qwen2.5-VL-32B | LoRA-only; 27B is the LoRA ceiling at pack≤1024 | 27B is the largest dense model that fits a LoRA run on a single Spark in practice. |
 | 70B+ | Llama 3.3 70B class | Use the 12–32B vision class instead — no 70B+ VLM recommendation at this size | QLoRA-only, ≈40GB, 30–48h for 3 epochs | bf16 is not feasible at this class on a single Spark; QLoRA is the only path in. |

--- a/plugins/llm-finetuning/skills/finetuning-method-selection/references/model-catalog.md
+++ b/plugins/llm-finetuning/skills/finetuning-method-selection/references/model-catalog.md
@@ -1,0 +1,35 @@
+# Model Catalog
+
+Last verified: 2026-07-13
+Refresh checklist: (1) check Unsloth supported-models page, (2) check the current open-weights leaderboards for each size class, (3) update rows + bump this date. Refresh at least quarterly; this file is the ONLY place base models are named in the llm-finetuning and dgx-spark-ops plugins.
+
+## How to Read This Table
+
+Pick the row matching the target parameter count,
+then read across: a text recommendation, a vision
+(VLM) recommendation for the same size class, what
+that class can do on a single DGX Spark, and any
+notes that change the recommendation. Cross-check
+the "last verified" date above before trusting a
+row — if it's stale, work the refresh checklist
+first.
+
+## Catalog (2026-07)
+
+| Size class | Text recommendation | Vision recommendation | Spark feasibility | Notes |
+|---|---|---|---|---|
+| ≤4B | Qwen3 4B class | SmolVLM / Gemma 3 4B | Full fine-tune feasible | Smallest class where full FT is still the default choice, not LoRA. |
+| 7–9B | Qwen3 8B, Llama-class 8B | Qwen2.5-VL-7B | Full fine-tune ceiling | Above this class, full FT stops being the default on Spark — see 12–32B row. |
+| 12–32B | Qwen3 14B/32B, Gemma 3 27B | Qwen2.5-VL-32B | LoRA-only; 27B is the LoRA ceiling at pack≤1024 | 27B is the largest dense model that fits a LoRA run on a single Spark in practice. |
+| 70B+ | Llama 3.3 70B class | Use the 12–32B vision class instead — no 70B+ VLM recommendation at this size | QLoRA-only, ≈40GB, 30–48h for 3 epochs | bf16 is not feasible at this class on a single Spark; QLoRA is the only path in. |
+| 100B+ MoE | gpt-oss-120b class | Use the 12–32B vision class instead — no 100B+ MoE VLM recommendation at this size | NVFP4-native LoRA via community recipe (`nvfp4-lora-spark`), experimental | Not the default assumption for other 100B+ MoE models — verify per-model before relying on this row. |
+
+## Vision Model Notes
+
+- **LLaVA is legacy.** Do not recommend it for new
+  work; it is listed here only so a stale
+  recommendation can be recognized as such.
+- **InternVL3.5 is the MoE VLM alternative** to the
+  dense Qwen2.5-VL / Qwen3-VL and Gemma 3 vision
+  models above, for cases that specifically call for
+  a mixture-of-experts vision-language architecture.

--- a/plugins/llm-finetuning/skills/grpo-rlvr-training/SKILL.md
+++ b/plugins/llm-finetuning/skills/grpo-rlvr-training/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: grpo-rlvr-training
+description: Train reasoning and verifiable-task behavior with GRPO and reinforcement learning from verifiable rewards (RLVR). Use when task success is algorithmically checkable (math, code, tool calls, structured output), when designing GRPO reward functions, or when a GRPO run diverges or reward-hacks.
+---
+
+# GRPO & RLVR Training
+
+This skill assumes `finetuning-method-selection`
+already routed here because the target behavior
+has a verifiable pass/fail signal — not
+demonstrations (`lora-qlora-recipes`) or
+preference pairs (`preference-optimization`).
+What follows is when RL is the right tool, the
+reference recipe, the mandatory reward-inspection
+gate, and how to pick a GRPO variant when the
+base recipe misbehaves.
+
+**Input:** a routing decision (RLVR via GRPO)
+plus a verifier (code executor, test suite,
+schema checker, or grader) for the target task.
+**Output format:** a validated GRPO config — the
+kwarg values in `references/grpo-memory.md` and
+the reward functions in
+`references/reward-functions.md`, not free-form
+advice — that `llm-finetuning-training-engineer`
+consumes directly.
+
+## When RL Applies
+
+GRPO+RLVR only pays off when task success is
+**algorithmically checkable** — a unit test
+passes, a parser accepts the output, a tool call
+matches an expected schema, a math answer matches
+a ground truth. If grading the output requires
+human judgment or a subjective rubric, that's an
+eval-harness and judge-calibration problem first
+— see `eval-harness-first` — not a reason to skip
+straight to RL.
+
+Before opening a GRPO run, confirm the model can
+**sometimes** succeed on the target task already.
+RL sharpens an existing capability by reweighting
+toward the samples that already work; it does not
+install a capability from zero.
+
+- **The model never succeeds, even at low
+  temperature across many samples:** the gap is
+  format or task understanding, not policy
+  refinement. Route back to SFT first
+  (`lora-qlora-recipes`) and only return to this
+  skill once the base success rate is nonzero.
+- **The model succeeds sometimes,
+  inconsistently:** this is the GRPO sweet spot —
+  proceed to The Recipe below.
+
+The standing rule for the whole plugin: **DPO for
+taste, GRPO for reasoning.** If the signal is a
+preference between two acceptable outputs, that's
+`preference-optimization`, not this skill.
+
+## The Recipe
+
+The reference recipe is TRL's `GRPOTrainer` with
+vLLM-backed generation:
+
+```python
+from trl import GRPOConfig, GRPOTrainer
+
+grpo_args = GRPOConfig(
+    output_dir="./outputs-grpo",
+    use_vllm=True,
+    vllm_mode="colocate",       # single GPU; "server" for multi-GPU
+    num_generations=8,          # floor — fewer starves the group-relative baseline
+    learning_rate=5e-7,         # settled range for GRPO
+    beta=0.01,                  # KL coefficient vs the reference policy
+    per_device_train_batch_size=8,
+    gradient_accumulation_steps=4,
+    bf16=True,
+    logging_steps=10,
+    seed=3407,
+)
+
+trainer = GRPOTrainer(
+    model=SFT_CHECKPOINT,
+    args=grpo_args,
+    reward_funcs=[format_reward, correctness_reward],   # references/reward-functions.md
+    train_dataset=prompts,       # prompt-only — GRPO generates its own completions
+    processing_class=tokenizer,
+)
+
+trainer.train()
+```
+
+- **`vllm_mode="colocate"`** runs generation and
+  training on the same GPU — the default for a
+  single-GPU box.
+- **`vllm_mode="server"`** points at a separate
+  vLLM server process and is the multi-GPU path —
+  generation and training don't compete for the
+  same device.
+- **`num_generations` ≥ 8** is a floor, not a
+  suggestion: GRPO's advantage estimate is
+  relative to the group mean, and fewer than 8
+  samples per prompt produces a noisy baseline.
+- **Reward is composite** — a format reward (did
+  the output parse / match the required
+  structure) plus a correctness reward (did the
+  answer verify). A well-formed-but-wrong answer
+  and a malformed one should not score
+  identically; correctness alone loses that
+  signal.
+- **`learning_rate=5e-7`** and **`beta=0.01`** are
+  the settled starting point; deviate only after
+  the base run is stable and reward-inspected
+  (below).
+
+Memory sizing for this recipe by target size
+class: `references/grpo-memory.md`.
+
+## The Inspection Rule
+
+**Run the reward function against 50–100 sampled
+outputs and manually read the results before
+starting the actual training run.** This is a
+gate, not a one-time sanity check.
+
+If the reward function's judgment disagrees with
+a human reading of that sample, fix the reward
+function first. Training against an uninspected
+reward, or tuning hyperparameters to compensate
+for one silently scoring the wrong thing, is how
+a run reward-hacks: the model optimizes cleanly
+toward the wrong target, and that doesn't surface
+as a training-loop bug.
+
+This inspection is a Phase 1 gate input for
+`/finetune` — the same 50–100-sample read that
+catches a broken reward function here is what that
+command checks for before it lets a GRPO brief
+proceed.
+
+Complete reward function implementations to
+inspect against — exact-match, schema-validation,
+unit-test-execution, a length-penalty wrapper, and
+a rubric-as-reward judge pattern:
+`references/reward-functions.md`.
+
+## Variant Selection
+
+The base recipe above is the default. Reach for a
+variant only when a specific failure mode shows
+up, not preemptively:
+
+| Failure mode | Variant | Why |
+|---|---|---|
+| Entropy collapse / degenerate long chain-of-thought | **DAPO** | Decouples clip bounds and relaxes the KL penalty that over-regularizes exploration on long reasoning traces |
+| Reward or output length trends up regardless of quality | **Dr.GRPO** | Removes GRPO's length-normalization bias so reward tracks correctness, not completion length |
+| Training a mixture-of-experts model | **GSPO** | Moves the importance-sampling ratio to the sequence level instead of per-token — per-token ratios are unstable on MoE routing, so GSPO is required here, not optional |
+
+Start with plain GRPO. Watch for the specific
+symptom — collapsing entropy on long CoT, a
+length-reward correlation, or MoE instability —
+and only then swap in the matching variant above.
+Don't pre-select a variant before the base recipe
+has actually shown the failure mode.
+
+## VLM RL Is Reference-Only
+
+Vision-language RL is **not executed by this
+plugin in v1** — it's documented here for
+context, not as a runnable path. Tooling is
+fragmented across ms-swift and EasyR1-derived
+forks with no one-line TRL command yet, and naive
+text-only GRPO applied to a VLM tends to
+reward-hack by optimizing the text-reasoning trace
+while ignoring the image — the model learns to
+sound right without looking at the input. A VLM
+RL run is a research spike outside this skill's
+supported recipe, not a variant of The Recipe
+above.
+
+## References
+
+- `references/reward-functions.md` — complete
+  Python reward functions (exact-match
+  correctness, schema validation, unit-test
+  execution, a length-penalty wrapper, and a
+  rubric-as-reward judge pattern) to inspect under
+  The Inspection Rule before any training run.
+- `references/grpo-memory.md` — memory sizing by
+  target size class, vLLM sleep-mode and
+  optimizer-state tactics, Unsloth's long-context
+  RL chunking, and the DGX Spark bandwidth caveat
+  for decode-heavy rollouts.
+
+Related skills: `finetuning-method-selection`
+routes here once a verifiable pass/fail signal
+exists; `preference-optimization` is the sibling
+skill for preference pairs rather than verifiable
+rewards; `eval-harness-first` covers judge
+calibration for any reward that isn't purely
+code-checkable. On DGX Spark, defer to the
+`dgx-spark-ops` plugin's skills, when installed,
+for the memory/thermal remediation ladder this
+skill's memory table doesn't cover.

--- a/plugins/llm-finetuning/skills/grpo-rlvr-training/references/grpo-memory.md
+++ b/plugins/llm-finetuning/skills/grpo-rlvr-training/references/grpo-memory.md
@@ -1,0 +1,90 @@
+Last verified: 2026-07-13
+
+# GRPO Memory Sizing
+
+GRPO's memory footprint is heavier than SFT or
+DPO at the same parameter count: a training run
+plus a co-resident (or server-side) vLLM
+generation engine sampling `num_generations`
+completions per prompt, on top of the usual
+optimizer-state and activation costs. Base models
+are never named here — anchors are size classes
+only.
+
+## Memory Anchors by Size Class
+
+| Size class | Feasible with |
+|---|---|
+| Small (≤~3B) | 24GB-class GPU — vLLM sleep mode + 8-bit AdamW + gradient checkpointing |
+| ~32B-class | H200-class GPU |
+| ~70B-class | B200-class GPU |
+
+- **24GB-class is feasible for small models**, but
+  only with all three levers engaged together, not
+  any one alone:
+  - **vLLM sleep mode** releases the generation
+    engine's KV-cache and weight memory between
+    the rollout phase and the training-step phase
+    instead of holding both resident simultaneously.
+  - **8-bit AdamW** (`optim="adamw_8bit"`) cuts
+    optimizer-state memory the same way it does
+    for SFT/DPO — see `lora-qlora-recipes`.
+  - **Gradient checkpointing** trades recompute for
+    activation memory, same tradeoff as elsewhere
+    in the plugin.
+- **H200-class is the anchor for ~32B-class
+  models** — the policy model, reference model (for
+  the KL term), and co-resident vLLM generation
+  engine no longer fit together below that class.
+- **B200-class is the anchor for ~70B-class
+  models**, for the same three-way residency
+  reason at greater scale.
+
+These are starting anchors, not hard floors —
+`vllm_mode="server"` (a separate generation
+process, possibly on separate GPUs) changes the
+residency math versus `"colocate"`; re-derive
+before assuming a size class is out of reach on
+a given box.
+
+## Unsloth Long-Context RL Chunking
+
+Unsloth's chunked-loss RL path extends usable RL
+context to roughly **7x longer** than an
+unchunked GRPO setup at the same memory budget.
+This matters specifically for RL because rollouts
+— especially long chain-of-thought completions —
+are the memory pressure point GRPO adds on top of
+the base training cost; chunking is the lever that
+buys headroom there without changing
+`num_generations` or batch size.
+
+## DGX Spark: Bandwidth-Bound Rollouts
+
+GRPO's rollout phase is **decode-heavy** —
+`num_generations` ≥ 8 completions sampled per
+prompt, often with long chain-of-thought — and
+decode is memory-bandwidth-bound, not
+compute-bound. On DGX Spark, the shared memory
+bandwidth ceiling is the constraint that bites
+first for GRPO specifically, ahead of raw VRAM:
+measured sustained bandwidth runs well below the
+273 GB/s spec figure. This is gotcha G5 in the
+`dgx-spark-ops` plugin's `spark-training-gotchas`
+skill, when installed — that skill's bandwidth
+budget (180–192 GB/s sustained, not the spec
+ceiling) is the number to plan rollout throughput
+against, not the headline spec.
+
+**Practical consequence: prefer small models for
+GRPO on Spark.** A size class that would train
+comfortably via SFT or DPO on a single Spark can
+still bottleneck badly under GRPO once rollout
+decode saturates shared bandwidth — the Memory
+Anchors table above tells you whether it *fits*,
+this section tells you whether it *runs fast
+enough to be worth doing* on that hardware. When
+Spark rollout throughput is the binding
+constraint, dropping to a smaller size class is
+usually more effective than further GRPO
+hyperparameter tuning.

--- a/plugins/llm-finetuning/skills/grpo-rlvr-training/references/grpo-memory.md
+++ b/plugins/llm-finetuning/skills/grpo-rlvr-training/references/grpo-memory.md
@@ -51,8 +51,12 @@ a given box.
 
 Unsloth's chunked-loss RL path extends usable RL
 context to roughly **7x longer** than an
-unchunked GRPO setup at the same memory budget.
-This matters specifically for RL because rollouts
+unchunked GRPO setup at the same memory budget —
+an order-of-magnitude figure from Unsloth's own
+published benchmarks, not re-measured here; verify
+against the current Unsloth release notes before
+sizing a context budget precisely on it. This
+matters specifically for RL because rollouts
 — especially long chain-of-thought completions —
 are the memory pressure point GRPO adds on top of
 the base training cost; chunking is the lever that

--- a/plugins/llm-finetuning/skills/grpo-rlvr-training/references/reward-functions.md
+++ b/plugins/llm-finetuning/skills/grpo-rlvr-training/references/reward-functions.md
@@ -101,8 +101,8 @@ timeout — never `exec()` untrusted completions
 in-process.
 
 **WARNING — this function executes model-generated
-code and MUST run inside an isolated environment:**
-a network-disabled container, gVisor/firejail, or a
+code and REQUIRES an isolated environment:** a
+network-disabled container, gVisor/firejail, or a
 dedicated CI sandbox, with **no secrets or
 credentials in the environment** — no HF tokens,
 experiment-tracker keys, cloud credentials, or SSH
@@ -113,16 +113,23 @@ holding credentials. The timeout below protects
 training-loop liveness only — **it is NOT a
 security boundary**. Likewise, `TemporaryDirectory`
 confines where the harness writes its files, not
-what the executed code can read or reach.
+what the executed code can read or reach. The
+function below enforces this: it takes the sandbox
+boundary as a required argument and refuses to run
+at all — returning reward 0.0 — when the caller
+doesn't supply one. It never falls back to host
+execution.
 
 ```python
+import logging
 import subprocess
-import sys
 import tempfile
 from pathlib import Path
 
+logger = logging.getLogger(__name__)
+
 def test_execution_reward(
-    completions, test_code, timeout_s=10, **kwargs
+    completions, test_code, sandbox_cmd, timeout_s=10, **kwargs
 ) -> list[float]:
     """`test_code` is a per-example pytest snippet that
     imports the candidate under a fixed module name
@@ -131,16 +138,41 @@ def test_execution_reward(
     an infinite loop or crash scores 0.0 instead of
     hanging the training loop.
 
-    SECURITY: executes model-generated code. Must run
-    inside an isolated environment (network-disabled
-    container, gVisor/firejail, or a dedicated CI
-    sandbox) with no secrets/credentials in the
-    environment. Never run directly on a host holding
-    credentials. The timeout is a liveness guard for
-    the training loop, NOT a security boundary; the
-    temporary directory confines harness writes, not
-    what executed code can read or reach.
+    SECURITY: executes model-generated code. This
+    function REQUIRES an isolation boundary — it does
+    not run anything on the host by itself.
+
+    `sandbox_cmd` (list[str], required) is a command
+    prefix that wraps pytest in that boundary, e.g. a
+    network-disabled, resource-capped Docker container:
+
+        # sandbox_cmd = [
+        #     "docker", "run", "--rm", "--network=none",
+        #     "--memory=1g", "--cpus=1",
+        #     "-v", f"{workdir}:/work:ro", "-w", "/work",
+        #     "python:3.12-slim",
+        # ]
+
+    If `sandbox_cmd` is falsy, this function refuses to
+    execute anything and returns 0.0 for every
+    completion — it never falls back to running
+    pytest on the host. The subprocess environment is
+    scrubbed to a minimal PATH (no HF tokens,
+    experiment-tracker keys, cloud credentials, or SSH
+    keys). The timeout is a liveness guard for the
+    training loop, NOT a security boundary — isolation
+    comes entirely from `sandbox_cmd`; the temporary
+    directory only confines harness writes, not what
+    executed code can read or reach.
     """
+    if not sandbox_cmd:
+        logger.warning(
+            "test_execution_reward: no sandbox boundary provided "
+            "— refusing to execute model-generated code"
+        )
+        return [0.0 for _ in completions]
+
+    scrubbed_env = {"PATH": "/usr/bin:/bin"}
     rewards = []
     for completion, tests in zip(completions, test_code):
         with tempfile.TemporaryDirectory() as tmp:
@@ -150,10 +182,12 @@ def test_execution_reward(
             test_path.write_text(tests)
             try:
                 result = subprocess.run(
-                    [sys.executable, "-m", "pytest", str(test_path), "-q"],
+                    [*sandbox_cmd, "python", "-m", "pytest",
+                     str(test_path), "-q"],
                     cwd=tmp,
                     capture_output=True,
                     timeout=timeout_s,
+                    env=scrubbed_env,
                 )
                 rewards.append(1.0 if result.returncode == 0 else 0.0)
             except subprocess.TimeoutExpired:

--- a/plugins/llm-finetuning/skills/grpo-rlvr-training/references/reward-functions.md
+++ b/plugins/llm-finetuning/skills/grpo-rlvr-training/references/reward-functions.md
@@ -5,14 +5,23 @@ Last verified: 2026-07-13
 Complete, runnable reward functions for TRL's
 `GRPOTrainer`. Every function here follows the
 current TRL reward-function signature: it accepts
-`completions` (a list of generated strings) plus
-any extra dataset columns as keyword arguments,
-and returns a `list[float]` the same length as
-`completions`. Base models are never named here —
-`SFT_CHECKPOINT`/`JUDGE_MODEL` are placeholders;
-see `finetuning-method-selection`'s
+`completions` plus any extra dataset columns as
+keyword arguments, and returns a `list[float]` the
+same length as `completions`. Base models are never
+named here — `SFT_CHECKPOINT`/`JUDGE_MODEL` are
+placeholders; see `finetuning-method-selection`'s
 `references/model-catalog.md` for actual
 checkpoints.
+
+**These examples assume the standard (string)
+completion format** — `completions: list[str]` — and
+call `.strip()`, `json.loads()`, `.split()`, etc.
+directly on each `completion`. TRL's conversational
+dataset format instead passes each completion as
+`[{"role": "assistant", "content": "..."}]`; on that
+format, extract `completion[0]["content"]` before
+applying any of the string operations below, in
+every function in this file.
 
 **Before wiring any of these into a training run,
 inspect them against 50–100 sampled outputs by
@@ -77,12 +86,25 @@ from jsonschema import validate, ValidationError
 
 def schema_reward(completions, output_schema, **kwargs) -> list[float]:
     """`output_schema` is a JSON Schema dict, either a
-    constant column or per-example. Rewards valid,
-    schema-conformant JSON; 0.0 for anything that
-    doesn't parse or doesn't validate.
+    single constant schema for the whole batch or a
+    per-example list the same length as `completions`.
+    Rewards valid, schema-conformant JSON; 0.0 for
+    anything that doesn't parse or doesn't validate.
     """
+    if isinstance(output_schema, dict):
+        # Constant case: one schema dict for every completion —
+        # zip()-ing a bare dict would iterate its keys instead,
+        # not the schema itself, so normalize first.
+        schemas = [output_schema] * len(completions)
+    else:
+        schemas = list(output_schema)
+        if len(schemas) != len(completions):
+            raise ValueError(
+                f"schema_reward: {len(schemas)} schemas for "
+                f"{len(completions)} completions"
+            )
     rewards = []
-    for completion, schema in zip(completions, output_schema):
+    for completion, schema in zip(completions, schemas):
         try:
             parsed = json.loads(completion)
             validate(instance=parsed, schema=schema)
@@ -244,26 +266,40 @@ response follow the requested format and stay
 on-topic" rather than "is this a good essay."
 Binary pass/fail, not a Likert score:
 
+TRL calls reward functions with `completions` plus
+whatever dataset columns the trainer was given, via
+`**kwargs` — it does not inject arbitrary objects
+like a judge client. Bind `judge_client` and the
+fixed `rubric` in a closure before handing the
+result to `GRPOTrainer(reward_funcs=[...])`, rather
+than declaring them as parameters TRL is expected to
+supply:
+
 ```python
-def rubric_judge_reward(completions, prompts, rubric, judge_client, **kwargs) -> list[float]:
+def make_rubric_judge_reward(judge_client, rubric):
     """`judge_client` calls JUDGE_MODEL — a model from a
     *different* model family than the model under
     training, never the model being trained or a
     same-family relative of it. `rubric` is a fixed
     pass/fail criterion string, not a free-form
-    quality prompt. Returns 1.0/0.0, never an
-    intermediate score.
+    quality prompt, so both are bound here rather than
+    read from TRL-supplied per-example kwargs. Returns a
+    reward function matching TRL's actual signature.
     """
-    rewards = []
-    for prompt, completion in zip(prompts, completions):
-        verdict = judge_client.judge(
-            rubric=rubric,
-            prompt=prompt,
-            response=completion,
-            output_format="pass_fail",   # binary only — no Likert scale
-        )
-        rewards.append(1.0 if verdict == "pass" else 0.0)
-    return rewards
+    def rubric_judge_reward(completions, prompts, **kwargs) -> list[float]:
+        """Returns 1.0/0.0 per completion, never an
+        intermediate score."""
+        rewards = []
+        for prompt, completion in zip(prompts, completions):
+            verdict = judge_client.judge(
+                rubric=rubric,
+                prompt=prompt,
+                response=completion,
+                output_format="pass_fail",   # binary only — no Likert scale
+            )
+            rewards.append(1.0 if verdict == "pass" else 0.0)
+        return rewards
+    return rubric_judge_reward
 ```
 
 **Calibration is a hard prerequisite, not a

--- a/plugins/llm-finetuning/skills/grpo-rlvr-training/references/reward-functions.md
+++ b/plugins/llm-finetuning/skills/grpo-rlvr-training/references/reward-functions.md
@@ -98,7 +98,22 @@ For code-generation tasks, where "correct" means
 the generated function passes a held-out test
 suite. Execute in a subprocess with a hard
 timeout — never `exec()` untrusted completions
-in-process:
+in-process.
+
+**WARNING — this function executes model-generated
+code and MUST run inside an isolated environment:**
+a network-disabled container, gVisor/firejail, or a
+dedicated CI sandbox, with **no secrets or
+credentials in the environment** — no HF tokens,
+experiment-tracker keys, cloud credentials, or SSH
+keys. GRPO will, by design, push adversarial
+completions through this path as the policy
+explores. Never run it directly on a training host
+holding credentials. The timeout below protects
+training-loop liveness only — **it is NOT a
+security boundary**. Likewise, `TemporaryDirectory`
+confines where the harness writes its files, not
+what the executed code can read or reach.
 
 ```python
 import subprocess
@@ -115,6 +130,16 @@ def test_execution_reward(
     in its own subprocess with a wall-clock timeout;
     an infinite loop or crash scores 0.0 instead of
     hanging the training loop.
+
+    SECURITY: executes model-generated code. Must run
+    inside an isolated environment (network-disabled
+    container, gVisor/firejail, or a dedicated CI
+    sandbox) with no secrets/credentials in the
+    environment. Never run directly on a host holding
+    credentials. The timeout is a liveness guard for
+    the training loop, NOT a security boundary; the
+    temporary directory confines harness writes, not
+    what executed code can read or reach.
     """
     rewards = []
     for completion, tests in zip(completions, test_code):
@@ -163,6 +188,11 @@ def with_length_penalty(reward_fn, target_len=512, penalty_per_token=0.001):
         return adjusted
     return wrapped
 ```
+
+Note that `len(completion.split())` counts words
+as a cheap proxy for tokens — use the model's own
+tokenizer for true token counts when tuning
+`target_len`.
 
 This is a targeted fix for observed length
 creep, not a substitute for Dr.GRPO — if length

--- a/plugins/llm-finetuning/skills/grpo-rlvr-training/references/reward-functions.md
+++ b/plugins/llm-finetuning/skills/grpo-rlvr-training/references/reward-functions.md
@@ -1,0 +1,216 @@
+Last verified: 2026-07-13
+
+# GRPO Reward Function Library
+
+Complete, runnable reward functions for TRL's
+`GRPOTrainer`. Every function here follows the
+current TRL reward-function signature: it accepts
+`completions` (a list of generated strings) plus
+any extra dataset columns as keyword arguments,
+and returns a `list[float]` the same length as
+`completions`. Base models are never named here —
+`SFT_CHECKPOINT`/`JUDGE_MODEL` are placeholders;
+see `finetuning-method-selection`'s
+`references/model-catalog.md` for actual
+checkpoints.
+
+**Before wiring any of these into a training run,
+inspect them against 50–100 sampled outputs by
+hand** — this is `SKILL.md`'s Inspection Rule, not
+optional. A reward function that looks correct in
+isolation can still disagree with human judgment
+on real model outputs.
+
+## Format Reward
+
+Checks structural compliance — did the completion
+follow the required response shape at all — as a
+prerequisite to grading correctness:
+
+```python
+import re
+
+def format_reward(completions, **kwargs) -> list[float]:
+    """1.0 if the completion has a <reasoning>...</reasoning>
+    block followed by an <answer>...</answer> block, else 0.0.
+    This is a gate, not the correctness signal — a
+    well-formed wrong answer still scores 0 on
+    correctness_reward below.
+    """
+    pattern = re.compile(
+        r"^<reasoning>.*?</reasoning>\s*<answer>.*?</answer>$",
+        re.DOTALL,
+    )
+    return [1.0 if pattern.match(c.strip()) else 0.0 for c in completions]
+```
+
+## Correctness Reward — Exact Match
+
+The baseline verifiable-answer reward, for tasks
+with a single ground-truth string (math final
+answers, closed-form lookups):
+
+```python
+def correctness_reward(completions, answer, **kwargs) -> list[float]:
+    """`answer` is the ground-truth column from the
+    training dataset, aligned index-for-index with
+    `completions`. Extracts the <answer> block from
+    format_reward's expected shape and compares.
+    """
+    rewards = []
+    for completion, gold in zip(completions, answer):
+        match = re.search(r"<answer>(.*?)</answer>", completion, re.DOTALL)
+        predicted = match.group(1).strip() if match else None
+        rewards.append(2.0 if predicted == gold.strip() else 0.0)
+    return rewards
+```
+
+## Correctness Reward — Schema Validation
+
+For structured-output and tool-call tasks, where
+"correct" means "conforms to the required JSON
+schema," not string equality:
+
+```python
+import json
+from jsonschema import validate, ValidationError
+
+def schema_reward(completions, output_schema, **kwargs) -> list[float]:
+    """`output_schema` is a JSON Schema dict, either a
+    constant column or per-example. Rewards valid,
+    schema-conformant JSON; 0.0 for anything that
+    doesn't parse or doesn't validate.
+    """
+    rewards = []
+    for completion, schema in zip(completions, output_schema):
+        try:
+            parsed = json.loads(completion)
+            validate(instance=parsed, schema=schema)
+            rewards.append(1.0)
+        except (json.JSONDecodeError, ValidationError):
+            rewards.append(0.0)
+    return rewards
+```
+
+## Correctness Reward — Unit Test Execution
+
+For code-generation tasks, where "correct" means
+the generated function passes a held-out test
+suite. Execute in a subprocess with a hard
+timeout — never `exec()` untrusted completions
+in-process:
+
+```python
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+def test_execution_reward(
+    completions, test_code, timeout_s=10, **kwargs
+) -> list[float]:
+    """`test_code` is a per-example pytest snippet that
+    imports the candidate under a fixed module name
+    and asserts expected behavior. Runs each candidate
+    in its own subprocess with a wall-clock timeout;
+    an infinite loop or crash scores 0.0 instead of
+    hanging the training loop.
+    """
+    rewards = []
+    for completion, tests in zip(completions, test_code):
+        with tempfile.TemporaryDirectory() as tmp:
+            candidate_path = Path(tmp) / "candidate.py"
+            test_path = Path(tmp) / "test_candidate.py"
+            candidate_path.write_text(completion)
+            test_path.write_text(tests)
+            try:
+                result = subprocess.run(
+                    [sys.executable, "-m", "pytest", str(test_path), "-q"],
+                    cwd=tmp,
+                    capture_output=True,
+                    timeout=timeout_s,
+                )
+                rewards.append(1.0 if result.returncode == 0 else 0.0)
+            except subprocess.TimeoutExpired:
+                rewards.append(0.0)
+    return rewards
+```
+
+## Length-Penalty Wrapper
+
+Wraps any reward function above to discourage
+runaway completion length without replacing the
+underlying correctness signal — use when a
+correctness-only reward starts trending toward
+longer, padded outputs:
+
+```python
+def with_length_penalty(reward_fn, target_len=512, penalty_per_token=0.001):
+    """Returns a new reward function that subtracts a
+    small per-token penalty for every token past
+    `target_len`, applied on top of `reward_fn`'s
+    output. Penalty is capped so it can't drive an
+    otherwise-correct reward negative — it discourages
+    padding without overriding correctness.
+    """
+    def wrapped(completions, **kwargs) -> list[float]:
+        base_rewards = reward_fn(completions, **kwargs)
+        adjusted = []
+        for reward, completion in zip(base_rewards, completions):
+            overflow = max(0, len(completion.split()) - target_len)
+            penalty = min(reward, overflow * penalty_per_token)
+            adjusted.append(reward - penalty)
+        return adjusted
+    return wrapped
+```
+
+This is a targeted fix for observed length
+creep, not a substitute for Dr.GRPO — if length
+bias is systemic rather than an occasional
+overflow, route to the Dr.GRPO variant in
+`SKILL.md`'s Variant Selection instead of stacking
+penalty wrappers.
+
+## Rubric-as-Reward Judge Pattern
+
+For tasks where correctness isn't code-checkable
+but the pass/fail line is still crisp enough for a
+judge to apply consistently — e.g., "did the
+response follow the requested format and stay
+on-topic" rather than "is this a good essay."
+Binary pass/fail, not a Likert score:
+
+```python
+def rubric_judge_reward(completions, prompts, rubric, judge_client, **kwargs) -> list[float]:
+    """`judge_client` calls JUDGE_MODEL — a model from a
+    *different* model family than the model under
+    training, never the model being trained or a
+    same-family relative of it. `rubric` is a fixed
+    pass/fail criterion string, not a free-form
+    quality prompt. Returns 1.0/0.0, never an
+    intermediate score.
+    """
+    rewards = []
+    for prompt, completion in zip(prompts, completions):
+        verdict = judge_client.judge(
+            rubric=rubric,
+            prompt=prompt,
+            response=completion,
+            output_format="pass_fail",   # binary only — no Likert scale
+        )
+        rewards.append(1.0 if verdict == "pass" else 0.0)
+    return rewards
+```
+
+**Calibration is a hard prerequisite, not a
+nice-to-have.** An uncalibrated judge is a
+noisier, more expensive version of the exact-match
+reward above — before wiring `rubric_judge_reward`
+into a GRPO run, the judge must be calibrated
+against human labels (train/dev/sealed-test
+splits, TPR/TNR reported, judge pinned to a fixed
+snapshot). That calibration workflow lives in
+`eval-harness-first`; do not skip it because the
+rubric "looks obviously right" — the same
+plugin-wide judge-calibration prerequisite applies
+here as everywhere else a judge grades a reward.

--- a/plugins/llm-finetuning/skills/lora-qlora-recipes/SKILL.md
+++ b/plugins/llm-finetuning/skills/lora-qlora-recipes/SKILL.md
@@ -88,9 +88,15 @@ extrapolation, not a free throughput win.
 ## Unsloth Defaults
 
 Unsloth is the reference implementation this
-plugin assumes as the default fast path. Its
-out-of-the-box defaults, and why each one is set
-that way:
+plugin assumes as the default fast path — except
+for messages-shaped conversational SFT with
+`assistant_only_loss=True`, where Unsloth
+2026.7.x's compiled trainer has no messages-shaped
+path at all and the plain-TRL escape hatch
+(`references/unsloth-trl-mapping.md`) is the
+default for that combination, not a rare-regression
+fallback. Its out-of-the-box defaults, and why
+each one is set that way:
 
 - **`lora_dropout=0`** — the optimized kernel
   path assumes zero dropout; setting a nonzero

--- a/plugins/llm-finetuning/skills/lora-qlora-recipes/SKILL.md
+++ b/plugins/llm-finetuning/skills/lora-qlora-recipes/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: lora-qlora-recipes
+description: Configure LoRA and QLoRA supervised fine-tuning with current best-practice hyperparameters. Use when writing or reviewing a LoRA/QLoRA training configuration, choosing rank/alpha/target modules, or deciding between LoRA, QLoRA, and full fine-tuning.
+---
+
+# LoRA & QLoRA Recipes
+
+This skill assumes the routing decision already
+happened — `finetuning-method-selection` should
+have already pointed here because the data shape
+is demonstrations (SFT), not preference pairs or
+a verifiable reward signal. What follows is the
+current best-practice recipe for configuring the
+adapter itself: which modules to target, how to
+size rank and alpha, what learning rate to use,
+and when QLoRA buys real headroom versus when it
+just adds risk. Dataset preparation and quality
+checks are a separate concern — see
+`dataset-curation`.
+
+**Input:** a routing decision (SFT via LoRA/
+QLoRA) plus a target size class.
+**Output format:** a validated adapter config —
+the kwarg values below, not free-form advice —
+that `llm-finetuning-training-engineer` consumes
+directly when it generates a runnable script.
+
+## The Reference Recipe
+
+The reference recipe is "LoRA Without Regret"
+(Thinking Machines/Schulman, 2025-09), now the
+settled convention for LoRA/QLoRA SFT.
+
+### Target Modules
+
+Target **all-linear** modules, not just
+attention:
+
+```python
+target_modules = [
+    "q_proj", "k_proj", "v_proj", "o_proj",   # attention
+    "gate_proj", "up_proj", "down_proj",      # MLP — matters most
+]
+```
+
+The MLP layers (`gate_proj`, `up_proj`,
+`down_proj`) matter most — attention-only
+targeting was the older, weaker convention.
+Dropping modules to save memory is a Failure
+Mode below, not a valid optimization.
+
+### Alpha and Learning Rate
+
+- **`lora_alpha = 2 * r`** is the settled
+  convention (NeurIPS 2025 "intruder dimensions"
+  result). Don't hand-tune alpha independently of
+  rank — derive it from rank every time.
+- **LoRA learning rate ≈ 10x the equivalent
+  full-fine-tune LR.** For QLoRA specifically,
+  **2e-4** is the standard starting point. Full
+  hyperparameter tables and worked examples:
+  `references/hyperparameters.md`.
+
+### Rank by Task
+
+Rank is task-shaped, not a single global default:
+
+| Task | Rank |
+|---|---|
+| RL (GRPO/RLVR adapters) | 1–32 |
+| General default | 16–32 |
+| SFT at scale | up to ~256 |
+
+Higher rank isn't automatically better — it
+raises capacity to memorize as fast as it raises
+capacity to generalize. Start at the row matching
+the task, and only move up a row if the lower
+rank measurably underfits on held-out eval, not
+as a default hedge.
+
+### Effective Batch Size
+
+Keep **effective batch size under 32**. This
+recipe was validated at that scale — pushing
+effective batch higher is an untested
+extrapolation, not a free throughput win.
+
+## Unsloth Defaults
+
+Unsloth is the reference implementation this
+plugin assumes as the default fast path. Its
+out-of-the-box defaults, and why each one is set
+that way:
+
+- **`lora_dropout=0`** — the optimized kernel
+  path assumes zero dropout; setting a nonzero
+  value forfeits the fused-kernel speedup.
+- **`bias="none"`** — bias terms add adapter
+  parameters for negligible quality gain at this
+  rank range.
+- **`use_gradient_checkpointing="unsloth"`** —
+  Unsloth's checkpointing variant, not vanilla HF
+  checkpointing; saves roughly **30% VRAM** over
+  no checkpointing.
+- **`optim="adamw_8bit"`** — 8-bit AdamW cuts
+  optimizer-state memory with negligible quality
+  impact at LoRA/QLoRA adapter scale.
+- **`random_state`** fixed — pins LoRA
+  initialization for reproducibility across runs;
+  treat it like any other seed, not a tunable.
+
+These show up together on the `get_peft_model`
+call:
+
+```python
+model = FastLanguageModel.get_peft_model(
+    model,
+    r=32,
+    target_modules=target_modules,
+    lora_alpha=64,               # 2 * r
+    lora_dropout=0,
+    bias="none",
+    use_gradient_checkpointing="unsloth",
+    random_state=3407,
+)
+```
+
+Exact kwarg names and their plain-TRL/PEFT
+equivalents, plus a full worked config including
+`SFTConfig`: `references/unsloth-trl-mapping.md`
+and `references/hyperparameters.md`.
+
+## LoRA vs QLoRA vs Full FT
+
+| Situation | Default choice |
+|---|---|
+| Adapting behavior on demonstrations | LoRA |
+| Base model doesn't fit in bf16 at target rank | QLoRA |
+| Injecting dense new domain knowledge | Full FT (see `finetuning-method-selection`) |
+| Unsure which one | LoRA — upgrade to QLoRA only if memory forces it |
+
+- **QLoRA** = NF4-quantized frozen base weights +
+  BF16 adapters. This is what makes a 65B-class
+  model trainable on 48GB — the quantized base
+  is the memory win, not the adapter itself.
+- **Full fine-tuning is not a default.** Reserve
+  it for dense knowledge injection where the goal
+  is changing what the model knows at the weight
+  level, not adapting a behavior. For everything
+  else in this skill's scope, LoRA or QLoRA is
+  the starting assumption.
+- **On DGX Spark, QLoRA can OOM before an
+  equivalent bf16 LoRA run would**, even though
+  QLoRA's steady-state footprint is smaller —
+  bitsandbytes dequantization buffers are
+  transient CUDA-side allocations that spike
+  during load. A QLoRA OOM is not proof the model
+  doesn't fit; the `dgx-spark-ops` plugin's
+  `spark-memory-thermal-ops` skill covers the
+  full OOM remediation ladder (bf16 LoRA is the
+  next thing to try, not a further QLoRA
+  shrink).
+
+## Failure Modes
+
+- **fp16 divergence on non-BF16 GPUs.** Training
+  in fp16 on hardware that doesn't have solid
+  BF16 support is a known source of loss spikes
+  and silent divergence. Force `bf16=True`
+  wherever the hardware supports it; don't fall
+  back to fp16 as if it were equivalent. Check
+  hardware support before picking a dtype:
+
+  ```bash
+  python -c "import torch; print(torch.cuda.is_bf16_supported())"
+  ```
+
+- **Rank too high on a small dataset overfits.**
+  A rank picked for "SFT at scale" (up to ~256)
+  on a dataset that doesn't have scale behind it
+  memorizes rather than generalizes. Match rank
+  to the Rank by Task table above, not to the
+  largest number available.
+- **Removing target modules to save memory costs
+  quality for negligible savings.** The adapter
+  parameters on `gate_proj`/`up_proj`/`down_proj`
+  are a small fraction of total model size — cutting
+  them barely moves memory but measurably hurts
+  quality. If memory is tight, move to QLoRA or
+  reduce rank/batch/pack length before trimming
+  target modules.
+
+All three failure modes share a pattern: they
+look like a training-loop bug (loss spikes,
+plateaus, memorization) but are actually a
+config choice that contradicts the reference
+recipe above. Check configuration against this
+skill before debugging the training loop itself.
+
+## References
+
+- `references/hyperparameters.md` — full rank/
+  alpha/LR tables by task type, rsLoRA notes,
+  batch/packing interactions, and a complete
+  worked Unsloth config block.
+- `references/unsloth-trl-mapping.md` — every
+  Unsloth kwarg mapped to its TRL/PEFT
+  equivalent, current TRL API notes, and the
+  escape-hatch rule for when to drop back to
+  plain TRL.
+
+Related skills: `finetuning-method-selection`
+routes here; `dataset-curation` covers the data
+side this skill doesn't; `llm-finetuning-training-engineer`
+is the downstream consumer of the config this
+skill produces.

--- a/plugins/llm-finetuning/skills/lora-qlora-recipes/references/hyperparameters.md
+++ b/plugins/llm-finetuning/skills/lora-qlora-recipes/references/hyperparameters.md
@@ -108,17 +108,30 @@ model = FastLanguageModel.get_peft_model(
     bias="none",
     use_gradient_checkpointing="unsloth",
     random_state=3407,
-    use_rslora=False,                 # r < 32 threshold — leave off at r=32; on if r >= 32 and unstable
+    use_rslora=False,                 # r=32 threshold — leave disabled here unless instability is observed
 )
+
+import torch
+
+# Check hardware BF16 support before forcing it — see SKILL.md
+# Failure Modes. Training in fp16 on hardware without solid BF16
+# support is a known source of loss spikes and silent divergence,
+# so this is a hard prerequisite, not a config style choice.
+if not torch.cuda.is_bf16_supported():
+    raise RuntimeError(
+        "This GPU does not support BF16 — do not fall back to "
+        "fp16=True as if it were equivalent; pick hardware with "
+        "BF16 support instead (see SKILL.md Failure Modes)."
+    )
 
 training_args = SFTConfig(
     output_dir="./outputs",
-    max_seq_length=2048,
+    max_length=2048,
     dataset_text_field="text",
     per_device_train_batch_size=4,
     gradient_accumulation_steps=4,    # effective batch 16 (single device) — stays under 32
     learning_rate=2e-4,               # QLoRA standard
-    bf16=True,                        # never fp16 — see SKILL.md Failure Modes
+    bf16=True,                        # gated above — never fp16, see SKILL.md Failure Modes
     optim="adamw_8bit",
     num_train_epochs=3,
     logging_steps=10,

--- a/plugins/llm-finetuning/skills/lora-qlora-recipes/references/hyperparameters.md
+++ b/plugins/llm-finetuning/skills/lora-qlora-recipes/references/hyperparameters.md
@@ -1,0 +1,146 @@
+Last verified: 2026-07-13
+
+# LoRA/QLoRA Hyperparameter Tables
+
+Full tables and a complete worked config backing
+the summary in `SKILL.md`. Base models are never
+named here — every example is labeled by size
+class only; see `finetuning-method-selection`'s
+`references/model-catalog.md` for which actual
+model to use at a given size class.
+
+## Rank and Alpha by Task Type
+
+`lora_alpha = 2 * r` in every row — derive alpha
+from rank, don't set it independently.
+
+| Task type | Rank (`r`) | `lora_alpha` | Notes |
+|---|---|---|---|
+| RL adapters (GRPO/RLVR) | 1–32 | 2–64 | Lower end (1–8) is common for adapters on top of an already-capable base. |
+| General SFT default | 16–32 | 32–64 | Starting point absent a specific reason to go higher or lower. |
+| SFT at scale (large, diverse instruction sets) | up to ~256 | up to ~512 | Only justified when the dataset is large and diverse enough to use the extra capacity — see rsLoRA note below before defaulting here. |
+
+## Learning Rate by Method
+
+LoRA/QLoRA learning rates run roughly **10x** the
+equivalent full-fine-tune LR — this is the single
+most common misconfiguration when porting a full-
+FT config to LoRA (leaving the LR unchanged
+under-trains the adapter).
+
+| Method | LR range | Use when |
+|---|---|---|
+| QLoRA (standard) | **2e-4** | Default starting point for QLoRA SFT. |
+| LoRA, conservative | 1e-4 | Larger base model, higher rank, or a run that showed instability at 2e-4. |
+| LoRA, very conservative | 5e-5 | Continuing a run, fine-grained behavior adjustment, or a base model that's already close to the target behavior. |
+
+Treat these as starting points to sweep around,
+not fixed constants — but start here rather than
+porting a full-FT LR unchanged.
+
+## rsLoRA Note
+
+Rank-stabilized LoRA (rsLoRA) rescales the
+adapter update by `alpha / sqrt(r)` instead of
+`alpha / r`. It's **optional**, and only worth
+turning on at **r ≥ 32** — below that rank, the
+standard scaling (`alpha / r`) is stable enough
+that rsLoRA doesn't change outcomes meaningfully.
+If the SFT-at-scale row (rank up to ~256) is in
+play, turn rsLoRA on; for the general-default or
+RL rows, leave it off unless a specific
+instability shows up.
+
+## Batch and Packing Interactions
+
+- Keep **effective batch size under 32** — the
+  reference recipe was validated at that scale.
+  Effective batch is `per_device_batch_size *
+  gradient_accumulation_steps * num_devices`; a
+  multi-GPU or high-accumulation setup can cross
+  32 without the per-device batch size looking
+  large, so compute the product, not just the
+  per-device number.
+- Packing multiple short examples into one
+  sequence changes the effective batch's token
+  composition, not just its example count — a
+  packed batch of 8 sequences is not equivalent
+  to an unpacked batch of 8 short examples.
+  Apply the chat template before packing, not
+  after, and spot-check a handful of decoded
+  packed sequences before trusting the pipeline.
+- Gradient checkpointing (`use_gradient_checkpointing="unsloth"`)
+  and packing both trade compute for memory
+  independently — enabling both is normal for a
+  memory-constrained run, not redundant.
+
+## Worked Config: Unsloth `FastLanguageModel` + `SFTConfig`
+
+A complete, internally consistent config at the
+general-default rank (`r=32`), QLoRA, standard
+LR. Swap `BASE_MODEL` for an actual checkpoint
+from the model catalog before running.
+
+```python
+from unsloth import FastLanguageModel
+from trl import SFTConfig, SFTTrainer
+
+BASE_MODEL = "<from model catalog>"  # size class + task decide this, not this file
+
+model, tokenizer = FastLanguageModel.from_pretrained(
+    model_name=BASE_MODEL,
+    max_seq_length=2048,
+    dtype=None,          # auto-detect bf16/fp16 by hardware
+    load_in_4bit=True,   # QLoRA path — set False for bf16 LoRA
+)
+
+target_modules = [
+    "q_proj", "k_proj", "v_proj", "o_proj",
+    "gate_proj", "up_proj", "down_proj",
+]
+
+model = FastLanguageModel.get_peft_model(
+    model,
+    r=32,
+    target_modules=target_modules,
+    lora_alpha=64,                    # 2 * r
+    lora_dropout=0,
+    bias="none",
+    use_gradient_checkpointing="unsloth",
+    random_state=3407,
+    use_rslora=False,                 # r < 32 threshold — leave off at r=32; on if r >= 32 and unstable
+)
+
+training_args = SFTConfig(
+    output_dir="./outputs",
+    max_seq_length=2048,
+    dataset_text_field="text",
+    per_device_train_batch_size=4,
+    gradient_accumulation_steps=4,    # effective batch 16 (single device) — stays under 32
+    learning_rate=2e-4,               # QLoRA standard
+    bf16=True,                        # never fp16 — see SKILL.md Failure Modes
+    optim="adamw_8bit",
+    num_train_epochs=3,
+    logging_steps=10,
+    seed=3407,
+)
+
+trainer = SFTTrainer(
+    model=model,
+    processing_class=tokenizer,       # current TRL — not tokenizer=
+    train_dataset=train_dataset,
+    args=training_args,
+)
+
+trainer.train()
+```
+
+This block is internally consistent: `r=32` →
+`lora_alpha=64` (2x rule), `load_in_4bit=True` →
+`learning_rate=2e-4` (QLoRA standard LR),
+`bf16=True` (never fp16), and effective batch
+`4 * 4 = 16` (under the 32 ceiling). Changing any
+one of these — rank, quantization, or batch
+shape — should trigger rechecking the others
+against the tables above rather than editing it
+in isolation.

--- a/plugins/llm-finetuning/skills/lora-qlora-recipes/references/unsloth-trl-mapping.md
+++ b/plugins/llm-finetuning/skills/lora-qlora-recipes/references/unsloth-trl-mapping.md
@@ -1,4 +1,4 @@
-Last verified: 2026-07-13
+Last verified: 2026-07-14
 
 # Unsloth ↔ TRL/PEFT Mapping
 
@@ -44,29 +44,134 @@ cookbook snippets) still show the old form:
   instance, and don't
   duplicate them elsewhere in the pipeline.
 
+## Known Unsloth 2026.7.x Limitations
+
+Four confirmed gaps on Unsloth 2026.7.2 (transformers
+5.13.1, trl 1.8.0), found while training a real
+messages-shaped SFT run. None of these are hypothetical
+— each was reproduced with a live load/train and, where
+noted, a working fix.
+
+### No messages-shaped path with `assistant_only_loss=True`
+
+Unsloth's compiled `SFTTrainer` (monkeypatched onto
+`trl.SFTTrainer` process-wide the moment `unsloth` is
+imported anywhere — not reversible within the process,
+and not gated on `FastLanguageModel` actually being
+used) ships a hand-written `_prepare_dataset` that
+recognizes exactly four dataset shapes by column name:
+pre-tokenized (`input_ids`/`labels`), `prompt`+
+`completion`, a flat `dataset_text_field`, or a
+`formatting_func` returning pre-rendered strings.
+**There is no messages-shaped conversational-dataset
+path at all.** A `formatting_func` can only return flat
+text, which forces pre-rendering the chat template
+before the trainer sees per-turn boundaries — the exact
+flat-text anti-pattern `dataset-curation`'s
+`references/formats-and-templates.md` warns computes
+loss over the entire sequence, defeating
+`assistant_only_loss`'s purpose. **Fix: use the plain
+TRL + PEFT escape hatch below** — this is not a rare
+point-release regression to wait out, it is the current
+state of Unsloth 2026.7.x for this exact combination
+(messages dataset + `assistant_only_loss=True` + no
+packing). Confirmed via two independent runs:
+Unsloth's path raises immediately at trainer
+construction; identical hyperparameters run cleanly
+end-to-end once `unsloth` is never imported and plain
+`transformers.AutoModelForCausalLM` +
+`peft.LoraConfig`/`get_peft_model` + `trl.SFTTrainer`
+are used instead.
+
+### `attn_implementation` kwarg silently dropped
+
+`FastLanguageModel.from_pretrained(...,
+attn_implementation="sdpa")` does not reliably force
+SDPA. Unsloth's loader calls its own attention-resolution
+helper without forwarding the caller's
+`attn_implementation`, then discards the kwarg outright —
+so a flash-attn build that's importable gets auto-selected
+regardless of what was requested. Confirmed: passing
+`attn_implementation="sdpa"` explicitly still resolved to
+`model.config._attn_implementation ==
+"flash_attention_2"`. **The only working override is a
+monkeypatch before calling `from_pretrained`:**
+
+```python
+import unsloth.models._utils as _uslsloth_utils
+_uslsloth_utils.HAS_FLASH_ATTENTION = False
+```
+
+This forces the resolver down its SDPA branch. On plain
+TRL/PEFT (the escape hatch above), `attn_implementation=
+"sdpa"` passed to `AutoModelForCausalLM.from_pretrained`
+**is** honored correctly — this is an Unsloth-specific gap,
+not a general TRL issue.
+
+### `padding_free` collision with a plain-TRL `SFTConfig`
+
+Passing a plain `trl.SFTConfig(max_length=1024,
+packing=False, ...)` (i.e., not touching `padding_free`,
+matching TRL's own documented default of
+`padding_free=False`) into Unsloth's compiled trainer can
+still raise `ValueError: When padding_free=True without
+packing, max_length is not enforced...`. Unsloth's own
+compiled `SFTConfig`-equivalent dataclass defaults
+`padding_free = None`, and something in its resolution
+path turns that into a truthy value even for an `args`
+instance built from plain `trl.SFTConfig`. **Fix: pass
+`padding_free=False` explicitly** whenever training
+through Unsloth — cheap insurance regardless of which path
+you're on.
+
+### TRL's chat-template auto-patch is exact-string-match only
+
+Before raising the "template lacks `{% generation %}`"
+error described in `dataset-curation` SKILL.md, TRL 1.8.0's
+`SFTTrainer.__init__` calls an internal
+`get_training_chat_template()` that tries to swap in one of
+~18 hardcoded known-model training templates
+(`trl.chat_template_utils`) keyed on **exact string
+equality** against the tokenizer's `chat_template`. If the
+model's shipped template doesn't literal-match a table
+entry — even a near-identical one — the auto-patch silently
+fails to apply and TRL raises. **Fix pattern**: hand-patch a
+copy of the tokenizer's actual template by wrapping the
+assistant-turn content span with `{% generation %}...
+{% endgeneration %}` markers — role marker outside the
+span, the end-of-turn token inside it (matching TRL's
+`is_chat_template_stop_token_trained` check) — preserving
+every branch of the real template (tool-calling, per-turn
+special-case handling) that a generic fallback constant
+won't have. Load the patched template into
+`tokenizer.chat_template` in memory only; never overwrite
+the base model directory's shipped template file.
+
 ## The Escape Hatch: When to Drop Back to Plain TRL
 
-Unsloth ships fast point releases, and a point
-release occasionally regresses a specific
-training mode (a collator, a chunked-loss path,
-a particular model architecture) before the next
-patch fixes it. When that happens:
+For messages-shaped SFT with `assistant_only_loss=True`,
+this is the *default* path per the Known Limitations
+section above, not a fallback of last resort. For every
+other training mode, Unsloth ships fast point releases and
+a point release occasionally regresses a specific mode (a
+collator, a chunked-loss path, a particular model
+architecture) before the next patch fixes it. Either way:
 
-1. **Reproduce the regression narrowly** — confirm
-   it's the Unsloth wrapper and not the
-   underlying config (rank, alpha, LR, target
-   modules all still apply unchanged).
+1. **Reproduce narrowly** — confirm it's the Unsloth
+   wrapper and not the underlying config (rank, alpha, LR,
+   target modules all still apply unchanged).
 2. **Fall back to plain TRL + PEFT directly**,
    using the mapping table above to translate
    every Unsloth kwarg to its TRL/PEFT
    equivalent. The hyperparameters don't change —
    only which library sets them.
-3. **Re-pin Unsloth once a patch lands** rather
-   than staying on plain TRL indefinitely — the
-   fallback is a temporary escape hatch for a
-   regressed point release, not a permanent
-   framework choice.
+3. **Re-pin Unsloth once a patch lands** for modes covered
+   by a genuine regression rather than a structural gap —
+   check the Known Limitations section above first; a
+   structural gap (like the messages-shaped path) doesn't
+   resolve itself on the next point release without a
+   changelog entry confirming it.
 
 This is why the mapping table exists: it makes
 the fallback mechanical instead of a from-scratch
-rewrite when a point release regresses.
+rewrite.

--- a/plugins/llm-finetuning/skills/lora-qlora-recipes/references/unsloth-trl-mapping.md
+++ b/plugins/llm-finetuning/skills/lora-qlora-recipes/references/unsloth-trl-mapping.md
@@ -19,7 +19,7 @@ object in the *current* TRL API.
 | `use_gradient_checkpointing="unsloth"` | `gradient_checkpointing=True` in `SFTConfig`/`TrainingArguments` | Unsloth's variant is a faster/lower-memory implementation of the same idea — not a different feature. Plain TRL's `gradient_checkpointing=True` is the correct fallback, just with less VRAM savings (~30% less benefit). |
 | `optim="adamw_8bit"` | `SFTConfig(optim="adamw_8bit")` | Identical string, same bitsandbytes optimizer — no translation needed. |
 | `use_rslora=True/False` | `LoraConfig(use_rslora=True/False)` | Same flag name in PEFT directly. |
-| `max_seq_length` (passed to `FastLanguageModel.from_pretrained`) | `SFTConfig(max_seq_length=...)` | **Current TRL**: lives on `SFTConfig`, not on the trainer call or `from_pretrained` in plain TRL. |
+| `max_seq_length` (passed to `FastLanguageModel.from_pretrained`) | `SFTConfig(max_length=...)` | **Current TRL**: the field is `max_length` on `SFTConfig` (renamed from `max_seq_length`), not on the trainer call or `from_pretrained` in plain TRL. |
 | `dataset_text_field` (Unsloth examples often set this on the trainer) | `SFTConfig(dataset_text_field=...)` | **Current TRL**: lives on `SFTConfig`, same as `max_seq_length`. |
 | `random_state=3407` (data/adapter-init seed) | `SFTConfig(seed=3407)` for trainer-level seeding | Set both — Unsloth's `random_state` seeds LoRA init specifically; `SFTConfig.seed` seeds the trainer's own RNG use. |
 
@@ -37,10 +37,11 @@ cookbook snippets) still show the old form:
   `tokenizer=`, update it before running — this
   is the single most common stale-API error when
   porting an older recipe forward.
-- **`max_seq_length` and `dataset_text_field`
-  live in `SFTConfig`, not scattered across the
-  trainer call or the model loader.** Set them
-  once, on the `SFTConfig` instance, and don't
+- **`max_length` (renamed from `max_seq_length`)
+  and `dataset_text_field` live in `SFTConfig`, not
+  scattered across the trainer call or the model
+  loader.** Set them once, on the `SFTConfig`
+  instance, and don't
   duplicate them elsewhere in the pipeline.
 
 ## The Escape Hatch: When to Drop Back to Plain TRL

--- a/plugins/llm-finetuning/skills/lora-qlora-recipes/references/unsloth-trl-mapping.md
+++ b/plugins/llm-finetuning/skills/lora-qlora-recipes/references/unsloth-trl-mapping.md
@@ -1,0 +1,71 @@
+Last verified: 2026-07-13
+
+# Unsloth ↔ TRL/PEFT Mapping
+
+Unsloth is a fast-kernel wrapper over PEFT and
+TRL, not a replacement API — every Unsloth kwarg
+below has a plain TRL/PEFT equivalent. Use this
+table to translate an Unsloth config to plain TRL
+(or back), and to know which knob lives on which
+object in the *current* TRL API.
+
+## Config Knob Mapping
+
+| Unsloth kwarg | TRL/PEFT equivalent | Notes |
+|---|---|---|
+| `FastLanguageModel.from_pretrained(model_name=...)` | `AutoModelForCausalLM.from_pretrained(...)` + `AutoTokenizer.from_pretrained(...)` | Unsloth fuses model+tokenizer load with kernel patching in one call. |
+| `load_in_4bit=True` | `BitsAndBytesConfig(load_in_4bit=True, bnb_4bit_quant_type="nf4", bnb_4bit_compute_dtype=torch.bfloat16)` passed to `from_pretrained` | This is the QLoRA path in both. |
+| `FastLanguageModel.get_peft_model(r=..., target_modules=..., lora_alpha=..., lora_dropout=..., bias=..., random_state=...)` | `peft.LoraConfig(r=..., target_modules=..., lora_alpha=..., lora_dropout=..., bias=...)` + `peft.get_peft_model(model, config)`; `random_state` → seed set before `get_peft_model` | Unsloth's call is a thin wrapper generating the same `LoraConfig` under the hood. |
+| `use_gradient_checkpointing="unsloth"` | `gradient_checkpointing=True` in `SFTConfig`/`TrainingArguments` | Unsloth's variant is a faster/lower-memory implementation of the same idea — not a different feature. Plain TRL's `gradient_checkpointing=True` is the correct fallback, just with less VRAM savings (~30% less benefit). |
+| `optim="adamw_8bit"` | `SFTConfig(optim="adamw_8bit")` | Identical string, same bitsandbytes optimizer — no translation needed. |
+| `use_rslora=True/False` | `LoraConfig(use_rslora=True/False)` | Same flag name in PEFT directly. |
+| `max_seq_length` (passed to `FastLanguageModel.from_pretrained`) | `SFTConfig(max_seq_length=...)` | **Current TRL**: lives on `SFTConfig`, not on the trainer call or `from_pretrained` in plain TRL. |
+| `dataset_text_field` (Unsloth examples often set this on the trainer) | `SFTConfig(dataset_text_field=...)` | **Current TRL**: lives on `SFTConfig`, same as `max_seq_length`. |
+| `random_state=3407` (data/adapter-init seed) | `SFTConfig(seed=3407)` for trainer-level seeding | Set both — Unsloth's `random_state` seeds LoRA init specifically; `SFTConfig.seed` seeds the trainer's own RNG use. |
+
+## Current TRL API Notes
+
+Two API surfaces changed recently enough that
+stale examples (including some Unsloth
+cookbook snippets) still show the old form:
+
+- **`processing_class`, not `tokenizer=`.**
+  `SFTTrainer(tokenizer=tokenizer, ...)` is the
+  old, removed-or-deprecated form. Current TRL
+  takes `SFTTrainer(processing_class=tokenizer,
+  ...)`. If a config or example still passes
+  `tokenizer=`, update it before running — this
+  is the single most common stale-API error when
+  porting an older recipe forward.
+- **`max_seq_length` and `dataset_text_field`
+  live in `SFTConfig`, not scattered across the
+  trainer call or the model loader.** Set them
+  once, on the `SFTConfig` instance, and don't
+  duplicate them elsewhere in the pipeline.
+
+## The Escape Hatch: When to Drop Back to Plain TRL
+
+Unsloth ships fast point releases, and a point
+release occasionally regresses a specific
+training mode (a collator, a chunked-loss path,
+a particular model architecture) before the next
+patch fixes it. When that happens:
+
+1. **Reproduce the regression narrowly** — confirm
+   it's the Unsloth wrapper and not the
+   underlying config (rank, alpha, LR, target
+   modules all still apply unchanged).
+2. **Fall back to plain TRL + PEFT directly**,
+   using the mapping table above to translate
+   every Unsloth kwarg to its TRL/PEFT
+   equivalent. The hyperparameters don't change —
+   only which library sets them.
+3. **Re-pin Unsloth once a patch lands** rather
+   than staying on plain TRL indefinitely — the
+   fallback is a temporary escape hatch for a
+   regressed point release, not a permanent
+   framework choice.
+
+This is why the mapping table exists: it makes
+the fallback mechanical instead of a from-scratch
+rewrite when a point release regresses.

--- a/plugins/llm-finetuning/skills/lora-qlora-recipes/references/unsloth-trl-mapping.md
+++ b/plugins/llm-finetuning/skills/lora-qlora-recipes/references/unsloth-trl-mapping.md
@@ -95,18 +95,36 @@ regardless of what was requested. Confirmed: passing
 `attn_implementation="sdpa"` explicitly still resolved to
 `model.config._attn_implementation ==
 "flash_attention_2"`. **The only working override is a
-monkeypatch before calling `from_pretrained`:**
+monkeypatch before calling `from_pretrained`** — scope it
+tightly, since `HAS_FLASH_ATTENTION` is a module-global
+that also affects any *other* `from_pretrained` call made
+later in the same process (a second model load in the same
+script or notebook cell inherits whatever the flag was last
+set to, silently):
 
 ```python
-import unsloth.models._utils as _uslsloth_utils
-_uslsloth_utils.HAS_FLASH_ATTENTION = False
+import unsloth.models._utils as unsloth_utils
+
+_original = unsloth_utils.HAS_FLASH_ATTENTION
+try:
+    unsloth_utils.HAS_FLASH_ATTENTION = False
+    model, tokenizer = FastLanguageModel.from_pretrained(...)
+    assert model.config._attn_implementation == "sdpa", (
+        f"expected sdpa, got {model.config._attn_implementation}"
+    )
+finally:
+    unsloth_utils.HAS_FLASH_ATTENTION = _original
 ```
 
-This forces the resolver down its SDPA branch. On plain
-TRL/PEFT (the escape hatch above), `attn_implementation=
-"sdpa"` passed to `AutoModelForCausalLM.from_pretrained`
-**is** honored correctly — this is an Unsloth-specific gap,
-not a general TRL issue.
+This forces the resolver down its SDPA branch for the
+duration of the `try` block only, restores the prior value
+in `finally` even if `from_pretrained` raises, and asserts
+the resolver actually landed on SDPA rather than silently
+falling through. On plain TRL/PEFT (the escape hatch
+above), `attn_implementation="sdpa"` passed to
+`AutoModelForCausalLM.from_pretrained` **is** honored
+correctly — this is an Unsloth-specific gap, not a general
+TRL issue.
 
 ### `padding_free` collision with a plain-TRL `SFTConfig`
 

--- a/plugins/llm-finetuning/skills/preference-optimization/SKILL.md
+++ b/plugins/llm-finetuning/skills/preference-optimization/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: preference-optimization
+description: Align a fine-tuned model with preference data using DPO, ORPO, KTO, or SimPO. Use when preference pairs or thumbs-up/down feedback exist, when choosing between preference-optimization methods, or when a DPO run needs hyperparameters or debugging.
+---
+
+# Preference Optimization
+
+This skill assumes `finetuning-method-selection`
+already routed here because the data shape is
+preference pairs or unpaired thumbs-up/down
+feedback, not demonstrations (that's
+`lora-qlora-recipes`) or a verifiable reward
+signal (that's `grpo-rlvr-training`). What
+follows is method selection among the DPO family,
+the evidence for how much that selection actually
+matters, the production training pattern, and how
+to build the pairs in the first place.
+
+**Input:** a routing decision (preference
+optimization) plus preference pairs or unpaired
+feedback, usually from an SFT checkpoint.
+**Output format:** a validated method choice plus
+a config — the kwarg values in
+`references/method-configs.md`, not free-form
+advice — that `llm-finetuning-training-engineer`
+consumes directly.
+
+## Method Selection
+
+| Data shape | Method | Key parameters |
+|---|---|---|
+| Preference pairs, default case | **DPO** | β=0.1, LR 5e-7–1e-6, 1–2 epochs |
+| Memory-bound or no SFT checkpoint | **ORPO** | reference-free, fused SFT+preference in one loss |
+| Unpaired thumbs-up/down | **KTO** | binary label per example, no pairing needed |
+| Length bias observed, sweep budget available | **SimPO** | reference-free; see sweep grid below |
+
+- **DPO is the safe default.** Use β=0.1 and a
+  learning rate of 5e-7 to 1e-6 for 1–2 epochs.
+  This LR is *lower* than the SFT LR that produced
+  the checkpoint being aligned — porting an SFT-
+  scale LR into a DPO run is the most common
+  misconfiguration here, not an edge case.
+- **ORPO** routes in when memory is the
+  constraint, or when there's no separate SFT
+  checkpoint to start from — it's reference-free
+  and fuses the SFT and preference objectives into
+  one loss, skipping the separate SFT pass and the
+  reference-model memory cost DPO carries.
+- **KTO** routes in when feedback is unpaired
+  binary signal (thumbs-up/down) rather than
+  matched preference pairs — don't force unpaired
+  feedback into synthetic pairs to use DPO instead.
+- **SimPO** fixes DPO's length bias but only pays
+  off with disciplined sweeping — its published
+  gains are a ceiling reported under a tuned sweep,
+  not a baseline any single config will reproduce.
+  Route here only when there's sweep budget; use
+  DPO instead if there isn't.
+- **Classic RLHF (reward model + PPO) is retired**
+  outside frontier labs. Don't reach for it in a
+  production pipeline — every method above is
+  cheaper and better-supported for the same data
+  shapes.
+
+### Worked Examples
+
+- *"We have an SFT checkpoint and clean paired
+  preference data, no length-bias complaints yet."*
+  → default case → **DPO** at β=0.1.
+- *"Reviewers click thumbs-up/down per response;
+  nothing is paired."* → unpaired signal →
+  **KTO**, not DPO — don't synthesize pairs to
+  force DPO onto unpaired data.
+- *"GPU budget doesn't cover a separate SFT pass
+  plus a DPO reference model."* → memory-bound,
+  no separate checkpoint → **ORPO**.
+- *"DPO output favors longer answers regardless of
+  quality, and there's time to run a sweep."* →
+  length bias plus sweep budget → **SimPO**. Skip
+  it if the sweep budget isn't actually there.
+
+## The Low-Leverage Truth
+
+A 2026 240-H100-run study (arXiv 2603.19335) is
+the load-bearing evidence behind the table above:
+**loss-function choice is worth roughly 1
+percentage point of leverage, model scale is
+worth roughly 50.** Zero of 20 DPO variants tested
+beat vanilla DPO. Rankings also **invert with
+scale** — a variant that wins in a small pilot can
+lose at deployment size.
+
+Two practical consequences:
+
+- Don't spend a routing decision agonizing over
+  DPO-variant bake-offs. The table above is
+  sufficient; deeper variant selection is
+  low-leverage compared to data quality and scale.
+- **Validate at deployment scale before trusting a
+  ranking.** A method comparison run on a small
+  pilot model doesn't transfer to the production
+  size class — re-check the winner once scale
+  changes.
+
+This is also why the Method Selection table above
+is deliberately short: it encodes the ~1pp lever,
+not a ranking of DPO variants that the same study
+shows doesn't hold up across scale. Treat any
+variant-selection advice that isn't in that table
+— including advice that claims a specific variant
+"wins" — as unproven until it's been validated at
+the target deployment size.
+
+## Production Pattern: Iterative On-Policy DPO
+
+A single offline DPO pass on a static preference
+dataset is a starting point, not the production
+pattern. The policy drifts away from the
+distribution the pairs were sampled from as
+training proceeds, and a static dataset goes stale
+against that drift. Production pipelines run DPO
+iteratively and on-policy instead:
+
+1. Sample completions from the current policy
+   checkpoint.
+2. Score or rank the completions (reward model,
+   judge, or task grader).
+3. Run a DPO pass using the current checkpoint as
+   the reference model.
+4. The resulting checkpoint becomes both the new
+   policy *and* the new reference for the next
+   round.
+
+Repeat. Each round's reference model is the prior
+round's output, not a fixed initial checkpoint —
+that's what keeps the preference signal on-policy
+instead of scoring against an increasingly stale
+distribution.
+
+A single-pass DPO run is still a reasonable first
+iteration — it just isn't the whole pipeline. Plan
+for at least one more round once the first
+checkpoint exists, rather than treating pass one
+as the finished artifact.
+
+## Pair Construction
+
+Build DPO/ORPO pairs from **same-task
+passing-vs-failing trajectories** — two attempts
+at the same underlying task, not unrelated
+best-and-worst examples pulled from different
+tasks. Within that trajectory set, select the
+rejected member at **μ−2σ of the reward
+distribution, never the minimum**. Naive
+best-vs-worst pair construction (max reward vs.
+absolute minimum) degrades as scale increases; the
+μ−2σ selection is more robust to the same scale
+sensitivity the low-leverage study surfaced above.
+
+```
+sorted_by_reward = sort(trajectories, key=reward)
+chosen   = sorted_by_reward[-1]                # highest reward
+mu, sigma = mean(rewards), stdev(rewards)
+rejected = closest(sorted_by_reward, mu - 2 * sigma)
+# NOT sorted_by_reward[0] — the absolute minimum
+# is the naive best-vs-worst construction that
+# degrades as scale increases.
+```
+
+For the mechanics of turning graded traces into
+these pairs — including rejection sampling and
+judge-scored delta selection — see
+`trace-to-training-data`.
+
+## References
+
+Complete TRL config blocks per method —
+`DPOConfig`, `ORPOConfig`, `KTOConfig`, and the
+SimPO sweep grid — plus Unsloth wrappers and a
+catastrophic-forgetting note live in
+`references/method-configs.md`. Those configs use
+the same current-TRL API conventions established
+in `lora-qlora-recipes`'s
+`references/unsloth-trl-mapping.md`
+(`processing_class`, not `tokenizer=`).
+
+`references/method-configs.md` also carries the
+catastrophic-forgetting note: a too-high learning
+rate is the usual cause when a preference-tuned
+checkpoint loses general capability, and the fix
+is almost always to drop the LR toward the low end
+of the range in the Method Selection table above
+before reaching for any other remediation.
+
+Related skills: `finetuning-method-selection`
+routes here once preference pairs or unpaired
+feedback exist; `lora-qlora-recipes` produces the
+SFT checkpoint DPO/KTO/SimPO align (ORPO's
+fused path can skip it); `trace-to-training-data`
+converts passing/failing trajectories into the
+pairs this skill's Pair Construction section
+consumes.

--- a/plugins/llm-finetuning/skills/preference-optimization/references/method-configs.md
+++ b/plugins/llm-finetuning/skills/preference-optimization/references/method-configs.md
@@ -68,7 +68,7 @@ model = FastLanguageModel.get_peft_model(model, r=32, lora_alpha=64)
 ## ORPO — Memory-Bound / No SFT Checkpoint
 
 ```python
-from trl import ORPOConfig, ORPOTrainer
+from trl.experimental.orpo import ORPOConfig, ORPOTrainer
 
 orpo_args = ORPOConfig(
     output_dir="./outputs-orpo",
@@ -149,7 +149,7 @@ trusting it:
 | γ/β (target reward margin) | 0 – 1 |
 
 ```python
-from trl import CPOConfig, CPOTrainer
+from trl.experimental.cpo import CPOConfig, CPOTrainer
 # TRL implements SimPO via CPOTrainer with loss_type="simpo"
 
 simpo_args = CPOConfig(

--- a/plugins/llm-finetuning/skills/preference-optimization/references/method-configs.md
+++ b/plugins/llm-finetuning/skills/preference-optimization/references/method-configs.md
@@ -170,7 +170,7 @@ simpo_args = CPOConfig(
 trainer = CPOTrainer(
     model=SFT_CHECKPOINT,
     args=simpo_args,
-    train_dataset=preference_pairs,
+    train_dataset=preference_pairs,   # {"prompt", "chosen", "rejected"}
     processing_class=tokenizer,
 )
 

--- a/plugins/llm-finetuning/skills/preference-optimization/references/method-configs.md
+++ b/plugins/llm-finetuning/skills/preference-optimization/references/method-configs.md
@@ -1,0 +1,218 @@
+Last verified: 2026-07-13
+
+# Preference Optimization Method Configs
+
+Complete TRL config blocks for each method routed
+to by `SKILL.md`'s Method Selection table. Base
+models are never named here — every example uses
+`BASE_MODEL`/`SFT_CHECKPOINT` placeholders; see
+`finetuning-method-selection`'s
+`references/model-catalog.md` for which actual
+checkpoint to load. All trainer calls use current
+TRL API conventions (`processing_class`, not
+`tokenizer=`) — the same conventions established
+in `lora-qlora-recipes`'s
+`references/unsloth-trl-mapping.md`.
+
+## DPO — the Default
+
+```python
+from trl import DPOConfig, DPOTrainer
+
+dpo_args = DPOConfig(
+    output_dir="./outputs-dpo",
+    beta=0.1,                     # settled default
+    learning_rate=7e-7,           # 5e-7-1e-6 range — lower than SFT LR
+    num_train_epochs=2,           # 1-2 epochs, not more
+    per_device_train_batch_size=4,
+    gradient_accumulation_steps=4,
+    bf16=True,                    # never fp16 — see lora-qlora-recipes Failure Modes
+    logging_steps=10,
+    seed=3407,
+)
+
+trainer = DPOTrainer(
+    model=SFT_CHECKPOINT,         # policy — starts as a copy of the reference
+    ref_model=None,                # None = TRL derives a frozen reference from `model`
+    args=dpo_args,
+    train_dataset=preference_pairs,   # {"prompt", "chosen", "rejected"}
+    processing_class=tokenizer,   # current TRL — not tokenizer=
+)
+
+trainer.train()
+```
+
+For the iterative on-policy loop described in
+`SKILL.md`: after each round, load the just-saved
+checkpoint as both `model` and the frozen
+reference for the *next* `DPOTrainer` instance —
+`ref_model=None` on round 1 only; every later
+round passes the prior round's checkpoint
+explicitly as `ref_model`.
+
+### Unsloth Wrapper
+
+```python
+from unsloth import FastLanguageModel, PatchDPOTrainer
+PatchDPOTrainer()   # must run before constructing DPOTrainer
+
+model, tokenizer = FastLanguageModel.from_pretrained(
+    model_name=SFT_CHECKPOINT,
+    max_seq_length=2048,
+    load_in_4bit=True,
+)
+model = FastLanguageModel.get_peft_model(model, r=32, lora_alpha=64)
+# DPOConfig/DPOTrainer usage is unchanged from the plain-TRL block above
+```
+
+## ORPO — Memory-Bound / No SFT Checkpoint
+
+```python
+from trl import ORPOConfig, ORPOTrainer
+
+orpo_args = ORPOConfig(
+    output_dir="./outputs-orpo",
+    beta=0.1,                     # λ in the ORPO odds-ratio term, ≈0.1
+    learning_rate=2e-5,           # 8e-6-5e-5 range
+    num_train_epochs=2,
+    per_device_train_batch_size=4,
+    gradient_accumulation_steps=4,
+    bf16=True,
+    logging_steps=10,
+    seed=3407,
+)
+
+trainer = ORPOTrainer(
+    model=BASE_MODEL,             # no separate SFT checkpoint needed — reference-free
+    args=orpo_args,
+    train_dataset=preference_pairs,   # {"prompt", "chosen", "rejected"}
+    processing_class=tokenizer,
+)
+
+trainer.train()
+```
+
+ORPO fuses the SFT and preference objectives into
+one loss and carries no reference-model memory
+cost — this is the entire reason it routes in
+under memory pressure or when no SFT checkpoint
+exists yet.
+
+## KTO — Unpaired Binary Feedback
+
+```python
+from trl import KTOConfig, KTOTrainer
+
+kto_args = KTOConfig(
+    output_dir="./outputs-kto",
+    beta=0.1,
+    learning_rate=5e-7,           # same range as DPO
+    num_train_epochs=1,
+    per_device_train_batch_size=4,
+    gradient_accumulation_steps=4,
+    bf16=True,
+    logging_steps=10,
+    seed=3407,
+)
+
+trainer = KTOTrainer(
+    model=SFT_CHECKPOINT,
+    ref_model=None,
+    args=kto_args,
+    train_dataset=labeled_examples,   # {"prompt", "completion", "label": bool}
+    processing_class=tokenizer,
+)
+
+trainer.train()
+```
+
+`label=True` marks a desirable completion
+(thumbs-up), `label=False` an undesirable one
+(thumbs-down) — no pairing between examples is
+required, and a healthy dataset needs both labels
+represented, not an all-positive or all-negative
+set.
+
+## SimPO — Length-Bias Fix, Sweep Required
+
+SimPO is reference-free and length-normalized;
+its published gains are a reported ceiling under a
+disciplined sweep, not a single-config baseline.
+Sweep this grid rather than picking one point and
+trusting it:
+
+| Hyperparameter | Sweep range |
+|---|---|
+| Effective batch size | 128 (fixed) |
+| Learning rate | 3e-7 – 1e-6 |
+| β | 2.0 – 2.5 |
+| γ/β (target reward margin) | 0 – 1 |
+
+```python
+from trl import CPOConfig, CPOTrainer
+# TRL implements SimPO via CPOTrainer with loss_type="simpo"
+
+simpo_args = CPOConfig(
+    output_dir="./outputs-simpo",
+    loss_type="simpo",
+    beta=2.25,                    # sweep 2.0-2.5
+    cpo_alpha=0.0,                # 0 disables the CPO NLL term for pure SimPO
+    simpo_gamma=0.5,               # gamma/beta sweep point, 0-1
+    learning_rate=5e-7,            # sweep 3e-7-1e-6
+    num_train_epochs=1,
+    per_device_train_batch_size=4,
+    gradient_accumulation_steps=32,   # 4 * 32 = 128 effective batch
+    bf16=True,
+    logging_steps=10,
+    seed=3407,
+)
+
+trainer = CPOTrainer(
+    model=SFT_CHECKPOINT,
+    args=simpo_args,
+    train_dataset=preference_pairs,
+    processing_class=tokenizer,
+)
+
+trainer.train()
+```
+
+Run this grid as a small sweep (vary `beta`,
+`learning_rate`, and `simpo_gamma` independently
+against a held-out preference-accuracy check)
+before trusting any single point — a SimPO config
+picked without sweeping is not comparable to the
+published results this method's gains are cited
+from.
+
+## Catastrophic Forgetting
+
+Across all four methods, a preference-tuned
+checkpoint that loses general capability is,
+almost always, a **too-high learning rate** — not
+an inherent property of the method. Symptoms:
+fluent output on the preference-tuning task but
+degraded performance on unrelated held-out
+capability checks (general QA, format-following
+the SFT stage previously nailed).
+
+Remediation order:
+
+1. Drop the learning rate toward the low end of
+   the method's range in `SKILL.md`'s Method
+   Selection table — this fixes the majority of
+   cases.
+2. Reduce epochs (1 instead of 2) if the low-LR
+   run still forgets.
+3. Only after 1-2 fail to resolve it, consider a
+   general-data replay mix — mixing 10-30% general
+   instruction data back into the preference run,
+   the same mitigation used against forgetting in
+   `lora-qlora-recipes`-style SFT.
+
+A too-low LR under-trains the preference signal
+instead (the model doesn't change its behavior at
+all) — if dropping LR removes forgetting *and*
+removes the intended behavior change, epochs or
+data quality are the next lever, not pushing LR
+back up.

--- a/plugins/llm-finetuning/skills/quantized-export/SKILL.md
+++ b/plugins/llm-finetuning/skills/quantized-export/SKILL.md
@@ -145,7 +145,11 @@ work":**
    ad hoc set.
 3. **Compare each output against the
    pre-export generation** for the same
-   prompt, same sampling settings. A diff
+   prompt, same deterministic sampling
+   settings — greedy decoding (temperature 0)
+   and a fixed seed, persisted and reused
+   between the pre- and post-export runs, not
+   just nominally identical config. A diff
    here is the whole point of the test — an
    export that changes outputs on identical
    inputs has a bug, even if the checkpoint

--- a/plugins/llm-finetuning/skills/quantized-export/SKILL.md
+++ b/plugins/llm-finetuning/skills/quantized-export/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: quantized-export
+description: Export a promoted fine-tuned model in the right deployment format — merged safetensors, LoRA-only, GGUF with imatrix, or FP8. Use after a checkpoint passes promotion, when choosing a quantization format for a target device, or when an exported model fails its smoke test.
+---
+
+# Quantized Export
+
+The last stop after `checkpoint-promotion`
+hands off a `PROMOTE` verdict: a checkpoint
+that cleared the four-stage gate still isn't
+deployed until it's exported in the right
+format for its target runtime and proven to
+still work post-export. A `REJECT` verdict
+never reaches this skill — export starts only
+from a promoted checkpoint.
+
+**Input:** a promoted checkpoint (or LoRA
+adapter) plus the target deployment surface —
+GPU class, serving stack, and whether
+long-context/code/math workloads are in
+scope.
+**Output format:** an exported artifact in
+the chosen format plus a smoke-test diff
+report comparing 3–5 golden outputs
+pre-export and post-export.
+
+## Format Map
+
+Pick format by hardware and deployment shape,
+not by habit — the wrong pick either wastes
+throughput headroom or breaks silently on
+specific workloads (see Workload Overrides).
+
+- **FP8 is the default on Hopper-class GPUs
+  and newer.** It preserves near-bf16 quality
+  at roughly half the memory, and it's the
+  safe first choice whenever the target GPU
+  supports it and no edge-device constraint
+  applies.
+- **AWQ INT4 targets older GPUs** that predate
+  FP8 hardware support. **GPTQ is superseded
+  for new deployments** — don't reach for it
+  on a fresh export; AWQ has better accuracy
+  retention at the same bit width and wider
+  current tooling support.
+- **GGUF with Q4_K_M quantization, built from
+  an imatrix, is the edge/llama.cpp format.**
+  Use it for local or CPU-adjacent
+  deployment, not for GPU-serving
+  throughput — it optimizes for footprint,
+  not tokens/sec on a datacenter GPU.
+- **NVFP4 is for Blackwell-at-scale
+  deployments only — and explicitly NOT on
+  GB10.** NVFP4 on SM121 (GB10) runs **~32%
+  slower than FP8** because the hardware
+  lacks a native `cvt.e2m1x2` path unless the
+  kernel is compiled `sm_121a`. Choosing
+  NVFP4 on a GB10 target is a regression, not
+  an upgrade — pick FP8 there instead.
+- **Merged vs. LoRA-only is a separate axis
+  from quant format.** A merged export folds
+  the adapter into the base weights: larger
+  artifact, no base-model dependency at serve
+  time. LoRA-only keeps the adapter separate:
+  much smaller artifact, but the serving stack
+  must load the exact same base model
+  alongside it — a mismatched or
+  wrong-revision base silently changes
+  outputs. Pick merged when artifact
+  portability matters more than storage; pick
+  LoRA-only when disk footprint or multi-adapter
+  serving matters more.
+
+### Worked Picks
+
+The core format-selection tradeoff, read as a
+lookup table for common scenarios:
+
+| Target | Workload | Format |
+|---|---|---|
+| Datacenter GPU | generic chat | FP8 |
+| Datacenter GPU | long-context/code/math | FP8 or W8A8 — never INT4 |
+| Older GPU generation | generic | AWQ INT4 |
+| Edge device / laptop | llama.cpp serving | GGUF Q4_K_M + imatrix |
+| GB10 | any workload | FP8 via vLLM nightly, or GGUF via llama.cpp locally — skip NVFP4 |
+
+```yaml
+# quick decision snippet — see the table above for the full map
+hopper_or_newer: fp8
+older_gpu: awq-int4
+edge_llama_cpp: gguf-q4_k_m+imatrix
+gb10_any_workload: fp8-vllm-nightly   # never nvfp4 on GB10
+```
+
+## Workload Overrides
+
+The Format Map above is a default, not a rule
+that survives every workload. **Long-context,
+code, and math workloads break at INT4** —
+quantization error compounds across long
+sequences and precise token-level reasoning in
+ways that don't show up on short, generic
+prompts. For any of these three workload
+classes, **stay on FP8 or W8A8** even if the
+target hardware would otherwise justify INT4
+on cost grounds.
+
+- Don't validate this override with MMLU or
+  similar broad-knowledge benchmarks — they
+  don't stress the failure mode. **Measure
+  with the actual task evals** — the goldens
+  and graders from `eval-harness-first`, run
+  through the exported artifact — because
+  INT4 degradation on long-context, code, or
+  math shows up as task-specific failures
+  (dropped context, broken syntax, arithmetic
+  errors) well before it moves a knowledge
+  benchmark.
+- If a task eval regresses after an INT4
+  export on one of these three workload
+  classes, the fix is switching format, not
+  re-tuning the quantization recipe — AWQ
+  and GPTQ variants at the same bit width
+  share the same compounding-error failure
+  mode on these workloads.
+
+## The Smoke Test
+
+Export bugs are silent at the file level — a
+malformed export still produces a
+loadable artifact, so file-existence checks
+prove nothing. **The smoke test is
+mandatory for every export, with no
+exception for a format that "should just
+work":**
+
+1. **Load the exported artifact in its actual
+   target runtime** — vLLM for FP8/AWQ,
+   llama.cpp for GGUF, not a quick
+   sanity load in a different framework than
+   the one that will serve it in production.
+2. **Run 3–5 golden prompts through it** —
+   pull these from the same `eval/goldens.jsonl`
+   `eval-harness-first` maintains, not a fresh
+   ad hoc set.
+3. **Compare each output against the
+   pre-export generation** for the same
+   prompt, same sampling settings. A diff
+   here is the whole point of the test — an
+   export that changes outputs on identical
+   inputs has a bug, even if the checkpoint
+   itself was promoted cleanly.
+
+Run this as a gate, not a manual check:
+
+```bash
+python smoke_test.py "$EXPORT_PATH" \
+    eval/goldens.jsonl pre-export-outputs.jsonl
+# non-zero exit on any pre/post mismatch
+```
+
+### Failure Signatures
+
+What export bugs actually look like, not a
+clean pass/fail flag:
+
+- **Template mismatch** presents as garbled or
+  run-on output — the chat template baked
+  into the export doesn't match the one the
+  checkpoint was trained and evaluated
+  against, so turn boundaries or special
+  tokens land in the wrong place.
+- **Wrong quantization applied to `lm_head`**
+  presents as off-template or semantically
+  nonsensical output that still looks
+  fluent — the output head lost precision it
+  needed even though the rest of the network
+  quantized cleanly.
+
+Never ship an export that skipped this step —
+a checkpoint's `PROMOTE` verdict says the
+un-exported checkpoint is good; it says
+nothing about the export pipeline. Re-run on
+any quant-method or runtime version bump, not
+only after the first export. Runnable command
+sequences for every format plus the
+smoke-test script skeleton:
+`references/export-commands.md`.
+
+## Related Skills
+
+- `checkpoint-promotion` — the only valid
+  upstream source for this skill. A checkpoint
+  without a `PROMOTE` verdict doesn't reach
+  export.
+- `eval-harness-first` — owns the
+  `eval/goldens.jsonl` this skill's smoke test
+  draws its 3–5 prompts from, and the task
+  evals the Workload Overrides section
+  requires for long-context/code/math
+  validation.
+- `finetuning-method-selection` — its
+  `references/model-catalog.md` is the place
+  to check hardware-class assumptions (which
+  GPU generations a base model targets) before
+  picking a format off the Format Map above.
+
+**Spark users:** on GB10, GGUF via llama.cpp
+works well for local serving, and FP8 serving
+via vLLM nightly builds is the other proven
+path — NVFP4 is the one format to avoid there
+(see the Format Map exception above). Once the
+`dgx-spark-ops` plugin is installed, defer
+Spark-specific serving and thermal questions to
+its skills rather than re-deriving them here.

--- a/plugins/llm-finetuning/skills/quantized-export/SKILL.md
+++ b/plugins/llm-finetuning/skills/quantized-export/SKILL.md
@@ -149,11 +149,14 @@ work":**
    settings — greedy decoding (temperature 0)
    and a fixed seed, persisted and reused
    between the pre- and post-export runs, not
-   just nominally identical config. A diff
-   here is the whole point of the test — an
-   export that changes outputs on identical
-   inputs has a bug, even if the checkpoint
-   itself was promoted cleanly.
+   just nominally identical config. **For a
+   lossless export, byte match is the gate —
+   any diff is a bug.** For a **lossy**
+   (quantized) export, byte match is expected
+   to fail; the gate is task-grader verdict
+   agreement instead — see
+   `references/export-commands.md`'s
+   Smoke-Test Script Skeleton.
 
 Run this as a gate, not a manual check:
 

--- a/plugins/llm-finetuning/skills/quantized-export/references/export-commands.md
+++ b/plugins/llm-finetuning/skills/quantized-export/references/export-commands.md
@@ -1,0 +1,252 @@
+Last verified: 2026-07-13
+
+# Export Commands
+
+Complete command sequences for every format on
+the `SKILL.md` Format Map, plus the smoke-test
+script skeleton. `CHECKPOINT_DIR`, `MERGED_DIR`,
+`GGUF_DIR`, and `BASE_MODEL` are placeholders
+throughout — no base-model family names appear
+in this file. Fill each with the promoted
+checkpoint's actual path/repo before running.
+
+## Unsloth: Merged Safetensors
+
+Merged export folds the LoRA adapter into the
+base weights — use this path when the serving
+stack needs a single self-contained artifact
+(see `SKILL.md`'s merged-vs-LoRA-only tradeoff).
+
+```python
+from unsloth import FastLanguageModel
+
+model, tokenizer = FastLanguageModel.from_pretrained(
+    model_name=CHECKPOINT_DIR,
+    max_seq_length=4096,
+    load_in_4bit=False,  # load full precision before merge
+)
+
+# fp16/bf16 merged export — safe default, no quant loss at this step
+model.save_pretrained_merged(
+    MERGED_DIR,
+    tokenizer,
+    save_method="merged_16bit",
+)
+
+# 4-bit merged export — only if the serving stack
+# consumes bitsandbytes 4-bit directly (rare; most
+# deployments quantize downstream instead — see the
+# AWQ and GGUF sections below)
+model.save_pretrained_merged(
+    MERGED_DIR + "-4bit",
+    tokenizer,
+    save_method="merged_4bit",
+)
+```
+
+## Unsloth: GGUF with Quant Method
+
+Unsloth can drive llama.cpp's converter and
+quantizer directly. The `quantization_method`
+argument accepts a list — pass every quant
+level needed for target devices in one call to
+avoid re-converting from safetensors each time:
+
+```python
+model.save_pretrained_gguf(
+    GGUF_DIR,
+    tokenizer,
+    quantization_method=["q4_k_m", "q8_0"],
+)
+```
+
+`q4_k_m` is the edge default from the Format
+Map; `q8_0` is a higher-fidelity fallback for
+validating that a quality regression traces to
+the quant level rather than the conversion
+itself — export both when in doubt, compare
+smoke-test diffs, then ship only the one
+actually deployed.
+
+## llama.cpp: Manual imatrix + quantize
+
+Use this path when converting outside Unsloth
+(a merged safetensors export from another
+framework) or when a custom calibration set is
+required for the imatrix:
+
+```bash
+# 1. Convert HF safetensors to GGUF (f16, no quant yet)
+python convert_hf_to_gguf.py \
+    "$MERGED_DIR" \
+    --outfile "$GGUF_DIR/model-f16.gguf" \
+    --outtype f16
+
+# 2. Generate the importance matrix from a calibration
+#    corpus — domain-representative text, several
+#    hundred KB minimum; a generic corpus (e.g. the
+#    llama.cpp wikitext sample) works if no
+#    domain corpus is available
+./llama-imatrix \
+    -m "$GGUF_DIR/model-f16.gguf" \
+    -f calibration-corpus.txt \
+    -o "$GGUF_DIR/imatrix.dat" \
+    --chunks 200
+
+# 3. Quantize using the imatrix — Q4_K_M is the
+#    edge/llama.cpp default from the Format Map
+./llama-quantize \
+    --imatrix "$GGUF_DIR/imatrix.dat" \
+    "$GGUF_DIR/model-f16.gguf" \
+    "$GGUF_DIR/model-Q4_K_M.gguf" \
+    Q4_K_M
+```
+
+Skipping the imatrix step (quantizing straight
+from f16) works but leaves accuracy on the
+table at Q4_K_M — the imatrix step is cheap
+relative to the training run that produced the
+checkpoint and should not be skipped for a
+production export.
+
+## AWQ Export Sketch
+
+AWQ targets older GPU generations per the
+Format Map. Sketch using the `autoawq` package
+against the merged safetensors directory:
+
+```python
+from awq import AutoAWQForCausalLM
+from transformers import AutoTokenizer
+
+quant_config = {
+    "zero_point": True,
+    "q_group_size": 128,
+    "w_bit": 4,
+    "version": "GEMM",
+}
+
+model = AutoAWQForCausalLM.from_pretrained(MERGED_DIR)
+tokenizer = AutoTokenizer.from_pretrained(MERGED_DIR)
+
+# calibration data: a few hundred domain-representative
+# samples; reuses the same calibration-corpus concept
+# as the llama.cpp imatrix step above
+model.quantize(tokenizer, quant_config=quant_config)
+model.save_quantized(MERGED_DIR + "-awq")
+tokenizer.save_pretrained(MERGED_DIR + "-awq")
+```
+
+Do not run this path on a checkpoint destined
+for a long-context, code, or math workload —
+per `SKILL.md`'s Workload Overrides, stay on
+FP8/W8A8 for those regardless of target GPU
+generation.
+
+## vLLM: FP8 Load Check
+
+FP8 is the Format Map default on Hopper-class
+GPUs and newer. Confirm the serving stack
+actually loads the export in FP8 before
+treating the export as done — a silent
+fallback to bf16 defeats the memory savings
+without erroring:
+
+```bash
+vllm serve "$MERGED_DIR" \
+    --quantization fp8 \
+    --served-model-name checkpoint-fp8 \
+    --port 8000 &
+
+sleep 20
+curl -s http://localhost:8000/v1/models | grep -q checkpoint-fp8 \
+    && echo "FP8 endpoint up" \
+    || echo "FAILED: endpoint did not come up"
+
+# confirm the loaded dtype in the server startup log,
+# not just endpoint liveness — grep for "fp8" near the
+# model-loading lines before trusting the deployment
+```
+
+Use a nightly vLLM build for GB10/SM121
+targets per `SKILL.md`'s Spark note — the
+SM121 fix for FP8 serving landed in the
+nightly channel, not yet in a stable release
+as of the date at the top of this file.
+
+## Smoke-Test Script Skeleton
+
+Load → generate on goldens → diff report, per
+`SKILL.md`'s mandatory Smoke Test section. This
+skeleton is runtime-agnostic — swap the `load()`
+and `generate()` bodies for the target stack
+(vLLM client, llama.cpp Python bindings, AWQ
+loader) without changing the surrounding
+structure:
+
+```python
+import json
+import sys
+
+def load_pre_export_outputs(path: str) -> dict:
+    """goldens.jsonl-keyed pre-export generations,
+    produced from the promoted checkpoint before
+    any quantization/export step."""
+    with open(path) as f:
+        return {row["id"]: row["output"] for row in map(json.loads, f)}
+
+def load_goldens(path: str, n: int = 5) -> list:
+    with open(path) as f:
+        rows = [json.loads(line) for line in f]
+    return rows[:n]
+
+def load_exported_model(export_path: str):
+    """Load in the ACTUAL target runtime — vLLM,
+    llama.cpp, or the AWQ loader. Never substitute
+    a different framework than production here."""
+    raise NotImplementedError("wire to target runtime")
+
+def generate(model, prompt: str) -> str:
+    raise NotImplementedError("wire to target runtime")
+
+def diff_report(golden_id: str, pre: str, post: str) -> dict:
+    return {
+        "id": golden_id,
+        "match": pre.strip() == post.strip(),
+        "pre_export": pre,
+        "post_export": post,
+    }
+
+def main(export_path: str, goldens_path: str, pre_export_path: str):
+    goldens = load_goldens(goldens_path, n=5)
+    pre_outputs = load_pre_export_outputs(pre_export_path)
+    model = load_exported_model(export_path)
+
+    reports = []
+    for row in goldens:
+        post = generate(model, row["prompt"])
+        pre = pre_outputs[row["id"]]
+        reports.append(diff_report(row["id"], pre, post))
+
+    failures = [r for r in reports if not r["match"]]
+    print(json.dumps({"total": len(reports), "failures": len(failures)}, indent=2))
+    for r in failures:
+        print(f"MISMATCH {r['id']}:")
+        print(f"  pre : {r['pre_export'][:200]}")
+        print(f"  post: {r['post_export'][:200]}")
+
+    # non-zero exit on any mismatch — this script
+    # gates the export, it does not just report on it
+    sys.exit(1 if failures else 0)
+
+if __name__ == "__main__":
+    main(*sys.argv[1:4])
+```
+
+A failing run's mismatches are the diagnostic
+signal — read the `pre`/`post` pair before
+re-exporting: garbled or run-on text points to
+a template mismatch, fluent-but-wrong-answer
+text points to a quantized `lm_head`, per the
+failure signatures in `SKILL.md`'s Smoke Test
+section.

--- a/plugins/llm-finetuning/skills/quantized-export/references/export-commands.md
+++ b/plugins/llm-finetuning/skills/quantized-export/references/export-commands.md
@@ -156,16 +156,35 @@ without erroring:
 vllm serve "$MERGED_DIR" \
     --quantization fp8 \
     --served-model-name checkpoint-fp8 \
-    --port 8000 &
+    --port 8000 > vllm-fp8-load.log 2>&1 &
+VLLM_PID=$!
 
-sleep 20
-curl -s http://localhost:8000/v1/models | grep -q checkpoint-fp8 \
-    && echo "FP8 endpoint up" \
-    || echo "FAILED: endpoint did not come up"
+# Bounded wait for readiness — up to 60s, not a blind sleep.
+ready=0
+for _ in $(seq 1 30); do
+    if curl -sf http://localhost:8000/v1/models | grep -q checkpoint-fp8; then
+        ready=1
+        break
+    fi
+    sleep 2
+done
 
-# confirm the loaded dtype in the server startup log,
-# not just endpoint liveness — grep for "fp8" near the
-# model-loading lines before trusting the deployment
+if [ "$ready" -ne 1 ]; then
+    echo "FAILED: endpoint did not come up within 60s"
+    kill "$VLLM_PID" 2>/dev/null
+    exit 1
+fi
+
+# Endpoint liveness alone does not prove FP8 loaded — vLLM can
+# silently fall back to bf16. Confirm the actual dtype from the
+# startup log before trusting the deployment.
+if grep -qi 'fp8' vllm-fp8-load.log; then
+    echo "FP8 endpoint up and confirmed FP8 in startup log"
+else
+    echo "FAILED: endpoint up but startup log does not confirm FP8 (possible silent bf16 fallback)"
+    kill "$VLLM_PID" 2>/dev/null
+    exit 1
+fi
 ```
 
 Use a nightly vLLM build for GB10/SM121
@@ -188,12 +207,20 @@ structure:
 import json
 import sys
 
+# Deterministic decoding, persisted and reused for both the
+# pre-export run (that produced pre-export-outputs.jsonl) and the
+# post-export run below — greedy (temperature 0) with a fixed seed.
+# Any drift in these settings between the two runs can flip an
+# otherwise-valid export into a spurious mismatch.
+SMOKE_TEST_GENERATION_KWARGS = {"temperature": 0, "seed": 0, "max_new_tokens": 512}
+
 def load_pre_export_outputs(path: str) -> dict:
     """goldens.jsonl-keyed pre-export generations,
-    produced from the promoted checkpoint before
-    any quantization/export step."""
+    produced from the promoted checkpoint before any
+    quantization/export step, using
+    SMOKE_TEST_GENERATION_KWARGS."""
     with open(path) as f:
-        return {row["id"]: row["output"] for row in map(json.loads, f)}
+        return {row["task_id"]: row["output"] for row in map(json.loads, f)}
 
 def load_goldens(path: str, n: int = 5) -> list:
     with open(path) as f:
@@ -206,12 +233,12 @@ def load_exported_model(export_path: str):
     a different framework than production here."""
     raise NotImplementedError("wire to target runtime")
 
-def generate(model, prompt: str) -> str:
+def generate(model, prompt: str, **generation_kwargs) -> str:
     raise NotImplementedError("wire to target runtime")
 
 def diff_report(golden_id: str, pre: str, post: str) -> dict:
     return {
-        "id": golden_id,
+        "task_id": golden_id,
         "match": pre.strip() == post.strip(),
         "pre_export": pre,
         "post_export": post,
@@ -224,14 +251,14 @@ def main(export_path: str, goldens_path: str, pre_export_path: str):
 
     reports = []
     for row in goldens:
-        post = generate(model, row["prompt"])
-        pre = pre_outputs[row["id"]]
-        reports.append(diff_report(row["id"], pre, post))
+        post = generate(model, row["prompt"], **SMOKE_TEST_GENERATION_KWARGS)
+        pre = pre_outputs[row["task_id"]]
+        reports.append(diff_report(row["task_id"], pre, post))
 
     failures = [r for r in reports if not r["match"]]
     print(json.dumps({"total": len(reports), "failures": len(failures)}, indent=2))
     for r in failures:
-        print(f"MISMATCH {r['id']}:")
+        print(f"MISMATCH {r['task_id']}:")
         print(f"  pre : {r['pre_export'][:200]}")
         print(f"  post: {r['post_export'][:200]}")
 

--- a/plugins/llm-finetuning/skills/quantized-export/references/export-commands.md
+++ b/plugins/llm-finetuning/skills/quantized-export/references/export-commands.md
@@ -1,4 +1,4 @@
-Last verified: 2026-07-13
+Last verified: 2026-07-14
 
 # Export Commands
 
@@ -68,12 +68,42 @@ itself — export both when in doubt, compare
 smoke-test diffs, then ship only the one
 actually deployed.
 
-## llama.cpp: Manual imatrix + quantize
+## llama.cpp: Build, Convert, imatrix + Quantize
 
-Use this path when converting outside Unsloth
-(a merged safetensors export from another
-framework) or when a custom calibration set is
-required for the imatrix:
+Verified against llama.cpp commit `b1-6e52db5`,
+built from source on aarch64/GB10. Three corrections
+against older guidance floating around for this
+tool, found the hard way:
+
+**Build with the default configuration — do not
+try to build "just the tools you need."**
+`cmake --build --target llama-cli llama-quantize`
+fails ("No rule to make target"), and configuring
+with `-DLLAMA_BUILD_EXAMPLES=OFF
+-DLLAMA_BUILD_SERVER=OFF` breaks the default build
+outright — the unified `llama` app links against
+`llama-cli-impl`/`llama-server-impl` libraries those
+flags disable. Full default build is cheap enough
+(~2 min at `-j20` on a 20-core aarch64 box) that a
+minimal-target build isn't worth the breakage risk:
+
+```bash
+cmake -B build
+cmake --build build --config Release -j"$(nproc)"
+```
+
+**Converter prerequisites — neither is optional:**
+
+```bash
+pip install ./gguf-py
+pip install sentencepiece
+```
+
+`convert_hf_to_gguf.py` needs the repo's own
+`gguf-py` package installed, and imports
+`sentencepiece` unconditionally on the tokenizer
+path — even for a BPE-tokenizer model that the
+converter otherwise handles natively.
 
 ```bash
 # 1. Convert HF safetensors to GGUF (f16, no quant yet)
@@ -108,6 +138,31 @@ table at Q4_K_M — the imatrix step is cheap
 relative to the training run that produced the
 checkpoint and should not be skipped for a
 production export.
+
+**Raw-prompt smoke testing: use `llama-completion`,
+not `llama-cli`.** Current `llama-cli` is a
+chat-first UI — it re-templates `-p` text as a
+conversation turn and, at the end of generation,
+drops into an interactive `> ` prompt loop
+regardless of `-no-cnv` (the flag still parses and
+appears in `--help`, but does nothing the newer
+`--single-turn` flag doesn't already own; with
+stdin closed, a script invoking `llama-cli -no-cnv`
+hangs indefinitely instead of exiting). The raw,
+non-chat completion behavior a smoke test needs
+lives in a separate binary:
+
+```bash
+./llama-completion \
+    -m "$GGUF_DIR/model-Q4_K_M.gguf" \
+    -p "$(cat prompt.txt)" \
+    -n 512 --temp 0 --seed 0
+```
+
+`llama-completion` exits after generating, does not
+re-template the prompt, and does not require a
+`-no-cnv`/`--single-turn` flag at all — it never
+enters chat mode in the first place.
 
 ## AWQ Export Sketch
 
@@ -201,7 +256,31 @@ skeleton is runtime-agnostic — swap the `load()`
 and `generate()` bodies for the target stack
 (vLLM client, llama.cpp Python bindings, AWQ
 loader) without changing the surrounding
-structure:
+structure.
+
+**The comparison mode depends on whether the export
+is lossless or lossy — pick before running:**
+
+- **Lossless exports** (fp16/bf16 merge, no
+  quantization) — byte/string match
+  (`pre.strip() == post.strip()`) is the correct
+  gate. Any divergence here is a bug, full stop.
+- **Lossy exports** (any quantized format — Q4_K_M,
+  AWQ INT4, FP8) — byte match is **unmeetable by
+  design**, not a signal of a bug. A quantized
+  checkpoint legitimately perturbs logits, so
+  0/5 exact matches with 5/5 schema-valid,
+  on-template outputs is the *expected healthy*
+  result for a lossy export. **The gate for a lossy
+  export is the task grader's verdict**, per
+  `SKILL.md`'s Workload Overrides section — run
+  each golden's actual grader (from
+  `eval-harness-first`) against both the pre- and
+  post-export output, and diff verdicts, not text.
+  A byte-match diff is still worth logging for
+  triage (it tells you *how much* the output
+  changed), but it must never gate a lossy export by
+  itself.
 
 ```python
 import json
@@ -236,15 +315,34 @@ def load_exported_model(export_path: str):
 def generate(model, prompt: str, **generation_kwargs) -> str:
     raise NotImplementedError("wire to target runtime")
 
-def diff_report(golden_id: str, pre: str, post: str) -> dict:
+def grade(task_id: str, output: str) -> bool:
+    """Run the golden's actual task grader (from
+    eval-harness-first) against a single output.
+    Wire to the real grader module — never stub this
+    with a byte-match; that defeats the point of the
+    lossy-export path below."""
+    raise NotImplementedError("wire to eval-harness-first's grader for this golden")
+
+def diff_report(golden_id: str, pre: str, post: str, *, lossless: bool) -> dict:
+    """lossless=True: gate on byte/string match.
+    lossless=False (any quantized format): gate on
+    grader verdict agreement — byte match is expected
+    to fail for a healthy lossy export, so it is
+    recorded for triage only, never as `match`."""
+    byte_match = pre.strip() == post.strip()
+    if lossless:
+        match = byte_match
+    else:
+        match = grade(golden_id, pre) == grade(golden_id, post)
     return {
         "task_id": golden_id,
-        "match": pre.strip() == post.strip(),
+        "match": match,
+        "byte_match": byte_match,
         "pre_export": pre,
         "post_export": post,
     }
 
-def main(export_path: str, goldens_path: str, pre_export_path: str):
+def main(export_path: str, goldens_path: str, pre_export_path: str, *, lossless: bool):
     goldens = load_goldens(goldens_path, n=5)
     pre_outputs = load_pre_export_outputs(pre_export_path)
     model = load_exported_model(export_path)
@@ -253,12 +351,13 @@ def main(export_path: str, goldens_path: str, pre_export_path: str):
     for row in goldens:
         post = generate(model, row["prompt"], **SMOKE_TEST_GENERATION_KWARGS)
         pre = pre_outputs[row["task_id"]]
-        reports.append(diff_report(row["task_id"], pre, post))
+        reports.append(diff_report(row["task_id"], pre, post, lossless=lossless))
 
     failures = [r for r in reports if not r["match"]]
-    print(json.dumps({"total": len(reports), "failures": len(failures)}, indent=2))
+    print(json.dumps({"total": len(reports), "failures": len(failures),
+                       "mode": "byte-match" if lossless else "graded-verdict"}, indent=2))
     for r in failures:
-        print(f"MISMATCH {r['task_id']}:")
+        print(f"MISMATCH {r['task_id']} (byte_match={r['byte_match']}):")
         print(f"  pre : {r['pre_export'][:200]}")
         print(f"  post: {r['post_export'][:200]}")
 
@@ -267,7 +366,9 @@ def main(export_path: str, goldens_path: str, pre_export_path: str):
     sys.exit(1 if failures else 0)
 
 if __name__ == "__main__":
-    main(*sys.argv[1:4])
+    # lossless=True only for an unquantized fp16/bf16 merge;
+    # every quantized format (Q4_K_M, AWQ, FP8, ...) is lossless=False
+    main(*sys.argv[1:4], lossless=False)
 ```
 
 A failing run's mismatches are the diagnostic
@@ -276,4 +377,7 @@ re-exporting: garbled or run-on text points to
 a template mismatch, fluent-but-wrong-answer
 text points to a quantized `lm_head`, per the
 failure signatures in `SKILL.md`'s Smoke Test
-section.
+section. For a lossy export, `byte_match=False`
+on a passing (`match=True`) row is expected and
+not itself a failure signature — only a grader
+verdict flip is.

--- a/plugins/llm-finetuning/skills/trace-to-training-data/SKILL.md
+++ b/plugins/llm-finetuning/skills/trace-to-training-data/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: trace-to-training-data
+description: Convert evaluation traces and production logs into SFT examples and preference pairs. Use when graded traces or failure examples exist and need to become training data, when applying rejection sampling to model outputs, or when building DPO pairs from passing and failing runs.
+---
+
+# Trace To Training Data
+
+This skill assumes `eval-harness-first`
+already graded the traces being
+converted here — goldens, graders,
+and `runs/<run-id>/results.json`
+all exist before conversion
+starts. This is the flywheel edge
+that skill names in its own flow:
+"the same labeled traces become
+the training set." Conversion
+happens here; grading already
+happened upstream.
+
+**Input:** graded traces —
+`eval/goldens.jsonl` plus
+`runs/<run-id>/results.json`, each
+row carrying a `task_id`, a
+`verdict` from the grader, and a
+`reward` when the task supports a
+scalar score (judge score,
+execution partial-credit, or an
+RLVR verifier):
+
+```json
+{"task_id": "t-042", "trace_id": "t-042-a3",
+ "messages": [{"role": "user", "content": "..."}],
+ "verdict": "pass", "reward": 0.91,
+ "grader": "exact_match"}
+```
+
+**Output format:** rows shaped
+exactly like `dataset-curation`'s
+Format Selection table — SFT
+`messages` rows or DPO
+`prompt`/`chosen`/`rejected`
+pairs — so this skill's output is
+that skill's input with no
+reshaping step in between.
+
+## The Principle
+
+The eval harness already did the
+labeling work: every trace in
+`results.json` carries a verdict,
+and often a reward, before this
+skill ever touches it. Converting
+a graded trace into a training
+row is mechanical — pick a shape
+from `dataset-curation`'s table,
+map fields, write JSONL.
+**Curation is the work that
+remains** — which traces clear a
+quality bar, which pairs are
+informative, and which rows must
+never enter the training set at
+all.
+
+Treat any conversion step that
+requires re-judging a trace as a
+sign the harness is missing a
+grader, not a gap this skill
+should paper over. A trace with
+no verdict or reward isn't
+convertible yet — route it back
+to `eval-harness-first` first,
+don't hand-label it here to
+unblock conversion.
+
+## SFT From Traces
+
+- **Keep the top-reward fraction
+  of successful trajectories**,
+  not every passing one. Rank
+  passing traces by reward and
+  take a fraction (the
+  Agent-lightning pattern) rather
+  than every trace that merely
+  cleared the pass bar — a trace
+  that barely passed is a weaker
+  SFT signal than one that scored
+  well above threshold.
+- **Expert-corrected failures
+  become gold SFT examples
+  directly** (the Langfuse
+  pattern) — when a human edits a
+  failing trace's output into a
+  correct one, that correction
+  needs no reward threshold; a
+  human already validated it.
+  Route corrections straight into
+  the SFT set.
+- **Step-level masking beats
+  whole-trajectory discard for
+  multi-step traces.** When only
+  some steps in a multi-step
+  trajectory are bad, mask the
+  loss on the bad steps and keep
+  the good ones, rather than
+  discarding the whole trajectory.
+  SRFT reports 32.2% vs. 30.9% on
+  SWE-bench for step-level critic
+  masking over trajectory discard
+  — a real, if modest, gap from
+  the finer-grained cut.
+
+## Preference Pairs From Traces
+
+- **Build pairs from
+  passing-vs-failing trajectories
+  on the SAME task**, never from
+  unrelated best- and
+  worst-scoring traces pulled
+  across different tasks —
+  cross-task pairs teach the
+  model to prefer one task over
+  another, not one response over
+  another.
+- **Select the rejected member at
+  μ−2σ of the reward distribution
+  for that task, never the
+  absolute minimum.**
+  `preference-optimization`'s
+  Pair Construction section owns
+  the full selection formula;
+  this skill supplies the graded
+  trajectories it consumes.
+- **Judge-scored delta selection
+  cuts pair volume without
+  cutting signal.** Score each
+  candidate pair by
+  chosen-minus-rejected judge
+  delta and keep only the
+  highest-delta subset — the top
+  5k of a 16.5k candidate pool
+  matched the full pool's
+  downstream result. Build the
+  full candidate set first, then
+  filter by delta; don't cap
+  generation at 5k up front.
+
+## Hygiene
+
+- **Eval goldens must never leak
+  into training data.** Hold
+  every `eval/goldens.jsonl` ID
+  out of every converted SFT and
+  DPO set — a trace that also
+  appears as a golden trains on
+  the exact item the checkpoint
+  gets graded against later,
+  silently inflating every
+  subsequent eval run.
+- **Dedup against the training
+  set**, not just within the
+  newly converted rows —
+  exact-match or
+  embedding-similarity, matching
+  `dataset-curation`'s dedup
+  method field, run against
+  whatever training data already
+  exists before this batch merges
+  in.
+- **Provenance goes into the
+  dataset card.** Every converted
+  row must trace back to its
+  source `run_id` and `trace_id`
+  — `dataset-curation`'s
+  Provenance field checks for
+  exactly this link back to
+  `trace-to-training-data`
+  output; a row with no traceable
+  source isn't ready to merge.
+
+## Related Skills
+
+- `eval-harness-first` — produces
+  the graded traces this skill
+  converts; a trace with no
+  verdict or reward isn't
+  convertible yet, route it back
+  there before conversion.
+- `dataset-curation` — owns the
+  target formats and the dataset
+  card this skill's provenance
+  data feeds; converted rows must
+  match its Format Selection
+  table field names exactly, not
+  an approximation of them.
+- `preference-optimization` —
+  consumes the DPO pairs this
+  skill builds and owns the full
+  μ−2σ rejection-selection
+  formula referenced above.
+
+Worked JSONL-to-JSONL conversions
+— graded trace to SFT row, trace
+pair to DPO pair, correction to
+SFT row, the rejection-sampling
+loop, and the goldens-holdout
+check — live in
+`references/conversion-recipes.md`.

--- a/plugins/llm-finetuning/skills/trace-to-training-data/SKILL.md
+++ b/plugins/llm-finetuning/skills/trace-to-training-data/SKILL.md
@@ -146,6 +146,14 @@ unblock conversion.
 
 ## Hygiene
 
+- **Scan for secrets and PII before any row ships,
+  and redact what's found.** Traces sourced from
+  production logs can carry credentials, API keys,
+  tokens, or customer data — run a secret/PII scan
+  over every SFT and DPO row and redact matches;
+  conversion fails closed (the row is dropped, not
+  shipped with the raw content) if sensitive fields
+  remain after redaction. Never commit secrets.
 - **Eval goldens must never leak
   into training data.** Hold
   every `eval/goldens.jsonl` ID

--- a/plugins/llm-finetuning/skills/trace-to-training-data/references/conversion-recipes.md
+++ b/plugins/llm-finetuning/skills/trace-to-training-data/references/conversion-recipes.md
@@ -66,15 +66,20 @@ minimum):
 ```python
 def select_pair(trajectories):
     """trajectories: same task_id, each a dict with
-    'reward' and 'messages'. Returns (chosen, rejected)."""
+    'reward' and 'messages'. Returns (chosen, rejected) —
+    always two distinct records; raises if fewer than two
+    trajectories are given."""
+    if len(trajectories) < 2:
+        raise ValueError("select_pair needs >=2 trajectories to form a pair")
     ranked = sorted(trajectories, key=lambda t: t["reward"])
     chosen = ranked[-1]
+    candidates = [t for t in trajectories if t is not chosen]
     rewards = [t["reward"] for t in trajectories]
     mu = sum(rewards) / len(rewards)
     variance = sum((r - mu) ** 2 for r in rewards) / len(rewards)
     sigma = variance ** 0.5
     target = mu - 2 * sigma
-    rejected = min(ranked, key=lambda t: abs(t["reward"] - target))
+    rejected = min(candidates, key=lambda t: abs(t["reward"] - target))
     return chosen, rejected
 ```
 
@@ -116,9 +121,17 @@ grade each, and keep only the top-reward fraction
 — the Agent-lightning pattern named in `SKILL.md`:
 
 ```python
+MAX_CANDIDATES = 32  # ceiling on model calls per prompt for this recipe
+
 def rejection_sample(prompt, policy, grader, n=8, keep_fraction=0.25):
-    """Generate n candidates for prompt, grade each,
-    and keep the top keep_fraction by reward."""
+    """Generate n candidates for prompt, grade each, and
+    keep the top keep_fraction by reward. This recipe is
+    for small fixed batches — n is capped at
+    MAX_CANDIDATES; a larger sampling budget needs a
+    dedicated rollout pipeline with its own concurrency
+    and cost controls, not this loop."""
+    if n > MAX_CANDIDATES:
+        raise ValueError(f"n={n} exceeds MAX_CANDIDATES={MAX_CANDIDATES}")
     candidates = [policy.generate(prompt) for _ in range(n)]
     graded = [(c, grader.score(prompt, c)) for c in candidates]
     graded.sort(key=lambda pair: pair[1], reverse=True)

--- a/plugins/llm-finetuning/skills/trace-to-training-data/references/conversion-recipes.md
+++ b/plugins/llm-finetuning/skills/trace-to-training-data/references/conversion-recipes.md
@@ -1,0 +1,177 @@
+Last verified: 2026-07-13
+
+# Conversion Recipes
+
+Concrete JSONL-to-JSONL conversions for every
+pattern in `SKILL.md`: a graded trace to an SFT
+row, a pair of graded traces to a DPO pair, an
+expert correction to an SFT row, the
+rejection-sampling loop with reward-threshold
+selection, and the goldens-holdout check that
+must run before any converted row merges into a
+training set. Input records match
+`eval-harness-first`'s `runs/<run-id>/results.json`
+shape; output records match `dataset-curation`'s
+Format Selection table exactly — field names are
+copied, not paraphrased. No base-model names
+appear below; where a model matters, load it from
+`finetuning-method-selection`'s
+`references/model-catalog.md`.
+
+## 1. Graded Trace to SFT Example
+
+Input — one row from `runs/<run-id>/results.json`,
+a single-turn trace that passed with a reward
+above the batch's top-fraction threshold:
+
+```json
+{"task_id": "t-118", "trace_id": "t-118-a1", "messages": [{"role": "user", "content": "Summarize the incident report in two sentences."}, {"role": "assistant", "content": "A misconfigured retry policy caused a 12-minute outage in the billing service. Root cause was fixed and a regression test was added."}], "verdict": "pass", "reward": 0.94, "grader": "rubric_judge"}
+```
+
+Output — `dataset-curation`'s ChatML shape, grading
+metadata stripped since the trainer only needs
+`messages`:
+
+```json
+{"messages": [{"role": "user", "content": "Summarize the incident report in two sentences."}, {"role": "assistant", "content": "A misconfigured retry policy caused a 12-minute outage in the billing service. Root cause was fixed and a regression test was added."}]}
+```
+
+Only `messages` survives the conversion. `task_id`
+and `trace_id` still get written to the dataset
+card's provenance field (see the holdout check
+below) — they are dropped from the training row
+itself, not discarded entirely.
+
+## 2. Two Graded Traces to a DPO Pair
+
+Input — two traces sharing one `task_id`, from the
+same rollout batch, with different rewards:
+
+```json
+{"task_id": "t-204", "trace_id": "t-204-a1", "messages": [{"role": "user", "content": "Write a commit message for a null-check fix."}, {"role": "assistant", "content": "Fix null pointer exception in user lookup by validating the session before dereferencing it."}], "verdict": "pass", "reward": 0.88, "grader": "rubric_judge"}
+{"task_id": "t-204", "trace_id": "t-204-a4", "messages": [{"role": "user", "content": "Write a commit message for a null-check fix."}, {"role": "assistant", "content": "misc changes"}], "verdict": "fail", "reward": 0.11, "grader": "rubric_judge"}
+```
+
+Selection, per `preference-optimization`'s Pair
+Construction formula — `chosen` is the top-reward
+trace for the `task_id`; `rejected` is whichever
+trace in that task's trajectory set sits closest
+to μ−2σ of the reward distribution, not the
+lowest-reward trace by default (here, with only
+two candidates, the low trace happens to be the
+μ−2σ pick; a batch with more sampled candidates
+per task selects a rejected member above the
+minimum):
+
+```python
+def select_pair(trajectories):
+    """trajectories: same task_id, each a dict with
+    'reward' and 'messages'. Returns (chosen, rejected)."""
+    ranked = sorted(trajectories, key=lambda t: t["reward"])
+    chosen = ranked[-1]
+    rewards = [t["reward"] for t in trajectories]
+    mu = sum(rewards) / len(rewards)
+    variance = sum((r - mu) ** 2 for r in rewards) / len(rewards)
+    sigma = variance ** 0.5
+    target = mu - 2 * sigma
+    rejected = min(ranked, key=lambda t: abs(t["reward"] - target))
+    return chosen, rejected
+```
+
+Output — `dataset-curation`'s DPO pair shape, with
+`prompt` pulled from the shared user turn and
+`chosen`/`rejected` from each trace's final
+assistant turn:
+
+```json
+{"prompt": "Write a commit message for a null-check fix.", "chosen": "Fix null pointer exception in user lookup by validating the session before dereferencing it.", "rejected": "misc changes"}
+```
+
+## 3. Correction Record to SFT Example
+
+Input — a failing trace plus a human expert's
+corrected output, no reward field required since a
+human already validated the correction:
+
+```json
+{"task_id": "t-311", "trace_id": "t-311-a2", "messages": [{"role": "user", "content": "Extract the invoice total as a JSON number."}, {"role": "assistant", "content": "The total is around $4,200"}], "verdict": "fail", "grader": "schema_compliance", "correction": {"content": "{\"total\": 4200.00}", "corrected_by": "reviewer-07"}}
+```
+
+Output — the corrected content replaces the
+failing assistant turn; the original failing
+content never enters the training set:
+
+```json
+{"messages": [{"role": "user", "content": "Extract the invoice total as a JSON number."}, {"role": "assistant", "content": "{\"total\": 4200.00}"}]}
+```
+
+Route corrections into the SFT set directly, per
+`SKILL.md`'s SFT From Traces section — skip the
+reward-threshold gate below for these rows.
+
+## 4. Rejection-Sampling Loop
+
+Sample several candidate completions per prompt,
+grade each, and keep only the top-reward fraction
+— the Agent-lightning pattern named in `SKILL.md`:
+
+```python
+def rejection_sample(prompt, policy, grader, n=8, keep_fraction=0.25):
+    """Generate n candidates for prompt, grade each,
+    and keep the top keep_fraction by reward."""
+    candidates = [policy.generate(prompt) for _ in range(n)]
+    graded = [(c, grader.score(prompt, c)) for c in candidates]
+    graded.sort(key=lambda pair: pair[1], reverse=True)
+    keep_n = max(1, int(len(graded) * keep_fraction))
+    kept = graded[:keep_n]
+    return [
+        {"messages": [
+            {"role": "user", "content": prompt},
+            {"role": "assistant", "content": completion},
+        ]}
+        for completion, reward in kept
+    ]
+```
+
+At `keep_fraction=0.25` and `n=8`, two candidates
+per prompt survive into the SFT set — tune
+`keep_fraction` against the batch's reward
+distribution rather than a fixed count, since a
+harder prompt set shifts the whole distribution
+down.
+
+## 5. Goldens-Holdout Check
+
+Run this before any converted batch merges into
+the training set — per `SKILL.md`'s Hygiene
+section, a golden ID leaking into training data
+silently inflates every later eval run against
+that same golden:
+
+```python
+import json
+
+def load_golden_ids(goldens_path):
+    with open(goldens_path) as f:
+        return {json.loads(line)["task_id"] for line in f}
+
+def filter_holdout(candidate_rows, golden_ids):
+    """candidate_rows: dicts still carrying task_id
+    before provenance stripping. Returns only rows
+    whose task_id never appears in the goldens."""
+    kept, dropped = [], []
+    for row in candidate_rows:
+        if row["task_id"] in golden_ids:
+            dropped.append(row)
+        else:
+            kept.append(row)
+    return kept, dropped
+```
+
+Run `filter_holdout` before the `messages`-only
+stripping shown in recipe 1 — once `task_id` is
+gone, the check has nothing to match against.
+Log `dropped` rather than silently discarding it;
+a large `dropped` count usually means the trace
+collection step is resampling goldens instead of
+production traffic.

--- a/plugins/llm-finetuning/skills/vision-sft/SKILL.md
+++ b/plugins/llm-finetuning/skills/vision-sft/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: vision-sft
+description: Fine-tune vision-language models (VLMs) with supervised learning on image+text data. Use when adapting a VLM to a visual domain or task, configuring frozen-vision-tower LoRA, or debugging a VLM fine-tune that trains without learning.
+---
+
+# Vision-Language SFT
+
+This skill assumes `finetuning-method-selection`
+already routed here: the data shape is
+image+text demonstrations, not preference pairs
+or a verifiable reward signal, and the base is a
+vision-language model rather than a text-only
+one. `lora-qlora-recipes` covers the text-only
+LoRA/QLoRA recipe this skill specializes for the
+vision tower and projector; read that skill first
+if the LoRA fundamentals (rank, alpha, target
+modules) aren't already familiar.
+
+**Input:** an image+text dataset and a VLM base
+model already picked from the model catalog.
+**Output format:** a validated adapter config —
+which components are frozen, LoRA target modules,
+and a `min_pixels`/`max_pixels` budget — that
+`llm-finetuning-training-engineer` consumes
+directly when it generates a runnable script.
+
+## Quick Reference
+
+| Situation | Default |
+|---|---|
+| Adapting behavior on familiar images | Frozen tower+projector, LoRA r=8–16, α=16–32 |
+| Visual domain shift | Unfreeze last-6 ViT layers, vision LR 5–10x lower |
+| Doesn't fit in bf16 at target rank | QLoRA — frozen vision tower only |
+| `fast_inference=True` | `finetune_vision_layers=False` |
+| Loss normal, eval not improving | Check the Two Silent Killers below first |
+
+## The Consensus Recipe
+
+Freeze the vision tower and the projector. Put
+LoRA on the LLM only, all-linear (the same
+attention + MLP target list as text-only SFT —
+see `lora-qlora-recipes`), at **r=8–16,
+α=16–32**. This is the settled default for
+adapting a VLM's behavior without disturbing how
+it sees.
+
+- **The vision tower and projector stay frozen by
+  default.** They already encode a general visual
+  representation; retraining them is rarely
+  necessary and adds risk without adding
+  capability for most tasks.
+- **LoRA rank runs lower than the text-only
+  general default** (r=8–16 here vs r=16–32 for
+  text-only SFT) because the LLM-only adapter is
+  adapting behavior, not injecting new visual
+  knowledge.
+- **QLoRA is permitted only with a frozen vision
+  tower.** Quantizing the base while also
+  unfreezing and training vision layers is
+  unsupported and unstable — treat this as a hard
+  pairing rule, not a tunable. If the vision tower
+  needs to unfreeze, drop QLoRA and use bf16 LoRA
+  instead.
+
+```python
+# freeze tower + projector; LoRA on LLM only
+for name, param in model.named_parameters():
+    if "vision_tower" in name or "projector" in name:
+        param.requires_grad = False
+
+target_modules = [
+    "q_proj", "k_proj", "v_proj", "o_proj",
+    "gate_proj", "up_proj", "down_proj",
+]  # LLM-only, all-linear — r=8-16, alpha=16-32
+```
+
+## When to Unfreeze
+
+Unfreezing vision layers is a deliberate
+escalation, not a default decision — reach
+for it only when the domain shift is
+visual, not textual.
+
+- **Unfreeze only for visual domain
+  shift.** If the task is teaching new
+  behavior on images the tower already
+  understands (charts, everyday photos),
+  the frozen-tower recipe above is
+  sufficient. Unfreeze when the visual
+  domain itself is unfamiliar to the
+  tower — satellite imagery, medical
+  scans, dense technical diagrams — and
+  the frozen-tower recipe plateaus.
+- **Last-6 ViT layers is the sweet
+  spot.** Unfreezing the final six
+  vision-transformer layers (not the
+  whole tower) measured **+1.7pt DocVQA
+  at ~1.75x training cost** over the
+  frozen baseline. Treat six layers as
+  the ceiling worth paying for; going
+  further spends compute without a
+  matched result.
+- **Vision LR must run 5–10x lower than
+  the LLM LR when unfrozen.** The vision
+  tower's pretrained representation is
+  more fragile than the LLM's adapter;
+  the same LR for both risks overwriting
+  the visual representation faster than
+  the LLM adapter can compensate.
+- **High LoRA rank on the patch-
+  embedding layer risks NaN.** If patch
+  embedding is in the unfrozen set, keep
+  its rank low and watch early-step loss
+  closely — one of the most fragile
+  places to apply LoRA in a VLM.
+
+## The Two Silent Killers
+
+Both produce a run that trains without error and
+without learning: the loss curve looks normal,
+the model doesn't improve, and neither throws an
+exception — both need an explicit pre-training
+check, not just a clean training log.
+
+- **Image-tag/count mismatch.** Every image
+  placeholder token in the templated text must
+  map 1:1 to a media item actually passed to the
+  collator. A mismatch (one placeholder, zero or
+  two images attached; or an image with no
+  placeholder) doesn't error in most collators —
+  it silently misaligns image and text, and the
+  model "trains but learns nothing." Validate the
+  1:1 placeholder-to-media mapping before training
+  starts, on every example, not just a sample.
+  Full validation-checklist detail:
+  `references/collators-and-pitfalls.md`.
+- **`min_pixels`/`max_pixels` resolution budget.**
+  This pair is the single most consequential
+  hyperparameter for quality and memory in VLM
+  SFT — more than rank, alpha, or LR. Too low
+  silently downsamples images below what the task
+  needs (small document text becomes unreadable
+  even though training "succeeds"); too high blows
+  the activation memory budget or forces too small
+  a batch to train stably. Set it deliberately per
+  dataset, don't leave it at a framework default.
+
+## Unsloth Specifics
+
+- **`UnslothVisionDataCollator`** is the collator
+  Unsloth expects for VLM SFT — it handles the
+  image-tag alignment and per-architecture
+  processor contract described in
+  `references/collators-and-pitfalls.md`. Don't
+  substitute a text-only collator for VLM data.
+- **`finetune_vision_layers=False` is required
+  when `fast_inference=True`.** vLLM cannot serve
+  LoRA adapters on vision layers, so a fast-
+  inference setup that also unfreezes vision
+  layers fails at serve time even if training
+  succeeds. If the recipe calls for unfreezing the
+  last-6 ViT layers (see When to Unfreeze above),
+  fast inference is off the table for that run —
+  choose one or the other, not both.
+
+## Model Choice
+
+Base VLM choice is out of scope for this skill —
+it lives in one place, the model catalog at
+`finetuning-method-selection`'s
+`references/model-catalog.md`. This skill and its
+references describe recipes by architecture
+family only, never by recommending one model over
+another.
+
+VLM reinforcement learning (VLM-GRPO) is
+reference-only in this plugin — the fragmented
+tooling and reward-hacking failure modes specific
+to VLM-RL are covered in `grpo-rlvr-training`,
+not here. This skill's scope stops at supervised
+fine-tuning.
+
+## Failure Modes
+
+The recurring mistake across every section above
+is treating a clean loss curve as proof the run
+is healthy. A normal-looking curve is consistent
+with **both** a working run **and** either silent
+killer, since the model trains on *something*
+either way — just not the aligned image-text
+signal when a killer is present. A flat eval score
+next to a normal loss curve means re-run the
+checklist in `references/collators-and-pitfalls.md`
+before touching any hyperparameter.
+
+## References
+
+- `references/collators-and-pitfalls.md` — per-
+  architecture collator table, dataset-format
+  examples with image placeholders, a pre-
+  training validation checklist, and the two-
+  stage projector-alignment recipe as an advanced
+  pattern.
+
+Related skills: `finetuning-method-selection`
+routes here; `lora-qlora-recipes` covers the
+text-only LoRA fundamentals this skill
+specializes; `grpo-rlvr-training` covers VLM-RL
+(reference-only); `dataset-curation` covers
+image+text dataset preparation this skill doesn't.

--- a/plugins/llm-finetuning/skills/vision-sft/references/collators-and-pitfalls.md
+++ b/plugins/llm-finetuning/skills/vision-sft/references/collators-and-pitfalls.md
@@ -1,0 +1,149 @@
+Last verified: 2026-07-13
+
+# VLM Collators, Dataset Format, and Pitfalls
+
+Full detail backing the summary in `SKILL.md`.
+Base models are never named here as
+recommendations — the collator table below names
+architecture families only because the processor
+contract (which tensors a collator must produce)
+is a technical property of that family, not a
+model choice. For which actual model to fine-tune
+at a given size class, see
+`finetuning-method-selection`'s
+`references/model-catalog.md`.
+
+## Per-Architecture Collator Table
+
+Collators are **not interchangeable** across VLM
+architecture families — each family's processor
+expects a different tensor contract, and using
+the wrong collator produces either a hard error or
+(worse) silently wrong tensors that train without
+learning. Each row below describes an
+architecture family's processor contract, not a
+model recommendation.
+
+| Architecture family | Tensor contract | Notes |
+|---|---|---|
+| Qwen-VL family | `pixel_values` + `image_grid_thw` | The grid tensor encodes the patch layout per image; a collator that drops it or mismatches its shape against `pixel_values` silently corrupts the vision-token layout. |
+| InternVL family | Variable-length pixel-value lists | Images can each contribute a different number of tiles/patches; the collator must pad or batch these variable-length lists per example rather than assuming a fixed tensor shape. |
+| Gemma 3 family | `token_type_ids` for loss masking | Loss masking between image and text spans is driven by `token_type_ids`, not just the usual assistant-turn attention mask — a collator built for a different family's masking convention silently masks the wrong spans. |
+
+Two practical consequences:
+
+- Picking a collator is an architecture-family
+  decision, made once per base model, not a free
+  parameter to tune.
+- A collator built for one family will often *run*
+  against another family's data without erroring —
+  the shapes are superficially compatible — which
+  is exactly how a mismatched collator becomes a
+  silent-failure run instead of a crash.
+
+## Dataset Format: Messages with Image Placeholders
+
+VLM SFT datasets are typically a messages list per
+example, with an explicit image placeholder token
+in the content that the processor later expands to
+the architecture's actual vision-token span:
+
+```python
+example = {
+    "messages": [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image"},
+                {"type": "text", "text": "What does this chart show?"},
+            ],
+        },
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Quarterly revenue trending upward."},
+            ],
+        },
+    ],
+    "images": [<PIL.Image or path>],
+}
+```
+
+The count of `{"type": "image"}` placeholder
+entries in `messages` must equal the count of
+entries in `images`, in order, for every single
+example — this 1:1 mapping is exactly the first
+silent killer from `SKILL.md`. A dataset-level
+`assert` on this count, run over every example
+before training starts, catches the mismatch at
+data-prep time instead of after a wasted training
+run.
+
+## Pre-Training Validation Checklist
+
+Run this checklist against one collated batch
+before launching a full training run. All three
+checks are cheap (seconds, one batch) relative to
+the cost of discovering a silent failure after
+hours of training:
+
+1. **Decode one collated batch back to text.**
+   Pull a batch from the dataloader, decode the
+   `input_ids` with the tokenizer, and read it.
+   Confirm the image placeholder tokens appear
+   where expected and the surrounding text matches
+   the source example — this catches template or
+   collator bugs that reshuffle content.
+2. **Count image tokens per example.** Compare the
+   number of vision tokens the processor actually
+   inserted against the expected count for that
+   image's resolution under the configured
+   `min_pixels`/`max_pixels` budget (the second
+   silent killer from `SKILL.md`). A count that
+   doesn't match the expected budget means the
+   resolution budget isn't being applied the way
+   it's configured.
+3. **Verify the loss mask covers assistant turns
+   only.** Inspect the labels tensor (or
+   `token_type_ids` for Gemma-3-family collators)
+   and confirm masked (`-100`) positions cover the
+   system/user turns and image tokens, with only
+   assistant-turn text contributing to the loss. A
+   loss mask that leaks onto image tokens or user
+   turns trains the model to predict input it
+   should only be conditioning on.
+
+If any of the three checks fails, fix the
+collator or dataset before starting the full run —
+none of these are the kind of thing a training
+curve reveals on its own.
+
+## Advanced Pattern: Two-Stage Projector-Alignment Recipe
+
+The consensus recipe in `SKILL.md` freezes the
+projector. When adapting to a base model or
+dataset far enough from the projector's original
+alignment that the frozen-projector recipe
+underperforms, a two-stage LLaVA-style alignment
+recipe is the advanced fallback:
+
+1. **Stage 1 — projector-only alignment.** Freeze
+   both the vision tower and the LLM. Train only
+   the projector (no LoRA involved yet) on a
+   broad, simple image-caption-style dataset. The
+   goal is purely to re-align the projector's
+   output space with the current LLM's embedding
+   space — this stage does not teach the target
+   task.
+2. **Stage 2 — task LoRA on top.** With the
+   realigned projector now frozen again, apply the
+   standard consensus recipe from `SKILL.md`
+   (LoRA on the LLM only, all-linear, r=8–16,
+   α=16–32) using the actual task dataset.
+
+This two-stage recipe is an escalation path, not a
+default — reach for it only when the single-stage
+frozen-projector recipe measurably underperforms,
+since it roughly doubles the number of training
+runs required. Most VLM SFT tasks in this plugin's
+scope stay on the single-stage consensus recipe.


### PR DESCRIPTION
## Summary

Two new local plugins (94 plugins total, +4 agents, +13 skills, +3 commands):

**`llm-finetuning`** — eval-gated fine-tuning lifecycle. The thesis: evals and fine-tuning belong together — no eval harness, no fine-tune.
- **Skills (10):** finetuning-method-selection (decision tree + the dated model catalog — the only file naming base models), lora-qlora-recipes, preference-optimization, grpo-rlvr-training, vision-sft, dataset-curation, eval-harness-first (the Phase 0 gate), trace-to-training-data (eval traces → SFT/DPO data), checkpoint-promotion (drift budgets, paired arena, PROMOTE/REJECT), quantized-export
- **Agents (3):** `llm-finetuning-architect` (opus — owns the eval gate and method selection), `llm-finetuning-training-engineer` (sonnet — data/config/train/export), `llm-finetuning-eval-engineer` (sonnet — deliberately independent gatekeeper: the gate isn't graded by the party that trained the model)
- **Commands (2):** `/finetune` (7-phase artifact-gated lifecycle: eval gate → brief → data → preflight → train → checkpoint gate → export, each phase blocked on the prior phase's on-disk artifact), `/promote-checkpoint` (standalone re-gate with goldens fingerprinting)

**`dgx-spark-ops`** — DGX Spark (GB10/aarch64/CUDA 13) operations, reusable beyond fine-tuning.
- **Skills (3):** spark-environment-setup (container-first workflow, ABI rules, stack matrix), spark-training-gotchas (ten known failure modes G1–G10 with runnable checks + preflight script), spark-memory-thermal-ops (UMA accounting, OOM ladder, thermal monitoring)
- **Agent + command:** `dgx-spark-ops-engineer`, `/spark-preflight` → `env-report.json`

Coupling is one-directional: `/finetune` Phase 3 uses `/spark-preflight` when installed, degrades to generic NVIDIA checks otherwise.

Content grounded in a 414-source research pass (mid-2026 framework landscape, technique state of practice, DGX Spark hardware realities, eval↔fine-tuning coupling literature). Version-sensitive facts carry `Last verified:` headers; base-model recommendations are isolated to one dated catalog file as a currency-rot defense.

## Quality evidence

- `make validate STRICT=1` — clean across 5 harnesses
- `make garden` — zero new warnings (10 pre-existing on main, untouched)
- `make test` — 483 passed, 1 skipped
- plugin-eval: **13/13 skills Gold** (80.3–86.6), zero anti-patterns
- Built via per-task implementer+reviewer subagent loop; final whole-branch review verified cross-file schema coherence (artifact names/schemas byte-identical between producers and consumers) with a post-review fix wave applied
- Docs/counts updated across all 7 reference files; per-harness artifacts regenerated

## Test plan

- [x] All repo gates green (above)
- [x] Dogfood ship gate: end-to-end `/finetune` run on DGX Spark (3–8B model, real Phase 0 harness, PROMOTE/REJECT verdict, GGUF export + smoke test) — planned as immediate follow-up; friction-log fixes will land as follow-up commits or a fast-follow PR

https://claude.ai/code/session_01RsN3Vz5fZRTdVMkNtmxhSf
