### PR TITLE
chore(meigen-ai-design): bump pinned meigen to 1.4.0

### DIFF
--- a/plugins/meigen-ai-design/README.md
+++ b/plugins/meigen-ai-design/README.md
@@ -11,7 +11,7 @@ This plugin requires the **meigen** MCP server. Install it by adding to your pro
   "mcpServers": {
     "meigen": {
       "command": "npx",
-      "args": ["-y", "meigen@1.3.3"]
+      "args": ["-y", "meigen@1.4.0"]
     }
   }
 }


### PR DESCRIPTION
Bumps the pinned npm version for the meigen-ai-design plugin from 1.3.3 to 1.4.0.

Release notes: https://github.com/jau123/MeiGen-AI-Design-MCP/releases/tag/v1.4.0

Highlights: model lineup/tiers/durations/reference-video limits are now served live via list_models instead of hardcoded tool text; explicit attemptId-based idempotency lifecycle to prevent double charges on retries; reference-video duration is server-probed for billing.