### PR TITLE
fix(plugin-eval): populate model_usage from judge and Monte Carlo layers (#660)

### DIFF
--- a/plugins/plugin-eval/src/plugin_eval/engine.py
+++ b/plugins/plugin-eval/src/plugin_eval/engine.py
@@ -124,6 +124,7 @@ class EvalEngine:
             config=self.config,
             layers=layers,
             composite=composite,
+            model_usage=self._merge_model_usage(layers),
         )
 
     def evaluate_plugin(self, plugin_dir: Path) -> PluginEvalResult:
@@ -156,6 +157,7 @@ class EvalEngine:
             config=self.config,
             layers=layers,
             composite=composite,
+            model_usage=self._merge_model_usage(layers),
         )
 
     # ------------------------------------------------------------------
@@ -312,6 +314,28 @@ class EvalEngine:
         if isinstance(token_eff, dict):
             normalized["token_efficiency"] = token_eff.get("efficiency_norm", 0.0)
         return normalized
+
+    # ------------------------------------------------------------------
+    # Model usage
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _merge_model_usage(layers: list[LayerResult]) -> dict[str, int]:
+        """Sum per-model token counts recorded by layers that made SDK calls.
+
+        Each layer that queries the Agent SDK (judge, monte_carlo) records its
+        own per-model totals in `metadata["model_usage"]`. Layers without SDK
+        calls (static) carry no such key, so a static-only run merges to {}.
+        """
+        merged: dict[str, int] = {}
+        for layer in layers:
+            usage = layer.metadata.get("model_usage")
+            if not isinstance(usage, dict):
+                continue
+            for model, tokens in usage.items():
+                if isinstance(tokens, int):
+                    merged[model] = merged.get(model, 0) + tokens
+        return merged
 
     # ------------------------------------------------------------------
     # Grading

--- a/plugins/plugin-eval/src/plugin_eval/layers/_sdk.py
+++ b/plugins/plugin-eval/src/plugin_eval/layers/_sdk.py
@@ -17,10 +17,11 @@ class SdkOutput(NamedTuple):
     result: str | None  # ResultMessage.result, if present (fallback text)
     errored: bool  # a ResultMessage reported is_error
     usage: dict[str, Any] | None  # ResultMessage.usage, if it was a dict
+    model: str | None  # AssistantMessage.model, if any assistant turn occurred
 
 
 def collect_sdk_output(messages: list) -> SdkOutput:
