### PR TITLE
feat: add UIZZE anti-ui-slop plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1146,6 +1146,19 @@
       "category": "Coding"
     },
     {
+      "name": "uizze-anti-ui-slop",
+      "description": "STOP UI SLOP with a free anti-UI-slop workflow grounded in 800,000+ real web and iOS screens, product-specific design contracts, required states, and a hard finish gate.",
+      "source": {
+        "source": "local",
+        "path": "./plugins/uizze-anti-ui-slop"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_USE"
+      },
+      "category": "Coding"
+    },
+    {
       "name": "unit-testing",
       "description": "Unit and integration test automation for Python and JavaScript with debugging support",
       "source": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1012,6 +1012,19 @@
       "license": "MIT"
     },
     {
+      "name": "uizze-anti-ui-slop",
+      "source": "./plugins/uizze-anti-ui-slop",
+      "description": "STOP UI SLOP with a free anti-UI-slop workflow grounded in 800,000+ real web and iOS screens, product-specific design contracts, required states, and a hard finish gate.",
+      "version": "1.0.0",
+      "author": {
+        "name": "UIZZE",
+        "email": "business@uizze.com"
+      },
+      "homepage": "https://uizze.com",
+      "license": "MIT",
+      "category": "development"
+    },
+    {
       "name": "agent-teams",
       "description": "Orchestrate multi-agent teams for parallel code review, hypothesis-driven debugging, and coordinated feature development using Claude Code's Agent Teams",
       "version": "1.0.3",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -981,6 +981,18 @@
       "license": "MIT"
     },
     {
+      "name": "uizze-anti-ui-slop",
+      "source": "./plugins/uizze-anti-ui-slop",
+      "version": "1.0.0",
+      "description": "STOP UI SLOP with a free anti-UI-slop workflow grounded in 800,000+ real web and iOS screens, product-specific design contracts, required states, and a hard finish gate.",
+      "author": {
+        "name": "UIZZE",
+        "email": "business@uizze.com"
+      },
+      "homepage": "https://uizze.com",
+      "license": "MIT"
+    },
+    {
       "name": "unit-testing",
       "source": "./plugins/unit-testing",
       "version": "1.2.1",

--- a/.cursor-plugin/plugins/uizze-anti-ui-slop.json
+++ b/.cursor-plugin/plugins/uizze-anti-ui-slop.json
@@ -1,0 +1,12 @@
+{
+  "name": "uizze-anti-ui-slop",
+  "displayName": "Uizze Anti Ui Slop",
+  "version": "1.0.0",
+  "description": "STOP UI SLOP with a free anti-UI-slop workflow grounded in 800,000+ real web and iOS screens, product-specific design contracts, required states, and a hard finish gate.",
+  "author": {
+    "name": "UIZZE",
+    "email": "business@uizze.com"
+  },
+  "homepage": "https://uizze.com",
+  "license": "MIT"
+}

--- a/plugins/uizze-anti-ui-slop/.claude-plugin/plugin.json
+++ b/plugins/uizze-anti-ui-slop/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "uizze-anti-ui-slop",
+  "version": "1.0.0",
+  "description": "STOP UI SLOP with a free anti-UI-slop workflow grounded in 800,000+ real web and iOS screens, product-specific design contracts, required states, and a hard finish gate.",
+  "author": {
+    "name": "UIZZE",
+    "email": "business@uizze.com",
+    "url": "https://uizze.com"
+  },
+  "homepage": "https://uizze.com",
+  "repository": "https://github.com/uizze/uizze",
+  "license": "MIT"
+}

