### PR TITLE
Add attester-verify plugin: existence-oracle checks before install

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -93,6 +93,19 @@
       "category": "Coding"
     },
     {
+      "name": "attester-verify",
+      "description": "Verify PyPI and npm package and symbol names against the attester.dev existence oracle before installing or importing, catching hallucinated dependencies",
+      "source": {
+        "source": "local",
+        "path": "./plugins/attester-verify"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_USE"
+      },
+      "category": "Coding"
+    },
+    {
       "name": "backend-api-security",
       "description": "API security hardening, authentication implementation, authorization patterns, rate limiting, and input validation",
       "source": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1313,6 +1313,27 @@
         "deck-generation",
         "slide-design"
       ]
+    },
+    {
+      "name": "attester-verify",
+      "source": "./plugins/attester-verify",
+      "description": "Verify PyPI and npm package and symbol names against the attester.dev existence oracle before installing or importing, catching hallucinated dependencies with a free keyless tier (25 checks/day per IP).",
+      "version": "1.0.0",
+      "author": {
+        "name": "attester.dev",
+        "url": "https://github.com/maminihds"
+      },
+      "homepage": "https://attester.dev",
+      "license": "MIT",
+      "category": "security",
+      "keywords": [
+        "package-verification",
+        "hallucination",
+        "supply-chain",
+        "pypi",
+        "npm",
+        "slopsquatting"
+      ]
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -88,6 +88,17 @@
       "license": "MIT"
     },
     {
+      "name": "attester-verify",
+      "source": "./plugins/attester-verify",
+      "version": "1.0.0",
+      "description": "Verify PyPI and npm package and symbol names against the attester.dev existence oracle before installing or importing, catching hallucinated dependencies",
+      "author": {
+        "name": "attester.dev",
+        "email": "hello@attester.dev"
+      },
+      "license": "MIT"
+    },
+    {
       "name": "backend-api-security",
       "source": "./plugins/backend-api-security",
       "version": "1.2.1",

--- a/.cursor-plugin/plugins/attester-verify.json
+++ b/.cursor-plugin/plugins/attester-verify.json
@@ -1,0 +1,11 @@
+{
+  "name": "attester-verify",
+  "displayName": "Attester Verify",
+  "version": "1.0.0",
+  "description": "Verify PyPI and npm package and symbol names against the attester.dev existence oracle before installing or importing, catching hallucinated dependencies",
+  "author": {
+    "name": "attester.dev",
+    "email": "hello@attester.dev"
+  },
+  "license": "MIT"
+}

--- a/plugins/attester-verify/.claude-plugin/plugin.json
+++ b/plugins/attester-verify/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "attester-verify",
+  "version": "1.0.0",
+  "description": "Verify PyPI and npm package and symbol names against the attester.dev existence oracle before installing or importing, catching hallucinated dependencies",
+  "author": {
+    "name": "attester.dev",
+    "email": "hello@attester.dev"
+  },
+  "license": "MIT"
+}

--- a/plugins/attester-verify/.codex-plugin/plugin.json
+++ b/plugins/attester-verify/.codex-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "attester-verify",
+  "version": "1.0.0",
+  "description": "Verify PyPI and npm package and symbol names against the attester.dev existence oracle before installing or importing, catching hallucinated dependencies",
+  "skills": "./skills/",
+  "author": {
+    "name": "attester.dev",
+    "email": "hello@attester.dev"
+  },
+  "license": "MIT",
+  "interface": {
+    "displayName": "Attester Verify",
+    "shortDescription": "Verify PyPI and npm package and symbol names against the attester.dev existence oracle before installing or\u2026",
+    "category": "Coding"
+  }
+}

--- a/plugins/attester-verify/README.md
+++ b/plugins/attester-verify/README.md
@@ -1,0 +1,41 @@
+# attester-verify
+
+Verify before install: check PyPI and npm package and symbol names against
+the attester.dev existence oracle so hallucinated dependencies never reach
+code. One Markdown skill, shipped to all six harnesses.
+
+## Disclosure
+
+This plugin wraps the attester.dev API, which the plugin author
+(github.com/maminihds) builds and operates. The free keyless tier (25
+calls per day per client IP, no account or API key) is the default path
+and covers normal use. A paid tier for higher volume exists and is never
+required; the plugin never sends you there.
+
+## What you get
+
+The `attester-verify` skill teaches the agent to:
+
+- POST `https://attester.dev/demo/v1/package/exists` before installing or
+  importing any package, and proceed only when `exists` is true.
+- POST `https://attester.dev/demo/v1/symbol/exists` before calling a
+  function, class, or constant it cannot confirm exists.
+- Pin a remote MCP server's tool manifest with
+  `https://attester.dev/v2/mcp/pin` and check it for drift later.
+- Treat quota exhaustion (25/day per IP) and network failure as "check
+  skipped, continue conservatively", never as a blocker.
+
+Why it matters: models invent plausible package names. A USENIX Security
+2025 study measured 5.2% to 21.7% of suggested package names as
+nonexistent, and attackers register those names ("slopsquatting"). The
+oracle answers from real published artifacts (PyPI wheels, npm tarballs),
+and every negative answer is signed.
+
+## Files
+
+- `skills/attester-verify/SKILL.md`: the workflow and exact curls.
+- `skills/attester-verify/references/details.md`: endpoint reference,
+  response shapes, status codes, allowlist guidance, paid path.
+
+Related: https://github.com/maminihds/attester-import-check enforces the
+same check as a pre-commit hook, a Claude Code hook, and a GitHub Action.

