### PR TITLE
fix(test): keep real-CLI smoke tests out of the ordinary test target (#664)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -153,7 +153,7 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run tools test suite
-        run: uv run pytest -q ../../tools/tests/
+        run: uv run pytest -q ../../tools/tests/ --ignore=../../tools/tests/test_cli_smoke.py
 
   multi-harness-generate:
     name: Cross-harness generation + validation

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -72,7 +72,7 @@ Three mechanical gates, each runnable as a make target and wired into CI:
 
 1. **`make validate`** — structural validation of every generated artifact. Errors block CI; warnings advisory.
 2. **`make garden`** — drift detection (dead links, stale artifacts, oversize skills, marketplace orphans). Sorted by severity with per-kind summary.
-3. **`make test`** — full pytest suite (386 tests: adapters + validators + gardener + real-source + round-trip + real-CLI smoke).
+3. **`make test`** — pytest suite (adapters + validators + gardener + real-source + round-trip). Real-CLI smoke tests are excluded; run them separately via `make smoke-test`.
 
 CI workflow: [`.github/workflows/validate.yml`](.github/workflows/validate.yml) runs all three on every PR, plus a `cli-smoke-test` job that installs OpenCode + Gemini and exercises them against the generated artifacts.
 

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ garden:
 
 # Full pytest suite — plugin-eval framework + tools/ adapters/validators/gardener.
 test:
-	uv run $(EVAL_PROJECT) pytest -q plugins/plugin-eval/ tools/tests/
+	uv run $(EVAL_PROJECT) pytest -q plugins/plugin-eval/ tools/tests/ --ignore=tools/tests/test_cli_smoke.py
 
 # Real-CLI smoke test. Generates artifacts (if not present), then invokes whichever
 # of opencode / gemini / codex / claude are on PATH. Per-CLI tests skip gracefully


### PR DESCRIPTION
## Summary

- Add `--ignore=tools/tests/test_cli_smoke.py` to the `make test` target and the CI `tools-tests` job so ordinary unit runs no longer invoke locally installed harness CLIs.
- `make smoke-test` and the dedicated `cli-smoke-test` CI job are byte-for-byte unchanged.

## Scope

- [x] CI / build / release

## Affected harnesses

- [x] Pure tooling / framework (no harness behavior change)

## Test plan

- [x] `make test` — 436 passed, 20 skipped, no harness CLI subprocesses
- [x] Collection checks: smoke module absent from ordinary target, still collectable standalone (8 tests)
- [x] validate.yml parses (yaml.safe_load)

## Cross-harness portability notes

N/A

## Related issue(s)

Closes #664