### PR TITLE
fix(plugin-eval): resolve nested skill references

### DIFF
--- a/plugins/plugin-eval/src/plugin_eval/layers/static.py
+++ b/plugins/plugin-eval/src/plugin_eval/layers/static.py
@@ -233,6 +233,8 @@ class StaticAnalyzer:
         skill_parent = skill.path.parent  # skills/ dir
         for ref in skill.cross_references:
             ref_path = skill_parent / ref
+            if not ref_path.exists() and ref.startswith("sub-skills/"):
+                ref_path = skill.path / ref
             if not ref_path.exists():
                 patterns.append(
                     AntiPattern(

--- a/plugins/plugin-eval/src/plugin_eval/parser.py
+++ b/plugins/plugin-eval/src/plugin_eval/parser.py
@@ -9,6 +9,10 @@ from pathlib import Path
 
 import yaml
 
+_CROSS_REFERENCE_PATTERN = re.compile(
+    r"(?<![\w-])((?:skill|skills|sub-skills)/[a-z0-9-]+(?:/[a-z0-9-]+)*)"
+)
+
 
 @dataclass
 class ParsedSkill:
@@ -93,7 +97,7 @@ def parse_skill(skill_dir: Path) -> ParsedSkill:
     must_pattern = re.compile(r"\b(MUST|NEVER|ALWAYS)\b")
     must_count = len(must_pattern.findall(content))
 
-    cross_refs = re.findall(r"(?:skill|skills)/([a-z0-9-]+)", body)
+    cross_refs = _extract_cross_references(body)
 
     return ParsedSkill(
         path=skill_dir,
@@ -134,7 +138,7 @@ def parse_agent(agent_path: Path) -> ParsedAgent:
     description = frontmatter.get("description", "")
     has_proactive = bool(re.search(r"use proactively", description, re.IGNORECASE))
 
-    skill_refs = re.findall(r"(?:skill|skills)/([a-z0-9-]+)", body)
+    skill_refs = _extract_cross_references(body)
 
     return ParsedAgent(
         path=agent_path,
@@ -196,3 +200,13 @@ def _split_frontmatter(content: str) -> tuple[dict, str]:
         frontmatter = {}
 
     return frontmatter, parts[2]
+
+
+def _extract_cross_references(body: str) -> list[str]:
+    """Extract skill paths while keeping references to nested skills intact."""
+    references = []
+    for reference in _CROSS_REFERENCE_PATTERN.findall(body):
+        if reference.startswith(("skill/", "skills/")):
+            reference = reference.split("/", 1)[1]
+        references.append(reference)
+    return references

--- a/plugins/plugin-eval/tests/test_parser.py
+++ b/plugins/plugin-eval/tests/test_parser.py
@@ -28,6 +28,21 @@ class TestParseSkill:
         with pytest.raises(FileNotFoundError):
             parse_skill(empty)
 
+    def test_parse_cross_references_preserves_nested_paths(self, tmp_path: Path):
+        skill_dir = tmp_path / "parent"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: parent\n"
+            'description: "Use when testing nested references."\n'
+            "---\n\n"
+            "See `sub-skills/child/SKILL.md` and `skills/sibling/SKILL.md`.\n"
+        )
+
+        skill = parse_skill(skill_dir)
+
+        assert skill.cross_references == ["sub-skills/child", "sibling"]
+
 
 class TestParseAgent:
     def test_parse_valid_agent(self, sample_plugin_dir: Path):

--- a/plugins/plugin-eval/tests/test_static.py
+++ b/plugins/plugin-eval/tests/test_static.py
@@ -54,6 +54,20 @@ class TestStaticAnalyzer:
         weak = "A skill."
         assert analyzer._description_pushiness(good) > analyzer._description_pushiness(weak)
 
+    def test_nested_cross_reference_resolves_from_skill_directory(self, tmp_path: Path):
+        skill_dir = _make_skill(tmp_path, "Use when testing nested references.", "parent")
+        nested_skill = skill_dir / "sub-skills" / "child"
+        nested_skill.mkdir(parents=True)
+        (nested_skill / "SKILL.md").write_text("# Child\n")
+        (skill_dir / "SKILL.md").write_text(
+            (skill_dir / "SKILL.md").read_text()
+            + "\nSee `sub-skills/child/SKILL.md`.\n"
+        )
+
+        result = StaticAnalyzer().analyze_skill(skill_dir)
+
+        assert "DEAD_CROSS_REF" not in [ap.flag for ap in result.anti_patterns]
+
 
 class TestTriggerPattern:
     """Regression coverage for the broadened trigger-phrase matcher.


### PR DESCRIPTION
## Summary

- Preserve nested `sub-skills/...` paths when parsing skill and agent cross-references.
- Resolve nested skill references relative to the current skill directory so valid helpers are not penalized.

## Scope

- [ ] Plugin authoring (new or modified `plugins/<name>/...`)
- [ ] Adapter framework (`tools/adapters/`)
- [x] Quality tooling (validators, gardener, plugin-eval)
- [ ] Per-harness setup or docs (GEMINI.md / docs/harnesses.md)
- [ ] AGENTS.md / ARCHITECTURE.md / docs/
- [ ] CI / build / release
- [ ] Other

## Affected harnesses

- [ ] Claude Code
- [ ] OpenAI Codex CLI
- [ ] Cursor
- [ ] OpenCode
- [ ] Gemini CLI
- [x] Pure tooling / framework (no harness behavior change)

## Test plan

- [x] `make validate STRICT=1` equivalent: `uv run --project plugins/plugin-eval python -X utf8 tools/validate_generated.py --strict`
- [x] `make garden` equivalent: `uv run --project plugins/plugin-eval python -X utf8 tools/doc_gardener.py --strict` (0 errors, 10 pre-existing warnings)
- [ ] `make test` equivalent on Windows: 458 passed, 10 failed because Codex is unavailable and symlink creation is not permitted on this host
- [ ] `make smoke-test` was not fully green on this Windows host for the same environment constraints
- [x] `uv run pytest` in `plugins/plugin-eval/` (105 passed, 2 skipped)
- [x] Ran ruff + ty in `plugins/plugin-eval/`
- [ ] Spot-checked behavior in a real harness

## Cross-harness portability notes

N/A — pure tooling change.

## Related issue(s)

Closes #661