### PR TITLE
fix(plugin-eval): stop counting errored runs as activations (#651)

### DIFF
--- a/plugins/plugin-eval/src/plugin_eval/layers/monte_carlo.py
+++ b/plugins/plugin-eval/src/plugin_eval/layers/monte_carlo.py
@@ -54,7 +54,12 @@ def _simresult_from_messages(messages: list, prompt: str, duration_ms: int) -> S
     """Build a SimResult from SDK messages (assistant text => activation + quality)."""
     output = collect_sdk_output(messages)
     tokens = usage_total_tokens(output.usage)
-    raw = output.text.strip() or (output.result or "").strip()
+    # An errored run carries diagnostic text, not skill output, so it must not
+    # register as activation. Counting it inflates the activation rate and puts
+    # this metric at odds with output consistency and token efficiency (both
+    # already drop errored runs) and with the exception path below, which
+    # reports activated=False for a run that failed before producing anything.
+    raw = "" if output.errored else (output.text.strip() or (output.result or "").strip())
     activated = bool(raw)
     quality_score = min(1.0, len(raw) / 500) if activated else 0.0
     return SimResult(

--- a/plugins/plugin-eval/tests/test_monte_carlo.py
+++ b/plugins/plugin-eval/tests/test_monte_carlo.py
@@ -61,6 +61,31 @@ class TestSimResultFromMessages:
         assert sim.activated is True
         assert sim.quality_score == 0.5
 
+    def test_errored_result_text_does_not_activate(self):
+        # An errored SDK run whose result carries diagnostic text used to come
+        # back activated=True *and* errored=True, so the same run was counted in
+        # both n_activated and n_errored.
+        sim = _simresult_from_messages([_result(is_error=True, result="API error")], "p", 10)
+        assert sim.errored is True
+        assert sim.activated is False
+        assert sim.quality_score == 0.0
+
+    def test_errored_run_with_assistant_text_does_not_activate(self):
+        # Same rule when the error arrives after some assistant text: the run
+        # failed, so it cannot count towards the activation rate.
+        sim = _simresult_from_messages(
+            [_assistant("x" * 250), _result(is_error=True, result="API error")], "p", 10
+        )
+        assert sim.errored is True
+        assert sim.activated is False
+        assert sim.quality_score == 0.0
+
+    def test_errored_run_matches_the_exception_path(self):
+        # run_simulation's except branch reports a failed run as
+        # activated=False/quality 0.0; an SDK-reported error must look the same.
+        sim = _simresult_from_messages([_result(is_error=True, result="boom")], "p", 10)
+        assert (sim.activated, sim.quality_score, sim.errored) == (False, 0.0, True)
+
     def test_tokens_summed_from_usage(self):
         sim = _simresult_from_messages(
             [_assistant("hi"), _result(usage={"input_tokens": 3, "output_tokens": 4})],
@@ -109,6 +134,22 @@ class TestMonteCarloAnalyzer:
         assert stats["triggering"]["activation_rate"] == pytest.approx(0.98)
         assert stats["failure_rate"]["p_fail"] == pytest.approx(0.02)
         assert stats["output_consistency"]["cv"] < 0.15
+
+    def test_errored_runs_do_not_inflate_the_activation_rate(self):
+        """An errored run counts once, against the failure rate -- not twice."""
+        analyzer = MonteCarloAnalyzer(MonteCarloConfig(n_runs=4))
+        results = [
+            _simresult_from_messages([_assistant("x" * 250), _result()], "p", 10),
+            _simresult_from_messages([_assistant("x" * 250), _result()], "p", 10),
+            _simresult_from_messages([_result(is_error=True, result="API error")], "p", 10),
+            _simresult_from_messages([_result(is_error=True, result="API error")], "p", 10),
+        ]
+
+        stats = analyzer._compute_statistics(results)
+
+        assert stats["triggering"]["n_activated"] == 2
+        assert stats["triggering"]["activation_rate"] == pytest.approx(0.5)
+        assert stats["failure_rate"]["p_fail"] == pytest.approx(0.5)
 
 
 class TestUsageTotalTokens:


### PR DESCRIPTION
Fixes #651.

## Root cause

`_simresult_from_messages` applied the `ResultMessage.result` fallback before consulting `is_error`:

```python
raw = output.text.strip() or (output.result or "").strip()
activated = bool(raw)
```

An errored SDK run whose `result` carries diagnostic text (`"API error"`) therefore came back **both** `activated=True` and `errored=True`, and got counted in `n_activated` *and* `n_errored`. That inflates `activation_rate` and, through it, the triggering contribution to the composite score.

It also left activation as the only metric that behaves this way. Everything adjacent already excludes errored runs:

| metric | filter on `main` |
|---|---|
| output consistency | `[r.quality_score for r in results if r.activated and not r.errored]` (`:277`) |
| token efficiency | excludes errored runs |
| **activation rate** | `sum(1 for r in results if r.activated)` (`:264`) — **no errored filter** |

And it disagreed with `run_simulation`'s own failure path, which reports a run that died before producing anything as `activated=False, quality_score=0.0, errored=True` (`:94-102`). A run that fails inside the SDK and a run that fails in transport should not score differently.

## The fix

Suppress the output when the run errored, so activation and quality collapse to the same values the exception path already produces:

```python
raw = "" if output.errored else (output.text.strip() or (output.result or "").strip())
```

This matches the issue's stated expectation — `errored=True`, `activated=False`, `quality_score=0.0`. Errored runs still count exactly once, against the failure rate.

Note the guard covers assistant text as well as the `result` fallback, not just the fallback the issue names. A run that streamed some text and *then* errored still failed, so counting it as a successful activation would reintroduce the same double-count in a narrower case. `test_activated_via_result_fallback` (the non-errored fallback path from #531) is unaffected and still passes.

## Testing

Four new tests in `tests/test_monte_carlo.py`:

- `test_errored_result_text_does_not_activate` — the issue's exact repro (`is_error=True`, `result="API error"`)
- `test_errored_run_with_assistant_text_does_not_activate` — the error-after-text case
- `test_errored_run_matches_the_exception_path` — pins the SDK-error result to the shape `run_simulation`'s `except` branch produces
- `test_errored_runs_do_not_inflate_the_activation_rate` — analyzer-level: 2 good + 2 errored runs give `n_activated == 2`, `activation_rate == 0.5`, `p_fail == 0.5`. On `main` this reports an activation rate of 1.0.

**Verified failing on unfixed `main`**: all four fail.

Full `plugins/plugin-eval` suite: **135 passed**. `ruff check` and `ruff format --check` clean on both files.