### PR TITLE
fix(copilot): do not clear caches when install fails (#663)

### DIFF
--- a/tools/install_copilot.py
+++ b/tools/install_copilot.py
@@ -209,7 +209,8 @@ def main() -> int:
         report = install(
             repo_root=args.repo_root, config_dir=config_dir, force=args.force
         )
-        cache_cleared = _clear_copilot_cache(config_dir)
+        if report.ok:
+            cache_cleared = _clear_copilot_cache(config_dir)
     else:
         report = uninstall(repo_root=args.repo_root, config_dir=config_dir)
     _print_report(args.action, config_dir, report, cache_cleared=cache_cleared)

--- a/tools/tests/test_install_copilot.py
+++ b/tools/tests/test_install_copilot.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
-from tools.install_copilot import default_config_dir, install, uninstall
+from tools.install_copilot import default_config_dir, install, main, uninstall
 
 
 def _write_generated_copilot(repo_root: Path) -> None:
@@ -84,6 +85,79 @@ def test_force_replaces_conflicting_symlink_only(tmp_path: Path):
     assert (
         target.resolve() == (repo_root / ".copilot" / "agents" / "demo__agent.agent.md").resolve()
     )
+
+
+def test_main_does_not_clear_caches_on_failed_install(tmp_path: Path, monkeypatch):
+    repo_root = tmp_path / "repo"
+    config_dir = tmp_path / "config"
+    _write_generated_copilot(repo_root)
+
+    # Conflict: a real (non-symlink) file already at the install destination.
+    target = config_dir / "agents" / "demo__agent.agent.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("user file\n")
+
+    pkg_dir = config_dir / "pkg"
+    pkg_dir.mkdir(parents=True)
+    pkg_sentinel = pkg_dir / "sentinel.txt"
+    pkg_sentinel.write_text("pkg\n")
+
+    marketplace_cache_dir = config_dir / "marketplace-cache"
+    marketplace_cache_dir.mkdir(parents=True)
+    marketplace_sentinel = marketplace_cache_dir / "sentinel.txt"
+    marketplace_sentinel.write_text("marketplace\n")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "install_copilot.py",
+            "install",
+            "--repo-root",
+            str(repo_root),
+            "--config-dir",
+            str(config_dir),
+        ],
+    )
+
+    result = main()
+
+    assert result != 0
+    assert pkg_sentinel.exists()
+    assert marketplace_sentinel.exists()
+
+
+def test_main_clears_caches_on_successful_install(tmp_path: Path, monkeypatch):
+    repo_root = tmp_path / "repo"
+    config_dir = tmp_path / "config"
+    _write_generated_copilot(repo_root)
+
+    pkg_dir = config_dir / "pkg"
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "sentinel.txt").write_text("pkg\n")
+
+    marketplace_cache_dir = config_dir / "marketplace-cache"
+    marketplace_cache_dir.mkdir(parents=True)
+    (marketplace_cache_dir / "sentinel.txt").write_text("marketplace\n")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "install_copilot.py",
+            "install",
+            "--repo-root",
+            str(repo_root),
+            "--config-dir",
+            str(config_dir),
+        ],
+    )
+
+    result = main()
+
+    assert result == 0
+    assert not pkg_dir.exists()
+    assert not marketplace_cache_dir.exists()
 
 
 def test_uninstall_removes_only_repo_owned_symlinks(tmp_path: Path):


### PR DESCRIPTION
## Summary

- Gate `_clear_copilot_cache()` on `report.ok` in `tools/install_copilot.py::main()` so a failed install no longer wipes `pkg/` and `marketplace-cache/` before exiting non-zero.
- Add two regression tests: failed install preserves cache sentinels; successful install still clears both cache dirs.

## Scope

- [x] Quality tooling (validators, gardener, plugin-eval)

## Affected harnesses

- [x] Pure tooling / framework (no harness behavior change)

## Test plan

- [x] `uv run --project plugins/plugin-eval --extra dev pytest -q tools/tests/test_install_copilot.py` — 8 passed (new failure test confirmed failing pre-fix)
- [x] Ran ruff (check + format) + ty at CI scope on touched paths — clean

## Cross-harness portability notes

N/A

## Related issue(s)

Closes #663