### PR TITLE
docs(readme): restore star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,3 +157,7 @@ integrations for this marketplace's other supported harnesses.
 ## License
 
 MIT — see [LICENSE](LICENSE).
+
+## Star history
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=wshobson/agents&type=date&legend=top-left)](https://star-history.dera.page/#wshobson/agents&type=date&legend=top-left)


### PR DESCRIPTION
The star history chart was removed in d72efd3 because the old embed stopped rendering due to GitHub's stargazer API restrictions. Those restrictions no longer apply to the chart's data source, so we can bring the chart back without an API token. It is restored at the same location it previously occupied in the README, right after the License section.

Fixes the broken star history visualization referenced in d72efd3.