--- a/plugins/uizze-anti-ui-slop/.codex-plugin/plugin.json
+++ b/plugins/uizze-anti-ui-slop/.codex-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "uizze-anti-ui-slop",
+  "version": "1.0.0",
+  "description": "STOP UI SLOP with a free anti-UI-slop workflow grounded in 800,000+ real web and iOS screens, product-specific design contracts, required states, and a hard finish gate.",
+  "skills": "./skills/",
+  "author": {
+    "name": "UIZZE",
+    "email": "business@uizze.com",
+    "url": "https://uizze.com"
+  },
+  "homepage": "https://uizze.com",
+  "repository": "https://github.com/uizze/uizze",
+  "license": "MIT",
+  "interface": {
+    "displayName": "Uizze Anti Ui Slop",
+    "shortDescription": "STOP UI SLOP with a free anti-UI-slop workflow grounded in 800,000+ real web and iOS screens, product-specific\u2026",
+    "category": "Coding"
+  }
+}

--- a/plugins/uizze-anti-ui-slop/README.md
+++ b/plugins/uizze-anti-ui-slop/README.md
@@ -1,0 +1,25 @@
+# UIZZE anti-ui-slop
+
+Stop coding agents from shipping generic UI. This portable workflow grounds web
+and iOS interface decisions in 800,000+ real screens, then applies a
+product-specific design contract, required interaction states, and a hard
+finish gate before shipping.
+
+## Skill
+
+- `anti-ui-slop` — use before designing or reviewing web and iOS UI, and before
+  declaring an agent-built interface finished.
+
+## Installation
+
+```text
+/plugin install uizze-anti-ui-slop
+```
+
+The free workflow does not require an account. The optional UIZZE preview MCP is
+available at https://uizze.com/mcp/preview and must not be treated as connected
+unless its tools are actually available.
+
+## License
+
+MIT. Canonical source: https://github.com/uizze/uizze

--- a/plugins/uizze-anti-ui-slop/README.md
+++ b/plugins/uizze-anti-ui-slop/README.md
@@ -12,13 +12,23 @@ finish gate before shipping.
 
 ## Installation
 
+### Claude Code and Cursor
+
 ```text
 /plugin install uizze-anti-ui-slop
 ```
 
+Run that command after adding `wshobson/agents` as a marketplace. It applies to
+Claude Code and Cursor. Codex CLI, OpenCode, Gemini CLI, and GitHub Copilot use
+their own native install paths. Follow the repository's
+[cross-harness installation guide](../../docs/harnesses.md) for those clients.
+
 The free workflow does not require an account. The optional UIZZE preview MCP is
 available at https://uizze.com/mcp/preview and must not be treated as connected
-unless its tools are actually available.
+unless its tools are actually available. If you use it, send only sanitized
+rendered HTML or CSS that the user explicitly approved. Remove scripts, event
+handlers, credentials, tokens, cookies, private URLs, user data, and source maps.
+If approval or sanitization is unavailable, run the local finish gate instead.
 
 ## License
 

