### PR TITLE
fix: repair broken python-project-setup link in python-design-patterns

### DIFF
--- a/plugins/python-development/skills/python-design-patterns/SKILL.md
+++ b/plugins/python-development/skills/python-design-patterns/SKILL.md
@@ -82,4 +82,4 @@ This is a layering violation. The service layer must not import from handlers. I
 ## Related Skills
 
 - [python-testing-patterns](../python-testing-patterns/SKILL.md) — Test each layer in isolation using the dependency injection structure established here
-- [python-project-setup](../python-project-setup/SKILL.md) — Set up project structure and tooling that enforces layer boundaries from the start
+- [python-project-structure](../python-project-structure/SKILL.md) — Organize modules and directory layout so layer boundaries are explicit from the start


### PR DESCRIPTION
Fixes #635.

`python-design-patterns/SKILL.md` linked to `../python-project-setup/SKILL.md`, which does not exist in the repo (and never has, per git history). The existing `python-project-structure` skill covers what the link intended — project organization, module architecture, and layout — so the reference now points there, with the description adjusted to match that skill's actual scope.

Verified: `make generate-all` (all 5 harnesses, 0 errors), `validate_generated.py --strict` (OK across 5 harnesses), and `doc_gardener.py --strict` (0 errors; remaining warnings are pre-existing in unrelated plugins).