--- a/plugins/attester-verify/skills/attester-verify/SKILL.md
+++ b/plugins/attester-verify/skills/attester-verify/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: attester-verify
+description: Verify PyPI and npm package and symbol names against the attester.dev existence oracle before installing or importing them. Use when adding dependencies, writing imports, calling library functions, or fixing build errors about missing packages or symbols.
+---
+
+# Verify packages before installing
+
+Models invent plausible package names: a USENIX Security 2025 study measured 5.2% to 21.7% of suggested package names as nonexistent, depending on model and ecosystem. Before any package name reaches a dependency file or an import line, check that it exists. The check is one HTTP POST to a free keyless oracle. No account, no API key, no signup.
+
+## When to Use
+
+- Before adding a package to a dependency file (requirements.txt, pyproject.toml, package.json) or running an install command for a package you did not choose yourself.
+- Before writing an import, require, or from-import for a third-party package.
+- Before calling a function, class, or constant you cannot confirm exists in the target package.
+- When a build fails on a missing package or symbol: check the name before changing anything else.
+
+Skip the check for standard library modules, local project modules, and names already verified this session.
+
+## How to check (free, keyless)
+
+Does the package exist:
+
+```bash
+curl -X POST https://attester.dev/demo/v1/package/exists \
+  -H 'Content-Type: application/json' \
+  -d '{"ecosystem": "pypi", "name": "requests"}'
+```
+
+Does the symbol exist in that package:
+
+```bash
+curl -X POST https://attester.dev/demo/v1/symbol/exists \
+  -H 'Content-Type: application/json' \
+  -d '{"ecosystem": "pypi", "package": "requests", "symbol": "get"}'
+```
+
+`ecosystem` is `pypi` or `npm`. Proceed only when `exists` is true. On a miss, prefer the oracle's closest real names (`adjacent_to` for packages, `closest_match` for symbols) over retrying invented variants. `typosquat_adjacent: true` means a real package sits within edit distance 2; never install the flagged name.
+
+## MCP server pinning (optional, also free)
+
+Before trusting a remote MCP server you approved earlier, pin its tool manifest and check for drift later:
+
+```bash
+curl -X POST https://attester.dev/v2/mcp/pin \
+  -H 'Content-Type: application/json' \
+  -d '{"server_url": "https://example.com/mcp"}'
+```
+
+The pin returns a signed `manifest_sha256`. A later call to `/v2/mcp/check` ($0.01) answers whether the manifest changed since, with a signed diff.
+
+## Quota and failure behavior
+
+25 free calls per day per client IP, shared across the demo endpoints, reset 00:00 UTC. HTTP 429 means the daily quota is spent: say the check was skipped and why, then continue with the most conservative option (well-known packages, pinned versions). Treat network failures the same way. Never block the task on the check itself.
+
+## Reading answers
+
+- `exists: true`: proceed. When pinning a version, prefer `latest_version`.
+- `exists: false`: do not install or import. Report the negative with the closest real names and ask which one was meant.
+- Negative answers carry `proof.artifact_sha256` and `source_url` for the artifact the oracle indexed, and every answer is signed.
+
+Full request and response shapes, allowlist guidance for import names that differ from package names (yaml, PIL, cv2), and the paid high-volume path: [references/details.md](references/details.md).