-    """Walk SDK messages → assistant text, result fallback, error flag, usage."""
+    """Walk SDK messages → assistant text, result fallback, error flag, usage, model."""
     from claude_agent_sdk import (  # type: ignore[import-untyped]
         AssistantMessage,
         ResultMessage,
@@ -31,8 +32,10 @@ def collect_sdk_output(messages: list) -> SdkOutput:
     result: str | None = None
     errored = False
     usage: dict[str, Any] | None = None
+    model: str | None = None
     for message in messages:
         if isinstance(message, AssistantMessage):
+            model = message.model
             for block in message.content:
                 if isinstance(block, TextBlock):
                     text += block.text
@@ -43,7 +46,7 @@ def collect_sdk_output(messages: list) -> SdkOutput:
                 result = message.result
             if isinstance(message.usage, dict):
                 usage = message.usage
-    return SdkOutput(text=text, result=result, errored=errored, usage=usage)
+    return SdkOutput(text=text, result=result, errored=errored, usage=usage, model=model)
 
 
 def usage_total_tokens(usage: dict[str, Any] | None) -> int:

--- a/plugins/plugin-eval/src/plugin_eval/layers/judge.py
+++ b/plugins/plugin-eval/src/plugin_eval/layers/judge.py
@@ -95,7 +95,9 @@ async def query_llm(
     crashing the whole evaluation.
 
     When `usage_sink` is given, the call's token usage (if any) is added to it
-    under `model`, letting callers accumulate per-model usage across calls.
+    under the SDK-reported model (falling back to the requested `model` if the
+    stream reported none), letting callers accumulate per-model usage across
+    calls even when routing or fallback selects a different model.
     """
     try:
         from claude_agent_sdk import (  # type: ignore[import-untyped]
@@ -121,9 +123,11 @@ async def query_llm(
         return {"unmeasured": True, "error": f"judge LLM call failed: {exc}"}
 
     if usage_sink is not None:
-        tokens = usage_total_tokens(collect_sdk_output(messages).usage)
+        output = collect_sdk_output(messages)
+        tokens = usage_total_tokens(output.usage)
         if tokens:
-            usage_sink[model] = usage_sink.get(model, 0) + tokens
+            usage_model = output.model or model
+            usage_sink[usage_model] = usage_sink.get(usage_model, 0) + tokens
 
     return _extract_and_parse(messages)
 
@@ -162,7 +166,6 @@ class JudgeAnalyzer:
     def __init__(self, config: JudgeConfig) -> None:
         self.config = config
         self._sem = asyncio.Semaphore(config.concurrency)
-        self.model_usage: dict[str, int] = {}
 
     # ------------------------------------------------------------------
     # Public API
@@ -171,11 +174,14 @@ class JudgeAnalyzer:
     async def analyze_skill(self, skill_or_dir: Path | ParsedSkill) -> LayerResult:
         """Run all 4 assessments concurrently and return a LayerResult."""
         skill = skill_or_dir if isinstance(skill_or_dir, ParsedSkill) else parse_skill(skill_or_dir)
+        # Local to this call so concurrent/repeated analyze_skill invocations on
+        # the same analyzer instance never mix or accumulate token counts.
+        model_usage: dict[str, int] = {}
         triggering, orchestration, output_quality, scope = await asyncio.gather(
-            self.assess_triggering(skill),
-            self.assess_orchestration(skill),
-            self.assess_output_quality(skill),
-            self.assess_scope(skill),
+            self.assess_triggering(skill, model_usage),
+            self.assess_orchestration(skill, model_usage),
+            self.assess_output_quality(skill, model_usage),
+            self.assess_scope(skill, model_usage),
         )
 
         raw_scores: dict[str, float | None] = {
@@ -197,7 +203,7 @@ class JudgeAnalyzer:
             "output_quality": output_quality,
             "scope": scope,
             "unmeasured": unmeasured,
-            "model_usage": dict(self.model_usage),
+            "model_usage": model_usage,
         }
 
         return LayerResult(
@@ -211,7 +217,9 @@ class JudgeAnalyzer:
     # Individual assessments
     # ------------------------------------------------------------------
 
-    async def assess_triggering(self, skill: Path | ParsedSkill) -> dict:
+    async def assess_triggering(
+        self, skill: Path | ParsedSkill, usage_sink: dict[str, int] | None = None
+    ) -> dict:
         """Generate 10 synthetic prompts and classify triggering accuracy via Haiku."""
         if isinstance(skill, Path):
             skill = parse_skill(skill)
@@ -242,9 +250,11 @@ Return JSON matching this schema:
 }}"""
 
         async with self._sem:
-            return await query_llm(prompt, system=system, model=model, usage_sink=self.model_usage)
+            return await query_llm(prompt, system=system, model=model, usage_sink=usage_sink)
 
-    async def assess_orchestration(self, skill: Path | ParsedSkill) -> dict:
+    async def assess_orchestration(
+        self, skill: Path | ParsedSkill, usage_sink: dict[str, int] | None = None
+    ) -> dict:
         """Rate orchestration fitness using an anchored rubric via Sonnet."""
         if isinstance(skill, Path):
             skill = parse_skill(skill)
@@ -275,9 +285,11 @@ Return JSON:
 }}"""
 
         async with self._sem:
-            return await query_llm(prompt, system=system, model=model, usage_sink=self.model_usage)
+            return await query_llm(prompt, system=system, model=model, usage_sink=usage_sink)
 
-    async def assess_output_quality(self, skill: Path | ParsedSkill) -> dict:
+    async def assess_output_quality(
+        self, skill: Path | ParsedSkill, usage_sink: dict[str, int] | None = None
+    ) -> dict:
         """Simulate 3 tasks and judge output quality via Sonnet."""
         if isinstance(skill, Path):
             skill = parse_skill(skill)
@@ -304,9 +316,11 @@ Return JSON:
 }}"""
 
         async with self._sem:
