### PR TITLE
Add kin as an external git-subdir entry for semantic code retrieval

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/wshobson"
   },
   "metadata": {
-    "description": "Production-ready workflow orchestration with 94 marketplace plugins, 203 local specialized agents, and 175 local skills - optimized for granular installation and minimal token usage",
+    "description": "Production-ready workflow orchestration with 95 marketplace plugins, 203 local specialized agents, and 175 local skills - optimized for granular installation and minimal token usage",
     "version": "1.7.1"
   },
   "plugins": [
@@ -1312,6 +1312,31 @@
         "slide-decks",
         "deck-generation",
         "slide-design"
+      ]
+    },
+    {
+      "name": "kin",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/firelock-ai/kin.git",
+        "path": "plugins/kin-claude"
+      },
+      "description": "Semantic code retrieval over a graph of entities, relationships, changes, and provenance. Locate, search, context packs, data-flow tracing, and impact analysis without raw file search.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Firelock",
+        "url": "https://github.com/firelock-ai"
+      },
+      "homepage": "https://github.com/firelock-ai/kin",
+      "license": "Apache-2.0",
+      "category": "development",
+      "keywords": [
+        "code-search",
+        "semantic-search",
+        "code-navigation",
+        "impact-analysis",
+        "code-review",
+        "mcp"
       ]
     }
   ]

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/wshobson"
   },
   "metadata": {
-    "description": "Production-ready workflow orchestration with 94 marketplace plugins, 203 local specialized agents, and 175 local skills - optimized for granular installation and minimal token usage",
+    "description": "Production-ready workflow orchestration with 95 marketplace plugins, 203 local specialized agents, and 175 local skills - optimized for granular installation and minimal token usage",
     "version": "1.7.1"
   },
   "plugins": [

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-code-workflows",
   "displayName": "Claude Code Workflows",
   "version": "1.7.1",
-  "description": "Production-ready workflow orchestration with 94 marketplace plugins, 203 local specialized agents, and 175 local skills - optimized for granular installation and minimal token usage",
+  "description": "Production-ready workflow orchestration with 95 marketplace plugins, 203 local specialized agents, and 175 local skills - optimized for granular installation and minimal token usage",
   "author": {
     "name": "Seth Hobson",
     "email": "seth@major7apps.com"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # claude-agents — multi-harness agentic plugin marketplace
 
-Production-ready agentic-workflow building blocks: **94 plugins** (90 local + 4 external), **203 agents**, **175 skills**, **109 commands**. Native source-of-truth for Claude Code; also consumed by OpenAI Codex CLI, Cursor, OpenCode, and Gemini CLI from a single Markdown source.
+Production-ready agentic-workflow building blocks: **95 plugins** (90 local + 5 external), **203 agents**, **175 skills**, **109 commands**. Native source-of-truth for Claude Code; also consumed by OpenAI Codex CLI, Cursor, OpenCode, and Gemini CLI from a single Markdown source.
 
 This file is the canonical context file. Codex / Cursor / OpenCode read it directly. Claude Code reads it via `CLAUDE.md`, a symlink to this file. Gemini CLI reads it via `gemini-extension.json` (`contextFileName`) / `.gemini/settings.json`.
 
@@ -10,7 +10,7 @@ This file is the canonical context file. Codex / Cursor / OpenCode read it direc
 
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — top-level architectural overview (adapter framework, source-of-truth invariant, capability matrix summary)
 - **[docs/architecture.md](docs/architecture.md)** — detailed design principles
-- **[docs/plugins.md](docs/plugins.md)** — full plugin catalog (94 plugins by category)
+- **[docs/plugins.md](docs/plugins.md)** — full plugin catalog (95 plugins by category)
 - **[docs/agents.md](docs/agents.md)** — agent reference (203 agents, model tiers)
 - **[docs/agent-skills.md](docs/agent-skills.md)** — skill reference (progressive disclosure model)
 - **[docs/usage.md](docs/usage.md)** — commands, workflows, examples

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agentic Plugin Marketplace
 
-> Production-ready agentic workflow building blocks: **94 plugins**, **203 agents**,
+> Production-ready agentic workflow building blocks: **95 plugins**, **203 agents**,
 > **175 skills**, **109 commands** — built for Claude Code and consumed natively by
 > OpenAI Codex CLI, Cursor, OpenCode, Gemini CLI, and GitHub Copilot from a single Markdown source.
 
@@ -19,7 +19,7 @@ Pick your harness:
 
 ```bash
 /plugin marketplace add wshobson/agents
-/plugin install python-development          # or any of 94 plugins
+/plugin install python-development          # or any of 95 plugins
 ```
 
 [→ Full Claude Code setup, troubleshooting, and plugin catalog](docs/usage.md)
@@ -47,7 +47,7 @@ Setup details and per-harness gotchas: [docs/harnesses.md](docs/harnesses.md). G
 
 | | Count | What it is |
 |---|---:|---|
-| **Plugins** | 94 | Granular, single-purpose installable units (90 local + 4 external via git-subdir) |
+| **Plugins** | 95 | Granular, single-purpose installable units (90 local + 5 external via git-subdir) |
 | **Agents** | 203 | Domain experts (architecture, languages, infra, security, data, ML, docs, business, SEO) |
 | **Skills** | 175 | Modular knowledge packages with progressive disclosure (load when activated) |
 | **Commands** | 109 | Slash commands: scaffolding, security scans, test gen, infrastructure setup |
@@ -125,7 +125,7 @@ uv run plugin-eval certify path/to/skill
 
 Detail lives in `docs/`. Read in this order:
 
-- **[docs/plugins.md](docs/plugins.md)** — full catalog of all 94 plugins
+- **[docs/plugins.md](docs/plugins.md)** — full catalog of all 95 plugins
 - **[docs/agents.md](docs/agents.md)** — all 203 agents by category
 - **[docs/agent-skills.md](docs/agent-skills.md)** — 175 skills with progressive disclosure
 - **[docs/usage.md](docs/usage.md)** — commands, workflows, examples

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,10 +36,10 @@ This marketplace follows industry best practices with a focus on granularity, co
 
 ### Plugin Distribution
 
-- **94 marketplace plugins** (90 local + 4 external via git-subdir) optimized for specific use cases
+- **95 marketplace plugins** (90 local + 5 external via git-subdir) optimized for specific use cases
 - **26 clear categories** with 1-10 plugins each for easy discovery
 - Organized by domain:
-  - **Development**: 6 plugins (debugging, backend, frontend, UI, multi-platform, essentials)
+  - **Development**: 7 plugins (debugging, backend, frontend, UI, multi-platform, essentials, semantic retrieval)
   - **Security**: 6 plugins (scanning, compliance, API, frontend/mobile, reverse engineering, hook policy)
   - **Operations**: 4 plugins (incident, diagnostics, distributed, observability)
   - **Languages**: 10 plugins (Python, JS/TS, systems, JVM, scripting, functional, embedded, and more)
@@ -81,7 +81,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 ```
 claude-agents/
 ├── .claude-plugin/
-│   └── marketplace.json          # Marketplace catalog (94 plugins)
+│   └── marketplace.json          # Marketplace catalog (95 plugins)
 ├── plugins/                       # Isolated plugin directories
 │   ├── python-development/
 │   │   ├── agents/               # Python language agents
@@ -393,5 +393,5 @@ Feature Development Workflow:
 
 - [Agent Skills](./agent-skills.md) - Modular knowledge packages
 - [Agent Reference](./agents.md) - Complete agent catalog
-- [Plugin Reference](./plugins.md) - All 94 marketplace plugins
+- [Plugin Reference](./plugins.md) - All 95 marketplace plugins
 - [Usage Guide](./usage.md) - Commands and workflows

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,6 +1,6 @@
 # Complete Plugin Reference
 
-Browse all **94 marketplace plugins** organized by category: 90 local plugins plus 4 externally hosted `git-subdir` entries (`pensyve`, `qa-orchestra`, `storymap-skill`, `ciagent`).
+Browse all **95 marketplace plugins** organized by category: 90 local plugins plus 5 externally hosted `git-subdir` entries (`pensyve`, `qa-orchestra`, `storymap-skill`, `ciagent`, `kin`).
 
 ## Quick Start - Essential Plugins
 
@@ -108,7 +108,7 @@ Next.js, React + Vite, and Node.js project setup with pnpm and TypeScript best p
 
 ## Complete Plugin Catalog
 
-### 🎨 Development (6 plugins)
+### 🎨 Development (7 plugins)
 
 | Plugin                          | Description                                                  | Install                                       |
 | ------------------------------- | ------------------------------------------------------------ | --------------------------------------------- |
@@ -118,6 +118,7 @@ Next.js, React + Vite, and Node.js project setup with pnpm and TypeScript best p
 | **ui-design**                   | UI/UX design for mobile (iOS, Android, React Native) and web | `/plugin install ui-design`                   |
 | **multi-platform-apps**         | Cross-platform app coordination (web/iOS/Android)            | `/plugin install multi-platform-apps`         |
 | **developer-essentials**        | Essential Git, SQL, code review, auth, debugging, and monorepo skills | `/plugin install developer-essentials`        |
+| **kin**                         | Semantic code retrieval over a graph of entities, relationships, changes, and provenance (external plugin) | `/plugin install kin`                         |
 
 ### 📚 Documentation (4 plugins)
 
@@ -365,7 +366,7 @@ plugins/python-development/
 /plugin marketplace add wshobson/agents
 ```
 
-This makes all 94 marketplace plugins available for installation, but **does not load any agents or tools** into your context.
+This makes all 95 marketplace plugins available for installation, but **does not load any agents or tools** into your context.
 
 ### Step 2: Install Specific Plugins
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -394,5 +394,5 @@ See [Agent Skills](./agent-skills.md) for details on the 175 specialized skills.
 
 - [Agent Skills](./agent-skills.md) - Specialized knowledge packages
 - [Agent Reference](./agents.md) - Complete agent catalog
-- [Plugin Reference](./plugins.md) - All 94 marketplace plugins
+- [Plugin Reference](./plugins.md) - All 95 marketplace plugins
 - [Architecture](./architecture.md) - Design principles


### PR DESCRIPTION
## Summary

Kin is semantic code retrieval over a graph of entities, relationships, changes, and provenance. This adds it as an external `git-subdir` entry, following the pensyve, qa-orchestra, storymap-skill, and ciagent precedent. The plugin lives at `plugins/kin-claude` in the source repo, where it ships an MCP server plus three skills for retrieval, blast-radius review, and first-run setup.

Plugin totals move from 94 to 95 and externals from 4 to 5 across the README, AGENTS.md, and docs. `.cursor-plugin/` is in the diff because the marketplace metadata description carries the plugin count, so `make generate-all` rewrites it. Nothing else regenerates: an external entry adds no local plugin directory, so it produces no per-harness artifacts, same as the other four.

One thing I left alone. The docs say 90 local plugins while `plugins/` holds 91 directories, and pptx-deck-creation is not in the `docs/plugins.md` catalog yet. I bumped every stated total by one rather than resyncing, so this PR stays about Kin.

Disclosure per CONTRIBUTING: I maintain Kin and the `@kinlab/kin-mcp` package the plugin runs. Both are Apache-2.0, free to install and run, with no paid tier and no key needed to use the tools.

After merge:

```
/plugin marketplace add wshobson/agents
/plugin install kin
```

## Scope

- [ ] Plugin authoring (new or modified `plugins/<name>/...`)
- [ ] Adapter framework (`tools/adapters/`)
- [ ] Quality tooling (validators, gardener, plugin-eval)
- [ ] Per-harness setup or docs (GEMINI.md / docs/harnesses.md)
- [x] AGENTS.md / ARCHITECTURE.md / docs/
- [ ] CI / build / release
- [x] Other (marketplace entry for an externally hosted plugin)

## Affected harnesses

- [x] Claude Code
- [ ] OpenAI Codex CLI
- [ ] Cursor
- [ ] OpenCode
- [ ] Gemini CLI
- [ ] Pure tooling / framework (no harness behavior change)

External entries are Claude Code only. The Codex, Cursor, OpenCode, and Gemini registries are generated from local `plugins/` and carry no external entries, which I checked against the four already in the tree.

## Test plan

- [x] `make validate STRICT=1`
- [x] `make garden`
- [x] `make test` (full pytest suite)
- [ ] `make smoke-test` (real-CLI subprocess tests)
- [x] Ran ruff + ty in `plugins/plugin-eval/`
- [ ] Spot-checked behavior in a real harness (which?): ____________

`make generate-all` leaves the tree clean apart from the two Cursor files committed here. `make validate STRICT=1` reports no issues across five harnesses. `make garden` reports 0 errors and the 10 pre-existing SKILL_OVER_CODEX_CAP warnings, none on files this PR touches. The pytest suite runs 485 passed and 2 skipped across `plugins/plugin-eval/` and `tools/tests/`, with one failure I could not clear locally: `tools/tests/test_cli_smoke.py::TestCodexSmoke::test_codex_doctor_passes_overall` times out because `codex doctor` does not return inside 60 seconds on my machine. It fails the same way on a clean checkout with no changes applied, so it is my environment and not this PR. That is also why I left `make smoke-test` unchecked. ruff check, ruff format --check, and ty all pass on the CI-scoped paths, and markdownlint passes on `*.md` and `docs/*.md`.

I did not install the marketplace into a live harness, so the spot-check box stays unchecked. I did confirm the git-subdir target resolves: `plugins/kin-claude/.claude-plugin/plugin.json` exists on `main` in the source repo, its `name` is `kin` to match the entry, and its version is the 0.1.0 recorded here. No name collides with an existing plugin, agent, or skill.

## Cross-harness portability notes

N/A. No plugin content is added to this repo.

## Related issue(s)

None. CONTRIBUTING asks for an issue first, and the recent external plugin entries went straight to a PR, so I followed those. Happy to file one if you would rather have the paper trail.

Repo: https://github.com/firelock-ai/kin
Install page: https://kinlab.ai/install