--- a/plugins/attester-verify/skills/attester-verify/references/details.md
+++ b/plugins/attester-verify/skills/attester-verify/references/details.md
@@ -1,0 +1,63 @@
+# attester-verify: reference details
+
+Full request and response shapes for the attester.dev existence oracle,
+plus allowlist guidance and the paid path. The skill body covers the
+workflow; this file is the lookup reference.
+
+## Disclosure
+
+This plugin wraps the attester.dev API, which the plugin author builds and
+operates (github.com/maminihds). The free keyless tier described here is
+the default path and needs nothing from the user. A paid tier exists for
+higher volume and is never required.
+
+## Free endpoints (keyless, 25 calls/day per client IP shared)
+
+| Endpoint | Body | Answers |
+| --- | --- | --- |
+| POST https://attester.dev/demo/v1/package/exists | `{"ecosystem": "pypi"\|"npm", "name": str}` | `exists`, `latest_version`, `typosquat_adjacent`, `adjacent_to`, `proof` |
+| POST https://attester.dev/demo/v1/symbol/exists | `{"ecosystem", "package", "symbol", "version"?}` | `exists`, `kind`, `deprecated`, `since_version`, `closest_match`, `version_resolved`, `proof` |
+| POST https://attester.dev/demo/v1/symbol/signature | `{"ecosystem", "package", "symbol", "version"?}` | `exists`, `signature`, `params`, `docstring_summary`, `deprecated`, `version_resolved`, `proof` |
+| POST https://attester.dev/demo/v1/diff | `{"ecosystem", "package", "from_version", "to_version"}` | `classification` (breaking/additive/neutral), `added`, `removed`, `changed`, `new_deprecations`, `proof` |
+| POST https://attester.dev/v2/mcp/pin | `{"server_url": str}` | `manifest_sha256`, `tool_count`, `server_info`, `pinned_at`, `attestation` |
+
+Every response also carries `attestation`, `attestation_hash`, and a
+signature (the signature endpoint names it `attestation_signature`,
+because `signature` there is the function signature). Verify any of them
+free at `POST /receipts/verify`.
+
+`proof` contains `artifact_sha256` and `source_url`: the exact wheel or
+tarball the oracle indexed. Package-level negatives return an empty proof
+plus the typosquat-adjacency fields.
+
+## Status codes
+
+- 200: the answer, signed.
+- 422: bad input (invalid ecosystem, misordered diff versions, unreachable
+  or non-MCP URL on pin). Never charged, never counted.
+- 429: daily free quota spent (25/day per client IP, reset 00:00 UTC).
+  The body names the paid route for that call.
+
+## Allowlist for false positives
+
+Some import names differ from their registry package names: `import yaml`
+installs as PyYAML, `from PIL import Image` as Pillow, `import cv2` as
+opencv-python, `import sklearn` as scikit-learn. When the import name is
+not itself a registry package, the oracle can return `exists: false` for
+code that is fine. Keep a per-project note of such names and skip checking
+them, or check the distribution name instead.
+
+## Enforcing the check mechanically
+
+The same guard packaged as a pre-commit hook, a Claude Code hook that
+blocks the write, and a GitHub Action that annotates PRs:
+https://github.com/maminihds/attester-import-check (MIT). It uses the same
+free endpoints and fails open on quota or network trouble.
+
+## Paid path (higher volume)
+
+Same answers without the daily cap: $0.002 per package check, $0.005 per
+symbol check, $0.01 per signature, $0.02 per diff, $0.01 per MCP drift
+check, $0.05 per MCP drift report. Payable per call with x402 (USDC on
+Base) or prepaid credits. Machine-readable terms:
+https://attester.dev/llms.txt.


### PR DESCRIPTION
References: #647

## What this adds

`plugins/attester-verify`: one skill (`attester-verify`) that teaches the agent to verify PyPI and npm package and symbol names against the attester.dev existence oracle before installing or importing them, plus pinning of remote MCP server manifests for later drift checks. Ships to all six harnesses through the standard pipeline; `make generate-all` output is committed.

## Why

Models invent plausible package names: a USENIX Security 2025 study measured 5.2% to 21.7% of suggested package names as nonexistent, depending on model and ecosystem. Attackers register those names ("slopsquatting"). The oracle answers from real published artifacts (PyPI wheels, npm tarballs) and signs every negative, so "does not exist" is a checkable fact rather than a model opinion. This is a failure mode models cannot self-check, which is the gap a rules-based skill closes well.

## Ownership disclosure (required)

I build and operate attester.dev, the API this plugin wraps (github.com/maminihds). The plugin uses only the free keyless tier: 25 calls per day per client IP, no account, no API key, no signup. There is no funnel: the skill tells the agent to continue conservatively when the quota is spent, and the paid tier appears once in references/details.md as reference material, never as a call to action. The same disclosure and free-tier shape was accepted in github/awesome-copilot#2387 and xpaysh/awesome-x402#940.

## Validation

- `make generate-all`: 732 files written, 0 errors; registries for all five compiled harnesses committed.
- `make validate STRICT=1`: OK, no issues across 5 harnesses.
- `make garden STRICT=1`: 0 errors for this plugin. The run exits 1 on 10 pre-existing warnings (SKILL_OVER_CODEX_CAP) in ship-mate, signed-audit-trails, and startup-business-analyst; verified identical on a clean baseline without this change.
- `make test`: 487 passed, 3 skipped.
- `make smoke-test`: 5 passed, 3 skipped (CLI binaries not installed locally; skips per the Makefile design; CI installs them).
- Code-quality checks (ruff/ty on tools/ and src/plugin_eval/): findings only in files this PR does not touch; the change is Markdown and JSON only.

## Notes

- Lifecycle hooks are not portable across the six harnesses (per docs/harnesses.md), so the enforcement variant lives in a separate MIT repo (github.com/maminihds/attester-import-check: pre-commit hook, Claude Code hook, GitHub Action) and is linked from the skill's references file rather than bundled.