-            return await query_llm(prompt, system=system, model=model, usage_sink=self.model_usage)
+            return await query_llm(prompt, system=system, model=model, usage_sink=usage_sink)
 
-    async def assess_scope(self, skill: Path | ParsedSkill) -> dict:
+    async def assess_scope(
+        self, skill: Path | ParsedSkill, usage_sink: dict[str, int] | None = None
+    ) -> dict:
         """Evaluate scope calibration using an anchored rubric via Sonnet."""
         if isinstance(skill, Path):
             skill = parse_skill(skill)
@@ -333,4 +347,4 @@ Return JSON:
 }}"""
 
         async with self._sem:
-            return await query_llm(prompt, system=system, model=model, usage_sink=self.model_usage)
+            return await query_llm(prompt, system=system, model=model, usage_sink=usage_sink)

--- a/plugins/plugin-eval/src/plugin_eval/layers/judge.py
+++ b/plugins/plugin-eval/src/plugin_eval/layers/judge.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from plugin_eval.layers._sdk import collect_sdk_output
+from plugin_eval.layers._sdk import collect_sdk_output, usage_total_tokens
 from plugin_eval.models import LayerResult
 from plugin_eval.parser import ParsedSkill, parse_skill
 
@@ -82,12 +82,20 @@ def _extract_and_parse(messages: list) -> dict:
         return {"unmeasured": True, "error": "judge response was not valid JSON", "raw": raw}
 
 
-async def query_llm(prompt: str, system: str = "", model: str = "claude-sonnet-5") -> dict:
+async def query_llm(
+    prompt: str,
+    system: str = "",
+    model: str = "claude-sonnet-5",
+    usage_sink: dict[str, int] | None = None,
+) -> dict:
     """Call Claude via the Agent SDK and return a parsed JSON dict.
 
     Degrades to an {"unmeasured": True, ...} marker (never raises) when the SDK
     is missing or the call fails, so the judge layer can be skipped instead of
     crashing the whole evaluation.
+
+    When `usage_sink` is given, the call's token usage (if any) is added to it
+    under `model`, letting callers accumulate per-model usage across calls.
     """
     try:
         from claude_agent_sdk import (  # type: ignore[import-untyped]
@@ -111,6 +119,11 @@ async def query_llm(prompt: str, system: str = "", model: str = "claude-sonnet-5
         ]
     except Exception as exc:  # noqa: BLE001 — judge is best-effort; degrade to unmeasured
         return {"unmeasured": True, "error": f"judge LLM call failed: {exc}"}
+
+    if usage_sink is not None:
+        tokens = usage_total_tokens(collect_sdk_output(messages).usage)
+        if tokens:
+            usage_sink[model] = usage_sink.get(model, 0) + tokens
 
     return _extract_and_parse(messages)
 
@@ -149,6 +162,7 @@ class JudgeAnalyzer:
     def __init__(self, config: JudgeConfig) -> None:
         self.config = config
         self._sem = asyncio.Semaphore(config.concurrency)
+        self.model_usage: dict[str, int] = {}
 
     # ------------------------------------------------------------------
     # Public API
@@ -183,6 +197,7 @@ class JudgeAnalyzer:
             "output_quality": output_quality,
             "scope": scope,
             "unmeasured": unmeasured,
+            "model_usage": dict(self.model_usage),
         }
 
         return LayerResult(
@@ -227,7 +242,7 @@ Return JSON matching this schema:
 }}"""
 
         async with self._sem:
-            return await query_llm(prompt, system=system, model=model)
+            return await query_llm(prompt, system=system, model=model, usage_sink=self.model_usage)
 
     async def assess_orchestration(self, skill: Path | ParsedSkill) -> dict:
         """Rate orchestration fitness using an anchored rubric via Sonnet."""
@@ -260,7 +275,7 @@ Return JSON:
 }}"""
 
         async with self._sem:
-            return await query_llm(prompt, system=system, model=model)
+            return await query_llm(prompt, system=system, model=model, usage_sink=self.model_usage)
 
     async def assess_output_quality(self, skill: Path | ParsedSkill) -> dict:
         """Simulate 3 tasks and judge output quality via Sonnet."""
@@ -289,7 +304,7 @@ Return JSON:
 }}"""
 
         async with self._sem:
