### PR TITLE
fix(plugin-eval): add missing plugin description (#617)

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -744,7 +744,8 @@
     {
       "name": "plugin-eval",
       "source": "./plugins/plugin-eval",
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "description": "Three-layer quality evaluation framework for Claude Code plugins with Elo ranking"
     },
     {
       "name": "protect-mcp",

--- a/.cursor-plugin/plugins/plugin-eval.json
+++ b/.cursor-plugin/plugins/plugin-eval.json
@@ -1,5 +1,6 @@
 {
   "name": "plugin-eval",
   "displayName": "Plugin Eval",
-  "version": "0.1.1"
+  "version": "0.1.1",
+  "description": "Three-layer quality evaluation framework for Claude Code plugins with Elo ranking"
 }

--- a/plugins/plugin-eval/.claude-plugin/plugin.json
+++ b/plugins/plugin-eval/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
   "name": "plugin-eval",
-  "version": "0.1.1"
+  "version": "0.1.1",
+  "description": "Three-layer quality evaluation framework for Claude Code plugins with Elo ranking"
 }

--- a/plugins/plugin-eval/.codex-plugin/plugin.json
+++ b/plugins/plugin-eval/.codex-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "plugin-eval",
   "version": "0.1.1",
-  "description": "",
+  "description": "Three-layer quality evaluation framework for Claude Code plugins with Elo ranking",
   "skills": "./skills/",
   "interface": {
     "displayName": "Plugin Eval",
-    "shortDescription": "plugin-eval",
+    "shortDescription": "Three-layer quality evaluation framework for Claude Code plugins with Elo ranking",
     "category": "Coding"
   }
 }


### PR DESCRIPTION
## Summary

Fixes #617

Installing the marketplace through the Codex CLI (`npx codex-marketplace add wshobson/agents --plugins`) fails schema validation with:

```
"message": "String must contain at least 1 character(s)", "path": ["description"]
```

The root cause is data, not the installer: the `plugin-eval` source manifest (`plugins/plugin-eval/.claude-plugin/plugin.json`) has no `description`, so the generator emits `"description": ""` into the committed Codex manifest (`plugins/plugin-eval/.codex-plugin/plugin.json`) and falls back to the plugin name for `interface.shortDescription`. The Codex marketplace schema requires a non-empty description, so the whole install aborts.

## Fix

Add the description to the source `.claude-plugin/plugin.json` (reusing the text already used for this plugin in the root `marketplace.json`), then regenerate the per-harness artifacts with `make generate-all`. This populates the real description in the Codex manifest and the Cursor manifests, so the marketplace installs cleanly and every harness shows the correct description instead of the plugin name.

Changed files (source edit plus regenerated artifacts):
- `plugins/plugin-eval/.claude-plugin/plugin.json` (source)
- `plugins/plugin-eval/.codex-plugin/plugin.json` (generated)
- `.cursor-plugin/plugins/plugin-eval.json` (generated)
- `.cursor-plugin/marketplace.json` (generated)

## Relationship to #626

#626 makes the Codex installer fall back to the plugin name when a description is empty, which is good defensive hardening. This PR is complementary: it fixes the underlying data so `plugin-eval` carries a real description everywhere, rather than surfacing its name as the description. The two can land together.

## Verification

`tools/validate_generated.py --strict` passes for the affected harnesses (codex, cursor, copilot). The description is plain ASCII and the diff is scoped to `plugin-eval` (no drift in other plugins' artifacts).
