### PR TITLE
fix: exit optimize() early when no variation improves the prompt

### DIFF
--- a/plugins/llm-application-dev/skills/prompt-engineering-patterns/scripts/optimize-prompt.py
+++ b/plugins/llm-application-dev/skills/prompt-engineering-patterns/scripts/optimize-prompt.py
@@ -152,6 +152,13 @@ class PromptOptimizer:
                     best_variation = variation
                     best_variation_metrics = var_metrics
 
+            # Variations are generated deterministically from the prompt, so a
+            # round with no improvement would repeat identical evaluations for
+            # every remaining iteration.
+            if best_variation == current_prompt:
+                print("No improving variation found. Stopping optimization.")
+                break
+
             current_prompt = best_variation
             current_metrics = best_variation_metrics
 


### PR DESCRIPTION
Fixes #634.

`PromptOptimizer.generate_variations()` is deterministic in the prompt, so once an iteration produces no improving variation, `current_prompt` is unchanged and every remaining iteration re-generates and re-evaluates the exact same variations — pure wasted API calls. The loop now breaks as soon as a round yields no improvement.

Measured with a stub client whose responses never improve (2 test cases, `max_iterations=5`): 32 LLM calls before, 8 after — the 24 removed calls are precisely the repeated evaluations of identical variations. The early-accuracy-target break and best-prompt tracking are unchanged.

`validate_generated.py --strict`: OK across 5 harnesses (no generated artifacts reference this script's body).