-            return await query_llm(prompt, system=system, model=model)
+            return await query_llm(prompt, system=system, model=model, usage_sink=self.model_usage)
 
     async def assess_scope(self, skill: Path | ParsedSkill) -> dict:
         """Evaluate scope calibration using an anchored rubric via Sonnet."""
@@ -318,4 +333,4 @@ Return JSON:
 }}"""
 
         async with self._sem:
-            return await query_llm(prompt, system=system, model=model)
+            return await query_llm(prompt, system=system, model=model, usage_sink=self.model_usage)

--- a/plugins/plugin-eval/src/plugin_eval/layers/monte_carlo.py
+++ b/plugins/plugin-eval/src/plugin_eval/layers/monte_carlo.py
@@ -33,6 +33,7 @@ class SimResult:
     duration_ms: int
     errored: bool = False
     prompt: str = ""
+    model: str | None = None
 
 
 @dataclass
@@ -69,6 +70,7 @@ def _simresult_from_messages(messages: list, prompt: str, duration_ms: int) -> S
         duration_ms=duration_ms,
         errored=output.errored,
         prompt=prompt,
+        model=output.model,
     )
 
 
@@ -128,7 +130,10 @@ class MonteCarloAnalyzer:
         skill = skill_or_dir if isinstance(skill_or_dir, ParsedSkill) else parse_skill(skill_or_dir)
         skill_content = skill.raw_content
 
-        prompts = await self._generate_prompts(skill.name, skill.description)
+        model_usage: dict[str, int] = {}
+        prompts = await self._generate_prompts(
+            skill.name, skill.description, usage_sink=model_usage
+        )
 
         # Repeat prompts to reach n_runs
         repeated: list[str] = []
@@ -138,6 +143,11 @@ class MonteCarloAnalyzer:
 
         results = await self._run_all(skill_content, prompts_to_run)
         stats = self._compute_statistics(results)
+
+        # Aggregate per-sim token usage by the model the SDK actually reported.
+        for r in results:
+            if r.model and r.tokens:
+                model_usage[r.model] = model_usage.get(r.model, 0) + r.tokens
 
         triggering = stats["triggering"]
         output_consistency = stats["output_consistency"]
@@ -169,6 +179,7 @@ class MonteCarloAnalyzer:
             "n_runs": len(results),
             "n_activated": sum(1 for r in results if r.activated),
             "n_errored": sum(1 for r in results if r.errored),
+            "model_usage": model_usage,
         }
 
         return LayerResult(
@@ -182,7 +193,9 @@ class MonteCarloAnalyzer:
     # Prompt generation
     # ------------------------------------------------------------------
 
-    async def _generate_prompts(self, name: str, description: str) -> list[str]:
+    async def _generate_prompts(
+        self, name: str, description: str, usage_sink: dict[str, int] | None = None
+    ) -> list[str]:
         """Use Haiku to generate 15 varied prompts. Falls back to basic variants."""
         try:
             from plugin_eval.layers.judge import query_llm
@@ -198,7 +211,7 @@ class MonteCarloAnalyzer:
                 f"Description: {description}\n\n"
                 f'Return a JSON array of 15 strings. Example: ["prompt 1", "prompt 2", ...]'
             )
-            result = await query_llm(prompt, system=system, model=model)
+            result = await query_llm(prompt, system=system, model=model, usage_sink=usage_sink)
             if isinstance(result, list) and len(result) >= 5:
                 return [str(p) for p in result[:15]]
         except Exception:

--- a/plugins/plugin-eval/tests/test_engine.py
+++ b/plugins/plugin-eval/tests/test_engine.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 from plugin_eval.engine import EvalEngine
-from plugin_eval.models import Depth, EvalConfig, PluginEvalResult
+from plugin_eval.models import Depth, EvalConfig, LayerResult, PluginEvalResult
 
 
 class TestEvalEngine:
@@ -40,3 +40,43 @@ class TestEvalEngine:
         )
         assert blended["triggering_accuracy"] > 0
         assert blended["orchestration_fitness"] > 0
+
+    def test_quick_eval_skill_has_empty_model_usage(self, sample_skill_dir: Path):
+        """Static-only (quick) runs never touch the SDK, so model_usage stays empty."""
+        config = EvalConfig(depth=Depth.QUICK)
+        engine = EvalEngine(config)
+        result = engine.evaluate_skill(sample_skill_dir)
+        assert result.model_usage == {}
+
+
+class TestMergeModelUsage:
+    """EvalEngine._merge_model_usage sums per-model tokens across layers."""
+
+    def test_merges_disjoint_models_across_layers(self):
+        layers = [
+            LayerResult(layer="static", score=0.9),
+            LayerResult(
+                layer="judge", score=0.8, metadata={"model_usage": {"claude-haiku-4-5": 10}}
+            ),
+            LayerResult(
+                layer="monte_carlo", score=0.7, metadata={"model_usage": {"claude-sonnet-5": 500}}
+            ),
+        ]
+        merged = EvalEngine._merge_model_usage(layers)
+        assert merged == {"claude-haiku-4-5": 10, "claude-sonnet-5": 500}
+
+    def test_sums_the_same_model_name_across_layers(self):
+        layers = [
+            LayerResult(
+                layer="judge", score=0.8, metadata={"model_usage": {"claude-sonnet-5": 300}}
+            ),
+            LayerResult(
+                layer="monte_carlo", score=0.7, metadata={"model_usage": {"claude-sonnet-5": 500}}
+            ),
+        ]
+        merged = EvalEngine._merge_model_usage(layers)
+        assert merged == {"claude-sonnet-5": 800}
+
+    def test_static_only_layers_merge_to_empty(self):
+        layers = [LayerResult(layer="static", score=0.9)]
+        assert EvalEngine._merge_model_usage(layers) == {}

--- a/plugins/plugin-eval/tests/test_judge.py
+++ b/plugins/plugin-eval/tests/test_judge.py
@@ -23,7 +23,7 @@ def _assistant(text: str) -> AssistantMessage:
 
 
 def _result(
-    *, is_error: bool = False, result: str | None = None, usage: dict | None = None
+    *, is_error: bool = False, result: str | None = None, usage: dict[str, int] | None = None
 ) -> ResultMessage:
     return ResultMessage(
         subtype="success" if not is_error else "error",
@@ -215,6 +215,26 @@ class TestQueryLlmUsageSink:
         result = await query_llm("prompt", model="claude-sonnet-5")
         assert result["unmeasured"] is True
 
+    @pytest.mark.asyncio
+    @patch("claude_agent_sdk.query")
+    async def test_usage_attributed_to_sdk_reported_model_not_requested_model(self, mock_query):
+        # The stream reports a different model than was requested (e.g. routing
+        # or fallback substituted the model actually used to serve the call).
+        async def fake_stream(*, prompt, options):
+            yield AssistantMessage(
+                content=[TextBlock(text='{"score": 0.8}')], model="claude-haiku-4-5-20251001"
+            )
+            yield _result(usage={"input_tokens": 3, "output_tokens": 4})
+
+        mock_query.side_effect = fake_stream
+        sink: dict[str, int] = {}
+
+        result = await query_llm("prompt", model="claude-sonnet-5", usage_sink=sink)
+
+        assert result == {"score": 0.8}
+        # Keyed by the SDK-reported model, not the model that was requested.
+        assert sink == {"claude-haiku-4-5-20251001": 7}
+
 
 class TestJudgeAnalyzerModelUsage:
     """The judge layer's SDK token usage flows into LayerResult.metadata."""
