### PR TITLE
fix(codex): fall back to plugin name when description is empty (#617)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -3,6 +3,7 @@
   "plugins": [
     {
       "name": "accessibility-compliance",
+      "description": "WCAG accessibility auditing, compliance validation, UI testing for screen readers, keyboard navigation, and inclusive design",
       "source": {
         "source": "local",
         "path": "./plugins/accessibility-compliance"
@@ -15,6 +16,7 @@
     },
     {
       "name": "agent-orchestration",
+      "description": "Multi-agent system optimization, agent improvement workflows, and context management",
       "source": {
         "source": "local",
         "path": "./plugins/agent-orchestration"
@@ -27,6 +29,7 @@
     },
     {
       "name": "agent-teams",
+      "description": "Orchestrate multi-agent teams for parallel code review, hypothesis-driven debugging, and coordinated feature development using Claude Code's Agent Teams",
       "source": {
         "source": "local",
         "path": "./plugins/agent-teams"
@@ -39,6 +42,7 @@
     },
     {
       "name": "api-scaffolding",
+      "description": "REST and GraphQL API scaffolding, framework selection, backend architecture, and API generation",
       "source": {
         "source": "local",
         "path": "./plugins/api-scaffolding"
@@ -51,6 +55,7 @@
     },
     {
       "name": "api-testing-observability",
+      "description": "API testing automation, request mocking, OpenAPI documentation generation, observability setup, and monitoring",
       "source": {
         "source": "local",
         "path": "./plugins/api-testing-observability"
@@ -63,6 +68,7 @@
     },
     {
       "name": "application-performance",
+      "description": "Application profiling, performance optimization, and observability for frontend and backend systems",
       "source": {
         "source": "local",
         "path": "./plugins/application-performance"
@@ -75,6 +81,7 @@
     },
     {
       "name": "arm-cortex-microcontrollers",
+      "description": "ARM Cortex-M firmware development for Teensy, STM32, nRF52, and SAMD with peripheral drivers and memory safety patterns",
       "source": {
         "source": "local",
         "path": "./plugins/arm-cortex-microcontrollers"
@@ -87,6 +94,7 @@
     },
     {
       "name": "backend-api-security",
+      "description": "API security hardening, authentication implementation, authorization patterns, rate limiting, and input validation",
       "source": {
         "source": "local",
         "path": "./plugins/backend-api-security"
@@ -99,6 +107,7 @@
     },
     {
       "name": "backend-development",
+      "description": "Backend API design, GraphQL architecture, workflow orchestration with Temporal, and test-driven backend development",
       "source": {
         "source": "local",
         "path": "./plugins/backend-development"
@@ -111,6 +120,7 @@
     },
     {
       "name": "before-you-build",
+      "description": "Pre-build product risk review for founders, product teams, and AI-assisted builders before implementation starts.",
       "source": {
         "source": "local",
         "path": "./plugins/before-you-build"
@@ -123,6 +133,7 @@
     },
     {
       "name": "block-no-verify",
+      "description": "PreToolUse hook that prevents AI agents from using --no-verify, --no-gpg-sign, and other bypass flags that skip git hooks",
       "source": {
         "source": "local",
         "path": "./plugins/block-no-verify"
@@ -135,6 +146,7 @@
     },
     {
       "name": "blockchain-web3",
+      "description": "Smart contract development with Solidity, DeFi protocol implementation, NFT platforms, and Web3 application architecture",
       "source": {
         "source": "local",
         "path": "./plugins/blockchain-web3"
@@ -147,6 +159,7 @@
     },
     {
       "name": "brand-landingpage",
+      "description": "Guides developers from brand discovery through iterative design to deployment-ready HTML via Stitch.",
       "source": {
         "source": "local",
         "path": "./plugins/brand-landingpage"
@@ -159,6 +172,7 @@
     },
     {
       "name": "business-analytics",
+      "description": "Business metrics analysis, KPI tracking, financial reporting, and data-driven decision making",
       "source": {
         "source": "local",
         "path": "./plugins/business-analytics"
@@ -171,6 +185,7 @@
     },
     {
       "name": "c4-architecture",
+      "description": "Comprehensive C4 architecture documentation workflow with bottom-up code analysis, component synthesis, container mapping, and context diagram generation",
       "source": {
         "source": "local",
         "path": "./plugins/c4-architecture"
@@ -183,6 +198,7 @@
     },
     {
       "name": "cicd-automation",
+      "description": "CI/CD pipeline configuration, GitHub Actions/GitLab CI workflow setup, and automated deployment pipeline orchestration",
       "source": {
         "source": "local",
         "path": "./plugins/cicd-automation"
@@ -195,6 +211,7 @@
     },
     {
       "name": "cloud-infrastructure",
+      "description": "Cloud architecture design for AWS/Azure/GCP/OCI, Kubernetes cluster configuration, Terraform infrastructure-as-code, hybrid cloud networking, and multi-cloud cost optimization",
       "source": {
         "source": "local",
         "path": "./plugins/cloud-infrastructure"
@@ -207,6 +224,7 @@
     },
     {
       "name": "code-documentation",
+      "description": "Documentation generation, code explanation, and technical writing with automated doc generation and tutorial creation",
       "source": {
         "source": "local",
         "path": "./plugins/code-documentation"
@@ -219,6 +237,7 @@
     },
     {
       "name": "code-refactoring",
+      "description": "Code cleanup, refactoring automation, and technical debt management with context restoration",
       "source": {
         "source": "local",
         "path": "./plugins/code-refactoring"
@@ -231,6 +250,7 @@
     },
     {
       "name": "codebase-cleanup",
+      "description": "Technical debt reduction, dependency updates, and code refactoring automation",
       "source": {
         "source": "local",
         "path": "./plugins/codebase-cleanup"
@@ -243,6 +263,7 @@
     },
     {
       "name": "comprehensive-review",
+      "description": "Multi-perspective code analysis covering architecture, security, and best practices",
       "source": {
         "source": "local",
         "path": "./plugins/comprehensive-review"
@@ -255,6 +276,7 @@
     },
     {
       "name": "conductor",
+      "description": "Context-Driven Development plugin that transforms Claude Code into a project management tool with structured workflow: Context \u2192 Spec & Plan \u2192 Implement",
       "source": {
         "source": "local",
         "path": "./plugins/conductor"
@@ -267,6 +289,7 @@
     },
     {
       "name": "content-marketing",
+      "description": "Content marketing strategy, web research, and information synthesis for marketing operations",
       "source": {
         "source": "local",
         "path": "./plugins/content-marketing"
@@ -279,6 +302,7 @@
     },
     {
       "name": "context-management",
+      "description": "Context persistence, restoration, and long-running conversation management",
       "source": {
         "source": "local",
         "path": "./plugins/context-management"
@@ -291,6 +315,7 @@
     },
     {
       "name": "customer-sales-automation",
+      "description": "Customer support workflow automation, sales pipeline management, email campaigns, and CRM integration",
       "source": {
         "source": "local",
         "path": "./plugins/customer-sales-automation"
@@ -303,6 +328,7 @@
     },
     {
       "name": "data-engineering",
+      "description": "ETL pipeline construction, data warehouse design, batch processing workflows, and data-driven feature development",
       "source": {
         "source": "local",
         "path": "./plugins/data-engineering"
@@ -315,6 +341,7 @@
     },
     {
       "name": "data-validation-suite",
+      "description": "Schema validation, data quality monitoring, streaming validation pipelines, and input validation for backend APIs",
       "source": {
         "source": "local",
         "path": "./plugins/data-validation-suite"
@@ -327,6 +354,7 @@
     },
     {
       "name": "database-cloud-optimization",
+      "description": "Database query optimization, cloud cost optimization, and scalability improvements",
       "source": {
         "source": "local",
         "path": "./plugins/database-cloud-optimization"
@@ -339,6 +367,7 @@
     },
     {
       "name": "database-design",
+      "description": "Database architecture, schema design, and SQL optimization for production systems",
       "source": {
         "source": "local",
         "path": "./plugins/database-design"
@@ -351,6 +380,7 @@
     },
     {
       "name": "database-migrations",
+      "description": "Database migration automation, observability, and cross-database migration strategies",
       "source": {
         "source": "local",
         "path": "./plugins/database-migrations"
@@ -363,6 +393,7 @@
     },
     {
       "name": "debugging-toolkit",
+      "description": "Interactive debugging, developer experience optimization, and smart debugging workflows",
       "source": {
         "source": "local",
         "path": "./plugins/debugging-toolkit"
@@ -375,6 +406,7 @@
     },
     {
       "name": "dependency-management",
+      "description": "Dependency auditing, version management, and security vulnerability scanning",
       "source": {
         "source": "local",
         "path": "./plugins/dependency-management"
@@ -387,6 +419,7 @@
     },
     {
       "name": "deployment-strategies",
+      "description": "Deployment patterns, rollback automation, and infrastructure templates",
       "source": {
         "source": "local",
         "path": "./plugins/deployment-strategies"
@@ -399,6 +432,7 @@
     },
     {
       "name": "deployment-validation",
+      "description": "Pre-deployment checks, configuration validation, and deployment readiness assessment",
       "source": {
         "source": "local",
         "path": "./plugins/deployment-validation"
@@ -411,6 +445,7 @@
     },
     {
       "name": "developer-essentials",
+      "description": "Essential developer skills including Git workflows, SQL optimization, error handling, code review, E2E testing, authentication, debugging, and monorepo management",
       "source": {
         "source": "local",
         "path": "./plugins/developer-essentials"
@@ -423,6 +458,7 @@
     },
     {
       "name": "dgx-spark-ops",
+      "description": "NVIDIA DGX Spark (GB10 Grace Blackwell) environment operations: aarch64/CUDA-13 stack setup, training gotcha preflights, and unified-memory/thermal management for local ML workloads",
       "source": {
         "source": "local",
         "path": "./plugins/dgx-spark-ops"
@@ -435,6 +471,7 @@
     },
     {
       "name": "distributed-debugging",
+      "description": "Distributed system tracing and debugging across microservices",
       "source": {
         "source": "local",
         "path": "./plugins/distributed-debugging"
@@ -447,6 +484,7 @@
     },
     {
       "name": "documentation-generation",
+      "description": "OpenAPI specification generation, Mermaid diagram creation, tutorial writing, API reference documentation",
       "source": {
         "source": "local",
         "path": "./plugins/documentation-generation"
@@ -459,6 +497,7 @@
     },
     {
       "name": "documentation-standards",
+      "description": "HADS (Human-AI Document Standard) \u2014 semantic tagging convention for writing documentation that works efficiently for both human readers and AI models. Reduces token consumption and hallucination risk by separating machine-critical facts from human context.",
       "source": {
         "source": "local",
         "path": "./plugins/documentation-standards"
@@ -471,6 +510,7 @@
     },
     {
       "name": "dotnet-contribution",
+      "description": "Comprehensive .NET backend development with C#, ASP.NET Core, Entity Framework Core, and Dapper for production-grade applications",
       "source": {
         "source": "local",
         "path": "./plugins/dotnet-contribution"
@@ -483,6 +523,7 @@
     },
     {
       "name": "error-debugging",
+      "description": "Error analysis, trace debugging, and multi-agent problem diagnosis",
       "source": {
         "source": "local",
         "path": "./plugins/error-debugging"
@@ -495,6 +536,7 @@
     },
     {
       "name": "error-diagnostics",
+      "description": "Error tracing, root cause analysis, and smart debugging for production systems",
       "source": {
         "source": "local",
         "path": "./plugins/error-diagnostics"
@@ -507,6 +549,7 @@
     },
     {
       "name": "file-conversion",
+      "description": "Convert files between 999 routes \u2014 PDF to Word, HEIC to JPG, MP4 to MP3, CSV to JSON, EPUB to MOBI \u2014 via the free ChangeThisFile API. MCP-aware with a zero-dependency script fallback; no API key required.",
       "source": {
         "source": "local",
         "path": "./plugins/file-conversion"
@@ -519,6 +562,7 @@
     },
     {
       "name": "framework-migration",
+      "description": "Framework updates, migration planning, and architectural transformation workflows",
       "source": {
         "source": "local",
         "path": "./plugins/framework-migration"
@@ -531,6 +575,7 @@
     },
     {
       "name": "frontend-mobile-development",
+      "description": "Frontend UI development and mobile application implementation across platforms",
       "source": {
         "source": "local",
         "path": "./plugins/frontend-mobile-development"
@@ -543,6 +588,7 @@
     },
     {
       "name": "frontend-mobile-security",
+      "description": "XSS prevention, CSRF protection, content security policies, mobile app security, and secure storage patterns",
       "source": {
         "source": "local",
         "path": "./plugins/frontend-mobile-security"
@@ -555,6 +601,7 @@
     },
     {
       "name": "full-stack-orchestration",
+      "description": "End-to-end feature orchestration with testing, security, performance, and deployment",
       "source": {
         "source": "local",
         "path": "./plugins/full-stack-orchestration"
@@ -567,6 +614,7 @@
     },
     {
       "name": "functional-programming",
+      "description": "Functional programming with Elixir, OTP patterns, Phoenix framework, and distributed systems",
       "source": {
         "source": "local",
         "path": "./plugins/functional-programming"
@@ -579,6 +627,7 @@
     },
     {
       "name": "game-development",
+      "description": "Unity game development with C# scripting, Minecraft server plugin development with Bukkit/Spigot APIs",
       "source": {
         "source": "local",
         "path": "./plugins/game-development"
@@ -591,6 +640,7 @@
     },
     {
       "name": "git-pr-workflows",
+      "description": "Git workflow automation, pull request enhancement, and team onboarding processes",
       "source": {
         "source": "local",
         "path": "./plugins/git-pr-workflows"
@@ -603,6 +653,7 @@
     },
     {
       "name": "hermes-tweet",
+      "description": "Hermes Agent plugin for X/Twitter research, timeline reading, tweet analysis, and approval-gated tweet actions through Hermes Tweet",
       "source": {
         "source": "local",
         "path": "./plugins/hermes-tweet"
@@ -615,6 +666,7 @@
     },
     {
       "name": "hr-legal-compliance",
+      "description": "HR policy documentation, legal compliance templates (GDPR/SOC2/HIPAA), employment contracts, and regulatory documentation",
       "source": {
         "source": "local",
         "path": "./plugins/hr-legal-compliance"
@@ -627,6 +679,7 @@
     },
     {
       "name": "incident-response",
+      "description": "Production incident management, triage workflows, and automated incident resolution",
       "source": {
         "source": "local",
         "path": "./plugins/incident-response"
@@ -639,6 +692,7 @@
     },
     {
       "name": "javascript-typescript",
+      "description": "JavaScript and TypeScript development with ES6+, Node.js, React, and modern web frameworks",
       "source": {
         "source": "local",
         "path": "./plugins/javascript-typescript"
@@ -651,6 +705,7 @@
     },
     {
       "name": "julia-development",
+      "description": "Modern Julia development with Julia 1.10+, package management, scientific computing, high-performance numerical code, and production best practices",
       "source": {
         "source": "local",
         "path": "./plugins/julia-development"
@@ -663,6 +718,7 @@
     },
     {
       "name": "jvm-languages",
+      "description": "JVM language development including Java, Scala, and C# with enterprise patterns and frameworks",
       "source": {
         "source": "local",
         "path": "./plugins/jvm-languages"
@@ -675,6 +731,7 @@
     },
     {
       "name": "kubernetes-operations",
+      "description": "Kubernetes manifest generation, networking configuration, security policies, observability setup, GitOps workflows, and auto-scaling",
       "source": {
         "source": "local",
         "path": "./plugins/kubernetes-operations"
@@ -687,6 +744,7 @@
     },
     {
       "name": "llm-application-dev",
+      "description": "LLM application development with LangGraph, RAG systems, vector search, and AI agent architectures for Claude 4.6 and GPT-5.4",
       "source": {
         "source": "local",
         "path": "./plugins/llm-application-dev"
@@ -699,6 +757,7 @@
     },
     {
       "name": "llm-finetuning",
+      "description": "Eval-gated LLM fine-tuning lifecycle: LoRA/QLoRA SFT, preference optimization (DPO/ORPO/KTO), GRPO/RLVR, vision SFT, and quantized export \u2014 Unsloth-first with TRL fallback, no eval harness means no fine-tune",
       "source": {
         "source": "local",
         "path": "./plugins/llm-finetuning"
@@ -711,6 +770,7 @@
     },
     {
       "name": "machine-learning-ops",
+      "description": "ML model training pipelines, hyperparameter tuning, model deployment automation, experiment tracking, and MLOps workflows",
       "source": {
         "source": "local",
         "path": "./plugins/machine-learning-ops"
@@ -723,6 +783,7 @@
     },
     {
       "name": "meigen-ai-design",
+      "description": "AI image generation with creative workflow orchestration, parallel multi-direction output, prompt engineering, and a 1,300+ curated inspiration library. Requires MeiGen MCP server (supports MeiGen Cloud, local ComfyUI, and OpenAI-compatible APIs).",
       "source": {
         "source": "local",
         "path": "./plugins/meigen-ai-design"
@@ -735,6 +796,7 @@
     },
     {
       "name": "multi-platform-apps",
+      "description": "Cross-platform application development coordinating web, iOS, Android, and desktop implementations",
       "source": {
         "source": "local",
         "path": "./plugins/multi-platform-apps"
@@ -747,6 +809,7 @@
     },
     {
       "name": "observability-monitoring",
+      "description": "Metrics collection, logging infrastructure, distributed tracing, SLO implementation, and monitoring dashboards",
       "source": {
         "source": "local",
         "path": "./plugins/observability-monitoring"
@@ -759,6 +822,7 @@
     },
     {
       "name": "operating-kit",
+      "description": "Portable operating method: session lifecycle agents (session-start/end), pre-ship code review, deploy with live verification, and production log health check. All agents use {{placeholders}} that adapt to your project.",
       "source": {
         "source": "local",
         "path": "./plugins/operating-kit"
@@ -771,6 +835,7 @@
     },
     {
       "name": "payment-processing",
+      "description": "Payment gateway integration with Stripe, PayPal, checkout flow implementation, subscription billing, and PCI compliance",
       "source": {
         "source": "local",
         "path": "./plugins/payment-processing"
@@ -783,6 +848,7 @@
     },
     {
       "name": "performance-testing-review",
+      "description": "Performance analysis, test coverage review, and AI-powered code quality assessment",
       "source": {
         "source": "local",
         "path": "./plugins/performance-testing-review"
@@ -795,6 +861,7 @@
     },
     {
       "name": "plugin-eval",
+      "description": "plugin-eval",
       "source": {
         "source": "local",
         "path": "./plugins/plugin-eval"
@@ -807,6 +874,7 @@
     },
     {
       "name": "protect-mcp",
+      "description": "Cedar policy enforcement + Ed25519 signed receipts for every Claude Code tool call. First cryptographic governance plugin \u2014 receipts independently verifiable offline.",
       "source": {
         "source": "local",
         "path": "./plugins/protect-mcp"
@@ -819,6 +887,7 @@
     },
     {
       "name": "python-development",
+      "description": "Modern Python development with Python 3.12+, Django, FastAPI, async patterns, and production best practices",
       "source": {
         "source": "local",
         "path": "./plugins/python-development"
@@ -831,6 +900,7 @@
     },
     {
       "name": "quantitative-trading",
+      "description": "Quantitative analysis, algorithmic trading strategies, financial modeling, portfolio risk management, and backtesting",
       "source": {
         "source": "local",
         "path": "./plugins/quantitative-trading"
@@ -843,6 +913,7 @@
     },
     {
       "name": "reverse-engineering",
+      "description": "Binary reverse engineering, malware analysis, firmware security, and software protection research for authorized security research, CTF competitions, and defensive security",
       "source": {
         "source": "local",
         "path": "./plugins/reverse-engineering"
@@ -855,6 +926,7 @@
     },
     {
       "name": "review-agent-governance",
+      "description": "Require a human approval signal before an AI agent can post PR reviews, comments, merges, or writes to CI config. Cedar-gated, receipt-signed, designed for the Hermes-style failure mode where a review bot posts without oversight.",
       "source": {
         "source": "local",
         "path": "./plugins/review-agent-governance"
@@ -867,6 +939,7 @@
     },
     {
       "name": "runapi-mcp",
+      "description": "RunAPI MCP server for browsing models, checking pricing, and creating image, video, music, audio, and LLM tasks.",
       "source": {
         "source": "local",
         "path": "./plugins/runapi-mcp"
@@ -879,6 +952,7 @@
     },
     {
       "name": "security-compliance",
+      "description": "SOC2, HIPAA, and GDPR compliance validation, secrets scanning, compliance checklists, and regulatory documentation",
       "source": {
         "source": "local",
         "path": "./plugins/security-compliance"
@@ -891,6 +965,7 @@
     },
     {
       "name": "security-scanning",
+      "description": "SAST analysis, dependency vulnerability scanning, OWASP Top 10 compliance, container security scanning, and automated security hardening",
       "source": {
         "source": "local",
         "path": "./plugins/security-scanning"
@@ -903,6 +978,7 @@
     },
     {
       "name": "seo-analysis-monitoring",
+      "description": "Content freshness analysis, cannibalization detection, and authority building for SEO",
       "source": {
         "source": "local",
         "path": "./plugins/seo-analysis-monitoring"
@@ -915,6 +991,7 @@
     },
     {
       "name": "seo-content-creation",
+      "description": "SEO content writing, planning, and quality auditing with E-E-A-T optimization",
       "source": {
         "source": "local",
         "path": "./plugins/seo-content-creation"
@@ -927,6 +1004,7 @@
     },
     {
       "name": "seo-technical-optimization",
+      "description": "Technical SEO optimization including meta tags, keywords, structure, and featured snippets",
       "source": {
         "source": "local",
         "path": "./plugins/seo-technical-optimization"
@@ -939,6 +1017,7 @@
     },
     {
       "name": "shell-scripting",
+      "description": "Production-grade Bash scripting with defensive programming, POSIX compliance, and comprehensive testing",
       "source": {
         "source": "local",
         "path": "./plugins/shell-scripting"
@@ -951,6 +1030,7 @@
     },
     {
       "name": "ship-mate",
+      "description": "Your AI development teammate. Turns a story file into a shipped, reviewed, and tested feature via orchestrator \u2192 architect \u2192 developer \u2192 PR reviewer \u2192 QA \u2192 Playwright.",
       "source": {
         "source": "local",
         "path": "./plugins/ship-mate"
@@ -963,6 +1043,7 @@
     },
     {
       "name": "signed-audit-trails",
+      "description": "Teaching skill: signed audit trails for Claude Code tool calls. Cookbook-style walkthrough of Cedar-gated tool calls with Ed25519 receipts, offline verification, and CI/CD integration. Pairs with the protect-mcp plugin.",
       "source": {
         "source": "local",
         "path": "./plugins/signed-audit-trails"
@@ -975,6 +1056,7 @@
     },
     {
       "name": "skill-forge-essentials",
+      "description": "Three behavioral skills addressing AI-specific failure patterns: hidden code debt from agent generation, context compaction amnesia, and imprecise Design Mode edits",
       "source": {
         "source": "local",
         "path": "./plugins/skill-forge-essentials"
@@ -987,6 +1069,7 @@
     },
     {
       "name": "social-publishing",
+      "description": "Schedule and publish social media posts across 13 platforms (X, LinkedIn Profile + Page, Instagram Business + Standalone, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, Pinterest) via SocialClaw \u2014 one workspace API key covers everything",
       "source": {
         "source": "local",
         "path": "./plugins/social-publishing"
@@ -999,6 +1082,7 @@
     },
     {
       "name": "startup-business-analyst",
+      "description": "Comprehensive startup business analysis with market sizing (TAM/SAM/SOM), financial modeling, team planning, and strategic research",
       "source": {
         "source": "local",
         "path": "./plugins/startup-business-analyst"
@@ -1011,6 +1095,7 @@
     },
     {
       "name": "systems-programming",
+      "description": "Systems programming with Rust, Go, C, and C++ for performance-critical and low-level development",
       "source": {
         "source": "local",
         "path": "./plugins/systems-programming"
@@ -1023,6 +1108,7 @@
     },
     {
       "name": "tdd-workflows",
+      "description": "Test-driven development methodology with red-green-refactor cycles and code review",
       "source": {
         "source": "local",
         "path": "./plugins/tdd-workflows"
@@ -1035,6 +1121,7 @@
     },
     {
       "name": "team-collaboration",
+      "description": "Team workflows, issue management, standup automation, and developer experience optimization",
       "source": {
         "source": "local",
         "path": "./plugins/team-collaboration"
@@ -1047,6 +1134,7 @@
     },
     {
       "name": "ui-design",
+      "description": "Comprehensive UI/UX design plugin for mobile (iOS, Android, React Native) and web applications with design systems, accessibility, and modern patterns",
       "source": {
         "source": "local",
         "path": "./plugins/ui-design"
@@ -1059,6 +1147,7 @@
     },
     {
       "name": "unit-testing",
+      "description": "Unit and integration test automation for Python and JavaScript with debugging support",
       "source": {
         "source": "local",
         "path": "./plugins/unit-testing"
@@ -1071,6 +1160,7 @@
     },
     {
       "name": "web-scripting",
+      "description": "Web scripting with PHP and Ruby for web applications, CMS development, and backend services",
       "source": {
         "source": "local",
         "path": "./plugins/web-scripting"

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -861,7 +861,7 @@
     },
     {
       "name": "plugin-eval",
-      "description": "plugin-eval",
+      "description": "Three-layer quality evaluation framework for Claude Code plugins with Elo ranking",
       "source": {
         "source": "local",
         "path": "./plugins/plugin-eval"
@@ -874,6 +874,7 @@
     },
     {
       "name": "pptx-deck-creation",
+      "description": "Create production-ready, editable PowerPoint decks through a spec-first, coordinate-explicit workflow with read-only reference analysis and quality gates.",
       "source": {
         "source": "local",
         "path": "./plugins/pptx-deck-creation"

--- a/plugins/plugin-eval/.codex-plugin/plugin.json
+++ b/plugins/plugin-eval/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-eval",
   "version": "0.1.1",
-  "description": "",
+  "description": "plugin-eval",
   "skills": "./skills/",
   "interface": {
     "displayName": "Plugin Eval",

--- a/tools/adapters/codex.py
+++ b/tools/adapters/codex.py
@@ -588,12 +588,21 @@ class CodexAdapter(HarnessAdapter):
         )
 
     def _codex_plugin_manifest(self, plugin: PluginSource) -> dict:
-        """Per-plugin `.codex-plugin/plugin.json` (mirrors the superpowers shape)."""
+        """Per-plugin `.codex-plugin/plugin.json` (mirrors the superpowers shape).
+
+        `description` falls back to `plugin.name` when the plugin's own
+        `.claude-plugin/plugin.json` omits it (e.g. `plugin-eval`): the
+        `codex-marketplace` installer's zod schema requires this field to be
+        non-empty (`description: z.string().min(1)` in `pluginManifestSchema`),
+        and this manifest — not the top-level `.agents/plugins/marketplace.json`
+        entry — is what that schema actually validates.
+        """
         pj = plugin.plugin_json or {}
+        desc = plugin.description or plugin.name
         manifest: dict = {
             "name": plugin.name,
             "version": plugin.version,
-            "description": plugin.description or "",
+            "description": desc,
             "skills": "./skills/",
         }
         if pj.get("author"):
@@ -601,7 +610,6 @@ class CodexAdapter(HarnessAdapter):
         for key in ("homepage", "repository", "license", "keywords"):
             if pj.get(key):
                 manifest[key] = pj[key]
-        desc = plugin.description or plugin.name
         if len(desc) > 120:
             # Cut on a word boundary so committed manifests never render mid-word.
             desc = desc[:117].rsplit(" ", 1)[0].rstrip(" ,.;:!?-") + "…"
@@ -618,8 +626,14 @@ class CodexAdapter(HarnessAdapter):
         Schema per openai/codex `core-plugins`: each entry needs `name`, a `source`
         (local variant `{"source": "local", "path": ...}`), a `policy`
         (`installation`/`authentication`), and `category`. Entries install the source
-        plugin dir directly; per-plugin display metadata comes from each plugin's own
-        `.codex-plugin/plugin.json`, so we don't repeat version/description here.
+        plugin dir directly; other per-plugin display metadata (including version and
+        description) comes from each plugin's own `.codex-plugin/plugin.json`, so we
+        don't repeat it here. We still include a top-level `description` per entry as
+        forward-compatible, non-authoritative metadata — `codex-marketplace`'s current
+        `marketplacePluginSchema` (npm `codex-marketplace@0.2.1`, `dist/schema.js`)
+        doesn't declare or require this field (unknown keys are silently stripped by
+        zod's default `.parse()`), so it is not what fixes the installer crash; see
+        `_codex_plugin_manifest()` for the field the installer actually validates.
         """
         root = self._read_marketplace_root()
         entries = []
@@ -628,6 +642,7 @@ class CodexAdapter(HarnessAdapter):
             entries.append(
                 {
                     "name": p.name,
+                    "description": p.description or p.name,
                     "source": {"source": "local", "path": f"./plugins/{p.name}"},
                     "policy": {"installation": "AVAILABLE", "authentication": "ON_USE"},
                     "category": pj.get("category") or "Coding",

--- a/tools/tests/test_adapters.py
+++ b/tools/tests/test_adapters.py
@@ -189,15 +189,25 @@ class TestCodexAdapter:
         empty_repo.mkdir()
         adapter = CodexAdapter(output_root=output_root, repo_root=empty_repo)
         adapter.emit_plugin(synthetic_plugin)
-        adapter.emit_global([synthetic_plugin])
+        no_desc_plugin = PluginSource(
+            name="no-desc",
+            dir=empty_repo / "no-desc",
+            plugin_json={"name": "no-desc", "version": "0.1.0"},
+        )
+        adapter.emit_global([synthetic_plugin, no_desc_plugin])
 
         marketplace_path = output_root / ".agents" / "plugins" / "marketplace.json"
         data = json.loads(marketplace_path.read_text(encoding="utf-8"))
-        assert data["plugins"], "expected at least one marketplace plugin entry"
+        assert len(data["plugins"]) == 2, "expected two marketplace plugin entries"
         for entry in data["plugins"]:
             assert "description" in entry, f"missing description key in entry: {entry}"
             assert isinstance(entry["description"], str)
             assert len(entry["description"]) > 0
+
+        no_desc_entry = next(p for p in data["plugins"] if p["name"] == "no-desc")
+        assert no_desc_entry["description"] == "no-desc", (
+            "expected description to fall back to plugin name"
+        )
 
     def test_plugin_manifest_description_falls_back_to_name(
         self, tmp_path: Path, output_root: Path

--- a/tools/tests/test_adapters.py
+++ b/tools/tests/test_adapters.py
@@ -169,6 +169,69 @@ class TestCodexAdapter:
         # Must warn about missing AGENTS.md
         assert any("AGENTS.md is missing" in w for w in result.warnings)
 
+    def test_marketplace_entries_have_description(
+        self, synthetic_plugin: PluginSource, output_root: Path, tmp_path: Path
+    ):
+        """Each `.agents/plugins/marketplace.json` entry carries a top-level
+        `description` as forward-compatible metadata, falling back to the plugin
+        name when the plugin's own manifest omits it.
+
+        NOTE: `codex-marketplace`'s installer (npm `codex-marketplace@0.2.1`,
+        `marketplacePluginSchema` in `dist/schema.js`) does not currently declare
+        or require this field — unknown keys are silently stripped by zod's
+        default `.parse()`. The field the installer actually validates is the
+        per-plugin `.codex-plugin/plugin.json` `description` — see
+        `test_plugin_manifest_description_falls_back_to_name` below.
+
+        Uses an empty `repo_root` so the real committed AGENTS.md isn't picked up.
+        """
+        empty_repo = tmp_path / "empty_repo"
+        empty_repo.mkdir()
+        adapter = CodexAdapter(output_root=output_root, repo_root=empty_repo)
+        adapter.emit_plugin(synthetic_plugin)
+        adapter.emit_global([synthetic_plugin])
+
+        marketplace_path = output_root / ".agents" / "plugins" / "marketplace.json"
+        data = json.loads(marketplace_path.read_text(encoding="utf-8"))
+        assert data["plugins"], "expected at least one marketplace plugin entry"
+        for entry in data["plugins"]:
+            assert "description" in entry, f"missing description key in entry: {entry}"
+            assert isinstance(entry["description"], str)
+            assert len(entry["description"]) > 0
+
+    def test_plugin_manifest_description_falls_back_to_name(
+        self, tmp_path: Path, output_root: Path
+    ):
+        """`codex-marketplace`'s installer parses each plugin's
+        `.codex-plugin/plugin.json` with `pluginManifestSchema`, which requires
+        `description: z.string().min(1)`. A plugin whose own manifest omits
+        `description` (e.g. `plugin-eval` upstream) must still get a non-empty
+        `description` in the generated Codex manifest, via the `plugin.name`
+        fallback — otherwise `npx codex-marketplace add <repo> --plugins` fails
+        with `String must contain at least 1 character(s)` at `path: ["description"]`
+        for that plugin (#617).
+        """
+        plugin_dir = tmp_path / "no-description-plugin"
+        plugin_dir.mkdir()
+        (plugin_dir / ".claude-plugin").mkdir()
+        (plugin_dir / ".claude-plugin" / "plugin.json").write_text(
+            '{"name": "no-description-plugin", "version": "0.1.0"}'
+        )
+        plugin = PluginSource(
+            name="no-description-plugin",
+            dir=plugin_dir,
+            plugin_json={"name": "no-description-plugin", "version": "0.1.0"},
+        )
+        assert plugin.description == ""  # sanity: this is the empty-description case
+
+        CodexAdapter(output_root=output_root).emit_plugin(plugin)
+
+        manifest_path = (
+            output_root / "plugins" / "no-description-plugin" / ".codex-plugin" / "plugin.json"
+        )
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        assert manifest["description"] == "no-description-plugin"
+
     def test_emit_global_validates_committed_agents_md(
         self, synthetic_plugin: PluginSource, output_root: Path, tmp_path: Path
     ):


### PR DESCRIPTION
## Summary

- `npx codex-marketplace add wshobson/agents --plugins` fails with
  `String must contain at least 1 character(s)` at `path: ["description"]`.
- Root cause: `codex-marketplace` (npm `codex-marketplace@0.2.1`) parses each
  plugin's `plugins/<name>/.codex-plugin/plugin.json` with a zod schema that
  requires `description: z.string().min(1)`. This repo's
  `_codex_plugin_manifest()` wrote `"description": plugin.description or ""`,
  and `plugin-eval`'s `.claude-plugin/plugin.json` has no `description` field,
  so its generated Codex manifest shipped an empty string. Because `--plugins`
  installs every marketplace plugin in one pass, that single bad manifest
  aborts the whole install.
- Fix: use the same `plugin.description or plugin.name` fallback already used
  for `interface.shortDescription` on the per-plugin manifest top-level
  `description`. Also add a top-level `description` to each
  `.agents/plugins/marketplace.json` entry as forward-compatible metadata
  (the installer's current `marketplacePluginSchema` does not require it;
  unknown keys are stripped by zod's default `.parse()` — the crash is fixed
  by the per-plugin manifest change).
- Regenerated Codex artifacts via `make generate HARNESS=codex`; only
  `plugins/plugin-eval/.codex-plugin/plugin.json` needed the description fix
  among existing plugins (plus descriptions for newly added marketplace
  entries). Regression test covers the `plugin.name` fallback.

Reported by @jkroepke in #617.

## Repro

```sh
mkdir /tmp/codex-repro && cd /tmp/codex-repro
npx -y codex-marketplace@0.2.1 add wshobson/agents --plugins --project -y
```

Against unpatched `main` (`codex-marketplace@0.2.1`):

```
◇  Inspection failed
■  [
│    {
│      "code": "too_small",
│      "minimum": 1,
│      "type": "string",
│      "inclusive": true,
│      "exact": false,
│      "message": "String must contain at least 1 character(s)",
│      "path": [
│        "description"
│      ]
│    }
│  ]
```

## Schema evidence

`codex-marketplace` on npm is Proprietary with no public `repository` field
(`npm view` / `npm pack codex-marketplace@0.2.1`). Relevant schemas from the
shipped tarball (`dist/schema.js`):

```js
// REGISTRY-level entry (.agents/plugins/marketplace.json)
// No description field; unknown keys silently stripped.
export const marketplacePluginSchema = z.object({
    name: z.string().min(1),
    source: z.object({
        source: z.literal("local"),
        path: z.string().min(1),
    }),
    policy: marketplacePolicySchema.optional(),
    category: z.string().min(1).optional(),
});

// PER-PLUGIN manifest (plugins/<name>/.codex-plugin/plugin.json)
// This is what requires a non-empty description.
export const pluginManifestSchema = z.object({
    name: z.string().min(1),
    version: z.string().min(1),
    description: z.string().min(1),
    ...
});
```

Call path in `dist/manifest.js`: marketplace config is validated with
`marketplacePluginSchema` (no description requirement), then each matched
source is loaded via `loadPluginManifest` → `pluginManifestSchema.parse(raw)`.

Verified against the installer's exported schemas: pre-fix,
`pluginManifestSchema.parse()` fails once for `plugin-eval` with the same
`too_small` error; post-fix, 0 of 90 plugin manifests fail.

`plugins/plugin-eval/.claude-plugin/plugin.json` is
`{"name": "plugin-eval", "version": "0.1.1"}` (no `description`), so
`PluginSource.description` defaulted to `""` and propagated into the generated
Codex manifest.

## Scope

- [x] Adapter framework (`tools/adapters/`)
- [ ] Plugin authoring (new or modified `plugins/<name>/...`)
- [ ] Quality tooling (validators, gardener, plugin-eval)
- [ ] Per-harness setup or docs (GEMINI.md / docs/harnesses.md)
- [ ] AGENTS.md / ARCHITECTURE.md / docs/
- [ ] CI / build / release
- [ ] Other

## Affected harnesses

- [ ] Claude Code
- [x] OpenAI Codex CLI
- [ ] Cursor
- [ ] OpenCode
- [ ] Gemini CLI
- [ ] Pure tooling / framework (no harness behavior change)

## Test plan

- [x] `make generate HARNESS=codex` — regenerated committed Codex artifacts.
- [x] `tools/tests/test_adapters.py` — 69 passed (includes
      `test_plugin_manifest_description_falls_back_to_name` and
      `test_marketplace_entries_have_description`).
- [x] Full `make test` — 447 passed, 6 skipped; 7 failed in OpenCode/Copilot
      round-trip count checks (stale `.opencode` / `.copilot` vs new plugins
      `llm-finetuning` / `dgx-spark-ops` on `main`; not introduced by this
      Codex-only change).
- [x] `ruff check tools/adapters/codex.py tools/tests/test_adapters.py` — clean.
- [x] Real installer repro against unpatched repo matches #617.
- [x] Installer schemas from npm tarball: 1 failure pre-fix (`plugin-eval`),
      0 post-fix.
- [ ] End-to-end `npx codex-marketplace add` against this branch not run
      (installer fetches from GitHub by repo spec); covered by running the
      installer's real schema code against generated output.

## Cross-harness portability notes

N/A — Codex-only adapter change; no plugin content, skill bodies, or
context-file line counts affected.

## Related issue(s)

Closes #617