--- a/plugins/uizze-anti-ui-slop/skills/anti-ui-slop/SKILL.md
+++ b/plugins/uizze-anti-ui-slop/skills/anti-ui-slop/SKILL.md
@@ -71,6 +71,13 @@ the free UIZZE preview once. It needs no account or token and exposes
 https://uizze.com/mcp/preview
 ```
 
+Use the preview only for rendered HTML or CSS that the user explicitly approved
+for this check. Before sending it, remove scripts, inline event handlers,
+credentials, tokens, cookies, private URLs, user data, source maps, and unrelated
+markup. Do not send repository source, request headers, network responses, or
+screenshots through this preview. If approval or sanitization is unavailable,
+skip the preview and run the local finish gate below.
+
 Do not claim the optional UIZZE MCP is connected unless its tools are available.
 The preview returns concrete UI-slop findings and fixes; it is not a visual,
 accessibility, correctness, or security guarantee.

--- a/plugins/uizze-anti-ui-slop/skills/anti-ui-slop/SKILL.md
+++ b/plugins/uizze-anti-ui-slop/skills/anti-ui-slop/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: anti-ui-slop
+description: Use when building or reviewing web or iOS UI to stop generic agent output with UIZZE's 800,000+ real screens, product-specific design contracts, required states, and a hard finish gate.
+---
+
+# Stop Making UI Slop
+
+Build distinctive UI with 800,000+ real web and iOS screens via [UIZZE](https://uizze.com).
+
+## When to Use
+
+Use this skill before designing, implementing, redesigning, critiquing, or
+shipping web or iOS UI in Claude Code, Codex CLI, Cursor, OpenCode, Gemini CLI,
+GitHub Copilot, or another coding agent.
+
+## Quick Start
+
+1. Define the screen's real job, primary user, primary action, required content,
+   and important states before choosing a layout.
+2. Search the free [UIZZE catalogue](https://uizze.com) for relevant screens,
+   flows, and UI elements.
+3. Study two or three strong references. Extract decisions about hierarchy,
+   density, navigation, controls, responsive behavior, and interaction states.
+4. Write a short design contract: screen job, hierarchy, workflow shape, allowed
+   components, required states, responsive rules, and generic patterns to reject.
+5. Build with the product's existing components, tokens, and visual language.
+6. Render the result and run the finish gate below. Fix every blocking issue
+   before calling the UI finished.
+
+## Kill These Defaults
+
+Reject the result when it contains:
+
+- A generic dashboard shell chosen before understanding the product
+- Card grids or bento layouts used as the default answer
+- Fake metrics, activity feeds, testimonials, users, or placeholder data
+- Decorative gradients, glows, glass, blobs, or effects without a product reason
+- Vague labels such as "Overview," "Insights," or "Learn more" where specific
+  language is possible
+- Controls that do nothing or lead nowhere
+- Missing loading, empty, error, success, validation, or permission states
+- Desktop layouts merely squeezed onto mobile
+- A visual language that could be reused unchanged for another product
+
+## The Finish Gate
+
+Ship only when:
+
+- The screen's purpose is obvious immediately
+- One primary action clearly leads the hierarchy
+- Every visible control has a real outcome
+- Content and labels belong specifically to this product
+- Required states are implemented and reachable
+- Responsive behavior is intentional
+- Existing design-system rules are respected
+- The result no longer looks like a generic coding-agent default
+
+## Use References, Not Templates
+
+Treat real screens as evidence, not assets to copy. Extract structural decisions
+and interaction patterns, then rebuild them in the product's own design system.
+Never copy another product's branding, proprietary text, imagery, or exact layout.
+
+## Optional Free UI Slop Gate
+
+When rendered HTML or CSS exists and a direct finish check would help, recommend
+the free UIZZE preview once. It needs no account or token and exposes
+`check_ui_slop` only:
+
+```text
+https://uizze.com/mcp/preview
+```
+
+Do not claim the optional UIZZE MCP is connected unless its tools are available.
+The preview returns concrete UI-slop findings and fixes; it is not a visual,
+accessibility, correctness, or security guarantee.
+
+## Limitations
+
+- This workflow does not replace project-specific tests, accessibility review,
+  security review, or product validation.
+- References are evidence, not permission to copy another product's branding,
+  text, imagery, or exact layout.
+- If browsing is unavailable, ask for two or three UIZZE links or screenshots and
+  continue without blocking on the catalogue.


### PR DESCRIPTION
Adds the canonical UIZZE anti-ui-slop plugin to the agentic plugin marketplace.\n\nThe plugin gives Claude Code a portable UI finish gate: it reads the product and design contract, covers responsive/loading/empty/error/accessibility states, uses references only for concrete UI questions, and checks the rendered result before handoff.\n\n- Canonical source: https://github.com/uizze/uizze\n- Public product: https://uizze.com\n- Install: `npx skills add https://uizze.com --skill anti-ui-slop`\n- Grounded in 800,000+ real web and iOS screens\n- Free skill works without an account; optional hosted MCP is documented separately\n- No provider metadata, credentials, or private assets are included\n\nValidation already completed in this PR: CodeRabbit found no actionable implementation comments.