@@ -228,7 +248,13 @@ class TestJudgeAnalyzerModelUsage:
         async def fake_query_llm(prompt, system="", model="claude-sonnet-5", usage_sink=None):
             if usage_sink is not None:
                 usage_sink[model] = usage_sink.get(model, 0) + 10
-            return {"f1": 0.9, "score": 0.9, "assessment": "ok", "predictions": [], "simulations": []}
+            return {
+                "f1": 0.9,
+                "score": 0.9,
+                "assessment": "ok",
+                "predictions": [],
+                "simulations": [],
+            }
 
         mock_query.side_effect = fake_query_llm
         analyzer = JudgeAnalyzer(JudgeConfig())
@@ -239,4 +265,36 @@ class TestJudgeAnalyzerModelUsage:
             "claude-haiku-4-5-20251001": 10,
             "claude-sonnet-5": 30,
         }
-        assert analyzer.model_usage == result.metadata["model_usage"]
+
+    @pytest.mark.asyncio
+    @patch("plugin_eval.layers.judge.query_llm")
+    async def test_repeated_analyze_skill_does_not_leak_usage_across_calls(
+        self, mock_query, sample_skill_dir: Path
+    ):
+        # A reused JudgeAnalyzer must not carry token totals from an earlier
+        # analyze_skill call into a later one's metadata.
+        async def fake_query_llm(prompt, system="", model="claude-sonnet-5", usage_sink=None):
+            if usage_sink is not None:
+                usage_sink[model] = usage_sink.get(model, 0) + 10
+            return {
+                "f1": 0.9,
+                "score": 0.9,
+                "assessment": "ok",
+                "predictions": [],
+                "simulations": [],
+            }
+
+        mock_query.side_effect = fake_query_llm
+        analyzer = JudgeAnalyzer(JudgeConfig())
+
+        first = await analyzer.analyze_skill(sample_skill_dir)
+        second = await analyzer.analyze_skill(sample_skill_dir)
+
+        assert (
+            first.metadata["model_usage"]
+            == second.metadata["model_usage"]
+            == {
+                "claude-haiku-4-5-20251001": 10,
+                "claude-sonnet-5": 30,
+            }
+        )

--- a/plugins/plugin-eval/tests/test_judge.py
+++ b/plugins/plugin-eval/tests/test_judge.py
@@ -14,6 +14,7 @@ from plugin_eval.layers.judge import (  # noqa: E402
     JudgeConfig,
     _extract_and_parse,
     _measured_score,
+    query_llm,
 )
 
 
@@ -21,7 +22,9 @@ def _assistant(text: str) -> AssistantMessage:
     return AssistantMessage(content=[TextBlock(text=text)], model="claude-sonnet-5")
 
 
-def _result(*, is_error: bool = False, result: str | None = None) -> ResultMessage:
+def _result(
+    *, is_error: bool = False, result: str | None = None, usage: dict | None = None
+) -> ResultMessage:
     return ResultMessage(
         subtype="success" if not is_error else "error",
         duration_ms=1,
@@ -30,6 +33,7 @@ def _result(*, is_error: bool = False, result: str | None = None) -> ResultMessa
         num_turns=1,
         session_id="t",
         result=result,
+        usage=usage,
     )
 
 
@@ -165,3 +169,74 @@ class TestWhitespaceFallback:
     def test_whitespace_text_falls_back_to_result(self):
         out = _extract_and_parse([_assistant("   \n"), _result(result='{"f1": 1.0}')])
         assert out == {"f1": 1.0}
+
+
+class TestQueryLlmUsageSink:
+    """query_llm accumulates real SDK token usage into a caller-provided sink."""
+
+    @pytest.mark.asyncio
+    @patch("claude_agent_sdk.query")
+    async def test_usage_sink_receives_token_totals(self, mock_query):
+        async def fake_stream(*, prompt, options):
+            yield _assistant('{"score": 0.8}')
+            yield _result(usage={"input_tokens": 3, "output_tokens": 4})
+
+        mock_query.side_effect = fake_stream
+        sink: dict[str, int] = {}
+
+        result = await query_llm("prompt", model="claude-sonnet-5", usage_sink=sink)
+
+        assert result == {"score": 0.8}
+        assert sink == {"claude-sonnet-5": 7}
+
+    @pytest.mark.asyncio
+    @patch("claude_agent_sdk.query")
+    async def test_usage_sink_accumulates_across_calls_for_same_model(self, mock_query):
+        async def fake_stream(*, prompt, options):
+            yield _result(usage={"input_tokens": 5, "output_tokens": 5})
+
+        mock_query.side_effect = fake_stream
+        sink: dict[str, int] = {}
+
+        await query_llm("p1", model="claude-sonnet-5", usage_sink=sink)
+        await query_llm("p2", model="claude-sonnet-5", usage_sink=sink)
+
+        assert sink == {"claude-sonnet-5": 20}
+
+    @pytest.mark.asyncio
+    @patch("claude_agent_sdk.query")
+    async def test_no_sink_means_no_tracking(self, mock_query):
+        async def fake_stream(*, prompt, options):
+            yield _result(usage={"input_tokens": 5, "output_tokens": 5})
+
+        mock_query.side_effect = fake_stream
+
+        # Must not raise when usage_sink is omitted (default None).
+        result = await query_llm("prompt", model="claude-sonnet-5")
+        assert result["unmeasured"] is True
+
+
+class TestJudgeAnalyzerModelUsage:
+    """The judge layer's SDK token usage flows into LayerResult.metadata."""
+
+    @pytest.mark.asyncio
+    @patch("plugin_eval.layers.judge.query_llm")
+    async def test_analyze_skill_records_model_usage(self, mock_query, sample_skill_dir: Path):
+        # Mirror query_llm's real usage_sink contract: each fake call adds its
+        # tokens under the model it was invoked with, exactly like the real
+        # SDK-backed implementation this test stands in for.
+        async def fake_query_llm(prompt, system="", model="claude-sonnet-5", usage_sink=None):
+            if usage_sink is not None:
+                usage_sink[model] = usage_sink.get(model, 0) + 10
+            return {"f1": 0.9, "score": 0.9, "assessment": "ok", "predictions": [], "simulations": []}
+
+        mock_query.side_effect = fake_query_llm
+        analyzer = JudgeAnalyzer(JudgeConfig())
+        result = await analyzer.analyze_skill(sample_skill_dir)
+
+        # triggering runs on haiku; orchestration/output_quality/scope on sonnet.
+        assert result.metadata["model_usage"] == {
+            "claude-haiku-4-5-20251001": 10,
+            "claude-sonnet-5": 30,
+        }
+        assert analyzer.model_usage == result.metadata["model_usage"]

--- a/plugins/plugin-eval/tests/test_monte_carlo.py
+++ b/plugins/plugin-eval/tests/test_monte_carlo.py
@@ -94,6 +94,14 @@ class TestSimResultFromMessages:
         )
         assert sim.tokens == 7
 
+    def test_model_captured_from_assistant_message(self):
+        sim = _simresult_from_messages([_assistant("hi"), _result()], "p", 10)
+        assert sim.model == "claude-sonnet-5"
+
+    def test_model_is_none_without_an_assistant_message(self):
+        sim = _simresult_from_messages([_result(result="x" * 250)], "p", 10)
+        assert sim.model is None
+
 
 class TestSimResult:
     def test_sim_result(self):
@@ -150,6 +158,51 @@ class TestMonteCarloAnalyzer:
         assert stats["triggering"]["n_activated"] == 2
         assert stats["triggering"]["activation_rate"] == pytest.approx(0.5)
         assert stats["failure_rate"]["p_fail"] == pytest.approx(0.5)
+
+
+class TestMonteCarloModelUsage:
+    """Per-sim token usage aggregates by the model the SDK actually reported."""
+
+    @pytest.mark.asyncio
+    @patch("plugin_eval.layers.judge.query_llm")
+    @patch("plugin_eval.layers.monte_carlo.run_simulation")
+    async def test_analyze_skill_records_model_usage(
+        self, mock_sim, mock_query_llm, sample_skill_dir: Path
+    ):
+        # Prompt generation also calls query_llm (Haiku); force the fallback
+        # path so this test's usage total reflects only the sims below.
+        mock_query_llm.return_value = {"unmeasured": True}
+        mock_sim.return_value = SimResult(
+            activated=True,
+            quality_score=0.82,
+            tokens=2800,
+            duration_ms=1500,
+            model="claude-sonnet-5",
+        )
+        config = MonteCarloConfig(n_runs=10, concurrency=2)
+        analyzer = MonteCarloAnalyzer(config)
+        result = await analyzer.analyze_skill(sample_skill_dir)
+
+        assert result.metadata["model_usage"] == {"claude-sonnet-5": 28000}
+
+    @pytest.mark.asyncio
+    @patch("plugin_eval.layers.judge.query_llm")
+    @patch("plugin_eval.layers.monte_carlo.run_simulation")
+    async def test_sims_without_a_reported_model_are_not_attributed(
+        self, mock_sim, mock_query_llm, sample_skill_dir: Path
+    ):
+        # run_simulation's exception path (and any stream lacking an
+        # AssistantMessage) leaves model=None -- those tokens can't be
+        # attributed to a model and must be skipped, not mis-keyed under "None".
+        mock_query_llm.return_value = {"unmeasured": True}
+        mock_sim.return_value = SimResult(
+            activated=False, quality_score=0.0, tokens=0, duration_ms=0, errored=True, model=None
+        )
+        config = MonteCarloConfig(n_runs=5, concurrency=2)
+        analyzer = MonteCarloAnalyzer(config)
+        result = await analyzer.analyze_skill(sample_skill_dir)
+
+        assert result.metadata["model_usage"] == {}
 
 
 class TestUsageTotalTokens:

--- a/plugins/plugin-eval/tests/test_reporter.py
+++ b/plugins/plugin-eval/tests/test_reporter.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 
 from plugin_eval.engine import EvalEngine
-from plugin_eval.models import Depth, EvalConfig
+from plugin_eval.models import CompositeResult, Depth, EvalConfig, PluginEvalResult
 from plugin_eval.reporter import Reporter, _effective_depth
 
 
@@ -30,6 +30,35 @@ class TestReporter:
         assert "Overall Score" in output
         assert "Layer Breakdown" in output
         assert "Dimension Scores" in output
+
+
+class TestModelUsageSection:
+    def test_static_only_run_shows_no_model_usage_line(self, sample_skill_dir: Path):
+        config = EvalConfig(depth=Depth.QUICK)
+        engine = EvalEngine(config)
+        result = engine.evaluate_skill(sample_skill_dir)
+        assert result.model_usage == {}
+
+        output = Reporter().to_markdown(result)
+        assert "_No model usage (static-only evaluation)._" in output
+        assert "| Model | Tokens |" not in output
+
+    def test_populated_model_usage_renders_per_model_rows(self, sample_skill_dir: Path):
+        result = PluginEvalResult(
+            plugin_path=str(sample_skill_dir),
+            timestamp="2026-01-01T00:00:00Z",
+            config=EvalConfig(depth=Depth.DEEP),
+            layers=[],
+            composite=CompositeResult(score=80.0),
+            model_usage={"claude-sonnet-5": 12345, "claude-haiku-4-5-20251001": 678},
+        )
+
+        output = Reporter().to_markdown(result)
+
+        assert "| Model | Tokens |" in output
+        assert "| claude-sonnet-5 | 12,345 |" in output
+        assert "| claude-haiku-4-5-20251001 | 678 |" in output
+        assert "_No model usage (static-only evaluation)._" not in output
 
 
 class TestDepthDowngradeWarning:


### PR DESCRIPTION
## Summary

- Capture the SDK-reported model in `SdkOutput`, thread an optional `usage_sink` through `query_llm()` (all four judge assessments) and Monte Carlo prompt-generation, and aggregate per-sim tokens by model.
- New `EvalEngine._merge_model_usage()` sums per-model totals across layers and populates `PluginEvalResult.model_usage` at both construction sites, so the report's Model Usage section now shows real per-model token counts; static-only runs still correctly print the static-only message.
- Tests for judge sink accumulation, Monte Carlo aggregation, engine merge, and reporter rendering — all SDK calls mocked.

## Scope

- [x] Quality tooling (validators, gardener, plugin-eval)

## Affected harnesses

- [x] Pure tooling / framework (no harness behavior change)

## Test plan

- [x] plugin-eval suite: 151 passed
- [x] `uv run ruff check src/plugin_eval/`, `ruff format --check`, `ty check` — all clean at CI scope

## Cross-harness portability notes

N/A

## Related issue(s)

Closes #660