### PR TITLE
Add eskill plugin — meta-skill to build top-tier Agent Skills

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -561,6 +561,19 @@
       "category": "Coding"
     },
     {
+      "name": "eskill",
+      "description": "Meta-skill to build top-tier Agent Skills: spec-compliant SKILL.md, eval loop, validator, market research, numbered-output pipeline",
+      "source": {
+        "source": "local",
+        "path": "./plugins/eskill"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_USE"
+      },
+      "category": "Coding"
+    },
+    {
       "name": "file-conversion",
       "description": "Convert files between 999 routes \u2014 PDF to Word, HEIC to JPG, MP4 to MP3, CSV to JSON, EPUB to MOBI \u2014 via the free ChangeThisFile API. MCP-aware with a zero-dependency script fallback; no API key required.",
       "source": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
     {
       "name": "documentation-standards",
       "source": "./plugins/documentation-standards",
-      "description": "HADS (Human-AI Document Standard) \u2014 semantic tagging convention for writing docs that work efficiently for both humans and AI models. Reduces token consumption by separating machine-critical facts from human context.",
+      "description": "HADS (Human-AI Document Standard) — semantic tagging convention for writing docs that work efficiently for both humans and AI models. Reduces token consumption by separating machine-critical facts from human context.",
       "version": "1.0.1",
       "author": {
         "name": "Niksa Barlovic",
@@ -754,7 +754,7 @@
     {
       "name": "social-publishing",
       "source": "./plugins/social-publishing",
-      "description": "Schedule and publish social media posts across 13 platforms (X, LinkedIn Profile + Page, Instagram Business + Standalone, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, Pinterest) via SocialClaw \u2014 one workspace API key covers everything",
+      "description": "Schedule and publish social media posts across 13 platforms (X, LinkedIn Profile + Page, Instagram Business + Standalone, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, Pinterest) via SocialClaw — one workspace API key covers everything",
       "version": "1.0.0",
       "author": {
         "name": "ndesv21",
@@ -974,7 +974,7 @@
     },
     {
       "name": "dgx-spark-ops",
-      "description": "NVIDIA DGX Spark (GB10) environment operations. Use when setting up, preflighting, or debugging ML workloads on DGX Spark or aarch64 Blackwell hardware \u2014 CUDA-13 wheel/ABI checks, unified-memory OOM ladders, thermal monitoring.",
+      "description": "NVIDIA DGX Spark (GB10) environment operations. Use when setting up, preflighting, or debugging ML workloads on DGX Spark or aarch64 Blackwell hardware — CUDA-13 wheel/ABI checks, unified-memory OOM ladders, thermal monitoring.",
       "version": "1.0.0",
       "author": {
         "name": "Seth Hobson",
@@ -991,7 +991,7 @@
       "description": "Binary reverse engineering, malware analysis, firmware security, and software protection research for authorized security research, CTF competitions, and defensive security",
       "version": "1.0.1",
       "author": {
-        "name": "D\u00e1vid Balatoni",
+        "name": "Dávid Balatoni",
         "url": "https://github.com/balcsida"
       },
       "homepage": "https://github.com/wshobson/agents",
@@ -1000,7 +1000,7 @@
     },
     {
       "name": "conductor",
-      "description": "Context-Driven Development plugin that transforms Claude Code into a project management tool with structured workflow: Context \u2192 Spec & Plan \u2192 Implement",
+      "description": "Context-Driven Development plugin that transforms Claude Code into a project management tool with structured workflow: Context → Spec & Plan → Implement",
       "version": "1.2.2",
       "author": {
         "name": "Seth Hobson",
@@ -1119,7 +1119,7 @@
     {
       "name": "protect-mcp",
       "source": "./plugins/protect-mcp",
-      "description": "Cedar policy enforcement + Ed25519 signed receipts for every Claude Code tool call. First cryptographic governance plugin \u2014 decisions are policy-gated before they run and every decision produces a tamper-evident receipt verifiable offline.",
+      "description": "Cedar policy enforcement + Ed25519 signed receipts for every Claude Code tool call. First cryptographic governance plugin — decisions are policy-gated before they run and every decision produces a tamper-evident receipt verifiable offline.",
       "version": "0.1.1",
       "author": {
         "name": "Tom Farley",
@@ -1189,7 +1189,7 @@
     {
       "name": "ship-mate",
       "source": "./plugins/ship-mate",
-      "description": "Your AI development teammate. Turns a story file into a shipped, reviewed, and tested feature via orchestrator \u2192 architect \u2192 developer \u2192 PR reviewer \u2192 QA \u2192 Playwright.",
+      "description": "Your AI development teammate. Turns a story file into a shipped, reviewed, and tested feature via orchestrator → architect → developer → PR reviewer → QA → Playwright.",
       "version": "1.0.1",
       "author": {
         "name": "Pranay Yadav",
@@ -1212,7 +1212,7 @@
     {
       "name": "file-conversion",
       "source": "./plugins/file-conversion",
-      "description": "Convert files between 999 routes \u2014 PDF to Word, HEIC to JPG, MP4 to MP3, CSV to JSON, EPUB to MOBI \u2014 via the free ChangeThisFile API. MCP-aware with a zero-dependency script fallback; no API key required.",
+      "description": "Convert files between 999 routes — PDF to Word, HEIC to JPG, MP4 to MP3, CSV to JSON, EPUB to MOBI — via the free ChangeThisFile API. MCP-aware with a zero-dependency script fallback; no API key required.",
       "version": "1.0.0",
       "author": {
         "name": "Aadil Razvi",
@@ -1253,6 +1253,19 @@
         "deck-generation",
         "slide-design"
       ]
+    },
+    {
+      "name": "eskill",
+      "source": "./plugins/eskill",
+      "description": "Meta-skill to build top-tier Agent Skills: spec-compliant SKILL.md, eval loop, validator, market research, numbered-output pipeline (MIT)",
+      "version": "1.4.1",
+      "author": {
+        "name": "Hedra Lab",
+        "url": "https://github.com/hedralab"
+      },
+      "homepage": "https://github.com/hedralab/eskill",
+      "license": "MIT",
+      "category": "development"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -486,6 +486,17 @@
       "license": "MIT"
     },
     {
+      "name": "eskill",
+      "source": "./plugins/eskill",
+      "version": "1.4.1",
+      "description": "Meta-skill to build top-tier Agent Skills: spec-compliant SKILL.md, eval loop, validator, market research, numbered-output pipeline",
+      "author": {
+        "name": "Hedra Lab",
+        "email": ""
+      },
+      "license": "MIT"
+    },
+    {
       "name": "file-conversion",
       "source": "./plugins/file-conversion",
       "version": "1.0.0",

--- a/.cursor-plugin/plugins/eskill.json
+++ b/.cursor-plugin/plugins/eskill.json
@@ -1,0 +1,11 @@
+{
+  "name": "eskill",
+  "displayName": "Eskill",
+  "version": "1.4.1",
+  "description": "Meta-skill to build top-tier Agent Skills: spec-compliant SKILL.md, eval loop, validator, market research, numbered-output pipeline",
+  "author": {
+    "name": "Hedra Lab",
+    "email": ""
+  },
+  "license": "MIT"
+}

--- a/plugins/eskill/.claude-plugin/plugin.json
+++ b/plugins/eskill/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "eskill",
+  "version": "1.4.1",
+  "description": "Meta-skill to build top-tier Agent Skills: spec-compliant SKILL.md, eval loop, validator, market research, numbered-output pipeline",
+  "author": {
+    "name": "Hedra Lab",
+    "url": "https://github.com/hedralab"
+  },
+  "license": "MIT"
+}

--- a/plugins/eskill/.codex-plugin/plugin.json
+++ b/plugins/eskill/.codex-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "eskill",
+  "version": "1.4.1",
+  "description": "Meta-skill to build top-tier Agent Skills: spec-compliant SKILL.md, eval loop, validator, market research, numbered-output pipeline",
+  "skills": "./skills/",
+  "author": {
+    "name": "Hedra Lab",
+    "url": "https://github.com/hedralab"
+  },
+  "license": "MIT",
+  "interface": {
+    "displayName": "Eskill",
+    "shortDescription": "Meta-skill to build top-tier Agent Skills: spec-compliant SKILL.md, eval loop, validator, market research\u2026",
+    "category": "Coding"
+  }
+}

--- a/plugins/eskill/skills/eskill/.gitignore
+++ b/plugins/eskill/skills/eskill/.gitignore
@@ -1,0 +1,18 @@
+# macOS
+.DS_Store
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+
+# Packaging — zip bản phát hành không đẩy lên repo
+*.zip
+*.tar.gz
+
+# Local scratch
+*.bak
+
+# Secrets — khong bao gio commit
+.env
+*.log

--- a/plugins/eskill/skills/eskill/.pre-commit-config.yaml
+++ b/plugins/eskill/skills/eskill/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+# Pre-commit hooks — cài: pip install pre-commit && pre-commit install
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: ["--maxkb=500"]

--- a/plugins/eskill/skills/eskill/.version-bump.json
+++ b/plugins/eskill/skills/eskill/.version-bump.json
@@ -1,0 +1,14 @@
+{
+  "version": "1.4.1",
+  "bump": "patch",
+  "sync_files": [
+    "SKILL.md",
+    "README.md",
+    "eval-results.json",
+    "RELEASE-NOTES.md",
+    ".claude-plugin/plugin.json",
+    ".codex-plugin/plugin.json",
+    ".cursor-plugin/plugin.json"
+  ],
+  "tag_prefix": "v"
+}

--- a/plugins/eskill/skills/eskill/CODE_OF_CONDUCT.md
+++ b/plugins/eskill/skills/eskill/CODE_OF_CONDUCT.md
@@ -1,0 +1,36 @@
+# Contributor Covenant Code of Conduct
+
+## Cam kết của chúng tôi
+
+Vì lợi ích của một môi trường mở và thân thiện, chúng tôi cam kết
+tham gia cộng đồng eSkill không có quấy rối, bất kể tuổi tác, ngoại hình,
+khuyết tật, dân tộc, bản dạng/giới tính, trình độ kinh nghiệm, quốc tịch,
+ngoại hình cá nhân, chủng tộc, tôn giáo hoặc khuynh hướng tình dục.
+
+## Chuẩn mực
+
+**Hành vi tích cực:**
+- Dùng ngôn ngữ thân thiện, hòa nhập
+- Tôn trọng quan điểm và kinh nghiệm khác nhau
+- Tiếp nhận phản hồi xây dựng
+- Hướng tới lợi ích cộng đồng
+
+**Hành vi không được chấp nhận:**
+- Ngôn ngữ/hình ảnh tình dục hóa
+- Troll, insult, comment công kích cá nhân
+- Quấy rối công khai hoặc riêng tư
+- Công bố thông tin riêng tư của người khác mà không được phép
+
+## Phạm vi
+
+Áp dụng trong mọi không gian cộng đồng và khi đại diện dự án công khai.
+
+## Thực thi
+
+Maintainer có quyền xóa, chỉnh sửa hoặc từ chối bình luận, commit, code,
+wiki edit, issue không phù hợp, và có thể cấm tạm thời hoặc vĩnh viễn
+bất kỳ contributor nào vi phạm.
+
+## Attribution
+
+Bản này phỏng theo [Contributor Covenant v1.4](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html).

--- a/plugins/eskill/skills/eskill/LICENSE
+++ b/plugins/eskill/skills/eskill/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Hedra
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/eskill/skills/eskill/README.md
+++ b/plugins/eskill/skills/eskill/README.md
@@ -1,0 +1,93 @@
+# eSkill — Meta-skill: build top-tier Agent Skills
+
+eSkill is the **skill for creating skills** — a production workflow distilled from the
+official [Agent Skills spec](https://agentskills.io/specification), Anthropic's
+[skill-creator](https://github.com/anthropics/skills) eval loop, and real lessons from
+building/shipping egram + the eSeed project.
+
+## What it gives you
+
+- **6-step process** to design, write, test and ship a skill (ask-first → pick a proven
+  standard as "north star" → write spec-compliant SKILL.md → package known pitfalls →
+  eval loop → pin activation)
+- **Spec rules**: frontmatter (name/description/license/compatibility/metadata),
+  progressive disclosure (<500 lines), 1-level references
+- **Eval loop**: forward-test with real-looking prompts, qualitative + quantitative review
+- **Naming** (Apple-style e-family: `e` + one word — eSkill, eSeed, egram)
+- **Commercial checklist**: leak scan (`--leak --brand`), LICENSE, README sync, marketplace
+- **Validator**: `scripts/validate-skill.py` — catches broken frontmatter, bad names,
+  broken refs, oversized SKILL.md, and leaks
+
+## Quickstart (3 prompts)
+
+1. `Create a skill that <does X> and check it works` — eSkill interviews you, then builds it
+2. `Improve this skill: <path>` — eSkill applies the eval loop and fixes it
+3. `Validate this skill: <path> [--leak]` — run the validator
+
+## Structure
+
+```
+eskill/
+├── SKILL.md                     # 6-step process + golden rules (Vietnamese — user-facing)
+├── README.md                    # This file (English — public-facing)
+├── LICENSE                      # MIT
+├── RELEASE-NOTES.md             # changelog (Keep a Changelog + semver)
+├── .version-bump.json           # current version + files to sync on bump
+├── CODE_OF_CONDUCT.md           # contributor covenant
+├── .gitignore · .pre-commit-config.yaml
+├── agents/openai.yaml           # marketplace/UI metadata
+├── .claude-plugin/ · .codex-plugin/ · .cursor-plugin/   # plugin manifests
+├── .github/                     # FUNDING + issue/PR templates
+├── assets/                      # icon
+├── template/SKILL.md            # copy-ready skill skeleton (full frontmatter)
+├── references/
+│   ├── spec-rules.md            # agentskills.io spec rules
+│   ├── naming.md                # Apple-style e-family naming
+│   ├── sales-discovery.md       # SPIN + Mom Test (step-0 interview)
+│   ├── eval-loop.md             # test → evaluate → fix loop
+│   ├── test-prompts-template.md # 5 test-prompt types
+│   ├── rubric.md                # pre-registered pass/fail rubric
+│   ├── docs-driven.md           # docs = hard gate 100%
+│   ├── 12-factor-skills.md      # maintainable skill ops
+│   ├── apple-writing.md         # concise SKILL.md writing
+│   ├── openai-yaml.md           # agents/openai.yaml guide
+│   ├── checklist-thuong-mai.md  # commercialization + safety checklist
+│   └── ban-tren-github.md       # selling via GitHub (private → public)
+├── examples/echeck/             # complete reference skill
+└── scripts/
+    ├── validate-skill.py        # validator: --leak --brand "a,b"
+    └── eval-skill.py            # eval harness: test set + --verify
+```
+
+## Release
+
+Version: `1.4.1` — xem [RELEASE-NOTES.md](RELEASE-NOTES.md).
+Quy trình: sửa xong → bump `.version-bump.json` → cập nhật RELEASE-NOTES → `gh release create vX.Y.Z`
+(chi tiết: `references/ban-tren-github.md`).
+
+## Install
+
+Recommended — one command via [skills.sh](https://skills.sh):
+
+```bash
+npx skills add hedralab/eskill
+```
+
+Claude Code — plugin marketplace:
+
+```
+/plugin marketplace add hedralab/eskill
+/plugin install eskill
+```
+
+Manual — copy the folder into your agent skills dir:
+
+```bash
+cp -R eskill ~/.deepseek/skills/eskill    # DeepSeek TUI
+# or ~/.claude/skills/eskill
+# or ~/.codex/skills/eskill
+```
+
+## License
+
+MIT — free to use, modify, and sell.

--- a/plugins/eskill/skills/eskill/RELEASE-NOTES.md
+++ b/plugins/eskill/skills/eskill/RELEASE-NOTES.md
@@ -1,0 +1,53 @@
+# Release Notes — eSkill
+
+Định dạng theo [Keep a Changelog](https://keepachangelog.com) — version semver, mỗi bản 1 mục.
+Quy trình: sửa xong → bump `.version-bump.json` → cập nhật mục này → `gh release create vX.Y.Z`.
+
+## [1.4.1] — 2026-08-20
+
+### Updated
+- market-research.md theo audit đội chuyên gia: thêm Google Trends/X/Product Hunt/newsletter · storefront thay thế (Lemon Squeezy/Paddle/Ko-fi/BMAC/AppSumo) · bỏ Telegram Stars + MCP dirs khỏi ưu tiên · fix mâu thuẫn funnel bán · quy tắc kèm URL nguồn
+
+## [1.4.0] — 2026-08-20
+
+### Added
+- market-research.md Section 8: Nghiên cứu INSIGHT (JTBD + 5 Whys + behavioral observation + outcome-driven) — nỗi đau là triệu chứng, insight là gốc rễ
+
+## [1.3.0] — 2026-08-19
+
+### Added
+- references/numbered-output.md: pattern file 0→n (học từ egram) — pipeline 0-goal → 1-market → 2-plan → 3-SKILL.md → 4-eval → 5-check
+- Quy tắc vàng mới: ghi từng bước thành file đánh số
+
+## [1.2.0] — 2026-08-19
+
+### Added
+- market-research.md Section 6: Post-launch measurement (skills.sh telemetry, GitHub API, kill/pivot/continue)
+- market-research.md Section 7: Research → Plan (Minto Pyramid + SCQA + MECE + JTBD)
+
+## [1.1.0] — 2026-08-19
+
+### Added
+- Trụ 11 — Market Research: `references/market-research.md` (nỗi đau người dùng, kênh phân phối ngoài GitHub, benchmark top-1, pricing, demand validation)
+- BƯỚC 0 mở rộng: nghiên cứu thị trường trước khi build skill bán
+
+## [1.0.0] — 2026-08-19
+
+Bản đầu tiên đủ điều kiện bán. Eval chính thức: **4/5 PASS** + static PASS
+(case lớn 3/5 — cần test phiên thật trước khi bán rộng, xem eval-results.json).
+
+### Added
+- Forward-test eval loop đầy đủ: 5 case (chính/biên/nhanh/sai/lớn), rubric pre-registered, evidence ghi trong `eval-results.json`
+- Quy tắc mới từ eval (2 patch): BƯỚC 0 auto-mode ("không có user → tự quyết, TIẾN HÀNH") + Bước 3 create-first ("bắt tay tạo file NGAY, KHÔNG mở examples khi tạo mới — template là đủ")
+- Đóng gói bán: `RELEASE-NOTES.md`, `.version-bump.json`, plugin manifests (Claude Code / Codex / Cursor), `.github/` templates + FUNDING, `CODE_OF_CONDUCT.md`, `.gitignore`, pre-commit, icon
+- Version thống nhất semver `1.0.0` trên mọi file (SKILL.md metadata.version · eval-results.json · README · plugin.json · tag)
+
+### Fixed
+- README lệch SKILL.md (thiếu 4 references + eval-skill.py + examples/ trong cây cấu trúc)
+- 3 file `.bak` còn sót trong gói
+- BƯỚC 0 chặn agent chạy tự động (kẹt cứng chờ hỏi user không có)
+
+## [Unreleased]
+- Bản EN (bán quốc tế — spec + marketplace đều EN)
+- Marketplace registration (skills.sh / plugin marketplace)
+- Re-test case "lớn" trên phiên làm việc thật (có user tương tác, không phải sub-agent harness)

--- a/plugins/eskill/skills/eskill/SKILL.md
+++ b/plugins/eskill/skills/eskill/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: eskill
+description: >
+  Skill mẹ tạo skill (meta-skill) — quy trình sản xuất Agent Skills chuẩn top-1:
+  theo spec chính thức agentskills.io, quy trình eval của anthropics/skills (skill-creator),
+  và kinh nghiệm thực chiến build egram/eseed. Dùng khi cần TẠO skill mới, CẢI THIỆN skill cũ,
+  validate/kiểm tra skill, chuẩn bị skill bán thương mại, hoặc khi user nói "tạo skill",
+  "làm eskill", "viết SKILL.md", "skill ngon nhất".
+license: MIT
+compatibility: Python 3.10+
+metadata:
+  author: hedra
+  version: "1.4.1"
+---
+
+# eskill — Quy trình tạo Agent Skill (11 trụ cột)
+
+## 11 trụ cột — mỗi trụ 1 kim chỉ nam top-1
+
+```
+1. Core         · agentskills.io spec      — format chuẩn (frontmatter, progressive disclosure, refs 1 cấp)
+2. UX/UI        · Apple HIG                — cấu trúc skill, quickstart, naming Apple-style
+3. Validation   · agentskills.io validator — bắt lỗi sớm bằng máy
+4. Docs & Bẫy   · docs chính thức          — docs-driven HARD GATE 100% + bẫy thực chiến
+5. Vận hành     · 12-Factor App            — skill gọn, tự chứa, idempotent
+6. Eval         · skill-creator Anthropic  — test prompts → forward-test → improver
+7. Nội dung     · Apple Writing            — câu ngắn, động từ, không thừa chữ
+8. Tăng trưởng  · AARRR                    — description chống undertrigger, adoption
+9. Thương mại   · OKX                      — leak scan, LICENSE, marketplace, PnL bán skill
+10. Tư vấn      · SPIN + Mom Test          — hỏi đúng nỗi đau, skill theo đúng ý user
+11. Thị trường · JTBD + Mom Test + Demand Validation — research trước, build sau
+```
+
+## Quickstart (3 câu — user mới bắt đầu từ đây)
+
+1. `Tạo một skill để <việc gì đó> và kiểm tra nó chạy được` → eskill hỏi ít câu rồi build
+2. `Cải thiện skill này: <đường dẫn>` → áp eval loop, tìm lỗi, sửa
+3. `Validate skill này: <đường dẫn>` → chạy validator
+
+Nguồn chuẩn: [agentskills.io/specification](https://agentskills.io/specification) (spec chính thức) · `anthropics/skills` (skill-creator + template) · kinh nghiệm build egram/eseed (đã vấp và sửa).
+
+## 6 bước — BƯỚC 0 quan trọng nhất
+
+1. **BƯỚC 0 — Tư vấn trước, không đoán (Trụ 10 — sales-discovery.md)**: trích mục tiêu từ hội thoại hiện có TRƯỚC (tool đã dùng, thứ tự, input/output, lỗi user sửa). Hỏi 1 câu/lượt, tối đa 6 câu theo chuỗi SPIN (S tình huống → P nỗi đau → I hệ quả → N giá trị) + Mom Test (hỏi CUỘC SỐNG họ, không hỏi "anh có cần...?"). Tóm tắt gap (hiện tại → mong muốn → rào cản) cho user XÁC NHẬN trước khi viết — skill build theo câu trả lời của user, không theo giả định model. **Chế độ tự động (không có user để trả lời): tự quyết từ thông tin có sẵn rồi TIẾN HÀNH — đừng dừng chờ hỏi (đã vấp: agent kẹt cứng ở BƯỚC 0 khi không có user — forward-test 2026-08-19).** **(Nếu build skill bán: làm Trụ 11 — nghiên cứu thị trường TRƯỚC, xem `references/market-research.md`)**
+2. **Chọn kim chỉ nam**: mỗi mảng lớn = 1 chuẩn ĐÃ CHỨNG MINH, không viết theo ý kiến. Egram đã dùng: BotFather · Apple HIG · Stripe · Telegram docs · 12-Factor · GitHub Actions · Apple Writing · AARRR · OKX. Tìm nguồn: docs chính thức + `gh search repos --sort stars`.
+3. **Viết SKILL.md theo spec** (chi tiết: `references/spec-rules.md`):
+   - Frontmatter: `name` (1-64, chữ thường + gạch nối, **= tên thư mục**) · `description` ≤1024 ký tự — nêu CẢ "làm gì" LẪN "khi nào dùng", kèm trigger keyword, viết "pushy" (chống undertrigger — Claude có xu hướng không bật skill dù cần)
+   - Body < 500 dòng: mỗi mảng = **quy tắc → code mẫu → checklist** (lặp đều, đọc xong làm được ngay)
+   - Chi tiết đẩy xuống `references/` — ref **1 cấp** từ SKILL.md, đường dẫn tương đối
+   - **Bắt tay tạo file NGAY**: copy `template/SKILL.md` vào thư mục đích rồi điền dần — đọc references tối thiểu, đừng lang thang đọc hết tài liệu trước khi viết (đã vấp 2 lần: 3/5 rồi 2/3 agent dành hết budget đọc examples/* mà không tạo file — forward-test case lớn 2026-08-19). **KHÔNG mở `examples/` khi TẠO skill mới — `template/SKILL.md` là đủ**; mở `examples/` chỉ khi CẢI THIỆN skill có sẵn
+4. **Đóng gói bẫy đã biết**: mục "Bẫy — đừng lặp" — mỗi bẫy 1 dòng: triệu chứng + fix. Đây là tài sản lớn nhất của skill (agent sau không lặp 2 tiếng debug của agent trước).
+5. **Test + validate**: vòng lặp test → đánh giá → sửa (`references/eval-loop.md`) · chạy `scripts/validate-skill.py` · bán thương mại → chạy `--leak` + `references/checklist-thuong-mai.md`.
+6. **Pin kích hoạt**: skill quan trọng cho 1 project → thêm vào `.deepseek/instructions.md` của project (luôn bật, không chỉ trigger theo description).
+
+## Quy tắc vàng (học từ sai lầm egram — đừng lặp)
+
+- **DOCS-DRIVEN — HARD GATE 100%**: trước khi code/đo với 1 API/service, PHẢI có docs chính thức trong `references/` (tự fetch được HOẶC user đưa vào). **KHÔNG có docs = KHÔNG code, KHÔNG chạy — DỪNG lại yêu cầu user đưa docs** (file/URL/export). Không dựa vào trí nhớ model — nó sai (bẫy thật: field `views` của Graph API không có trong docs Video object nhưng model tin là có → đo sai lệch 10×: 74.714 vs 7.400 thật). Quy trình chi tiết: `references/docs-driven.md`
+- **Doc phải tự kiểm chứng**: mọi lệnh/đường dẫn trong SKILL.md/README phải chạy được. Lỗi kinh điển: egram v1 tuyên bố references là symlink nhưng thực tế là copy + thư mục đích không tồn tại.
+- **Idempotent + backup**: mọi patch/script chạy lại 100 lần an toàn, có `.bak` trước khi sửa.
+- **Smoke test đóng gói**: 1 script chạy 1 lệnh = bằng chứng skill hoạt động, không cần tin lời.
+- **Sanitize trước khi public**: grep secret/path/brand/chat_id/token — làm hệ thống, không làm tay (egram lộ chat_id thật + path home cá nhân khi chuẩn bị bán (bài học: thay placeholder `<chat_id>`, `<project_root>`)).
+- **Đổi tên/version đồng bộ mọi file**: README/SKILL/frontmatter — validate chéo (egram v1 README ghi "8 trụ/Hedragram" khi skill đã 9 trụ/egram).
+
+- **Ghi từng bước thành file đánh số 0→n**: hỏi/ghi ngay kết quả mỗi bước vào file (0-goal → 1-market → 2-plan → 3-SKILL.md → 4-eval → 5-check) — state trên disk, user duyệt từng lớp, máy kiểm tra được (học từ egram: 0-logic → 5-month). Chi tiết: `references/numbered-output.md`
+
+## Giới hạn (trung thực — khi nào KHÔNG dùng)
+
+- Skill **không thay thế test trên máy thật** của user — eval loop là agent chạy thử, user vẫn phải tự verify trên môi trường thật
+- Skill quốc tế → SKILL.md + README nên viết tiếng Anh (eskill bản VN là chuẩn nội bộ của tác giả)
+
+## References
+
+- `references/spec-rules.md` — Trụ 1+3: frontmatter + progressive disclosure + file refs (spec agentskills.io)
+- `references/naming.md` — Trụ 2: đặt tên kiểu Apple/e-family (brand ≠ prefix, `e` + 1 từ chính, ≤3 âm tiết)
+- `references/sales-discovery.md` — Trụ 10: hỏi đúng nỗi đau (SPIN + Mom Test + Gap) — skill theo ý user
+- `references/eval-loop.md` — Trụ 6: vòng lặp test prompts → eval → sửa (skill-creator Anthropic)
+- `references/test-prompts-template.md` — Trụ 6: 5 kiểu test prompt giả lập user thật (chính/biên/sai/nhanh/lớn)
+- `references/rubric.md` — Trụ 6: tiêu chí pass/fail mã hóa TRƯỚC (4 loại: artifact · string · behavior · LLM-judge)
+- `references/docs-driven.md` — Trụ 4: docs là HARD GATE 100% (không docs = không code, yêu cầu user đưa)
+- `references/12-factor-skills.md` — Trụ 5: vận hành skill bền (tự chứa, idempotent, state disk)
+- `references/apple-writing.md` — Trụ 7: viết SKILL.md ngắn gọn (câu ngắn, động từ, specific)
+- `references/openai-yaml.md` — Trụ 9: agents/openai.yaml cho marketplace/UI (display_name, short_description, default_prompt)
+- `references/checklist-thuong-mai.md` — Trụ 9: chuẩn bị bán: sanitize rò rỉ + LICENSE + README đồng bộ + an toàn khi cài skill lạ
+- `references/ban-tren-github.md` — Trụ 9: bán trên GitHub: push repo · cấp quyền từng khách (private) · tag/release · chuyển public
+- `template/SKILL.md` — khung SKILL.md copy dùng ngay (frontmatter đủ field + quy tắc → code mẫu → ví dụ → checklist + Bẫy)
+- `examples/echeck/` — SKILL MẪU HOÀN CHỈNH (kiểm tra URL sống) — hình mẫu đối chiếu cho mọi skill tạo ra
+- `scripts/validate-skill.py` — validator: frontmatter, quy tắc name, độ dài, refs; `--leak` quét rò rỉ; `--brand "a,b"` quét brand nội bộ
+- `scripts/eval-skill.py` — eval harness: static check + test set versioned (eval-results.json) + trace verdict · `--verify` tổng kết pass rate/trigger rate + rubric bắt buộc per case
+
+- `references/market-research.md` — Trụ 11: research trước build sau (nỗi đau user, kênh phân phối, pricing, demand validation)
+- `references/numbered-output.md` — pattern file 0→n (học từ egram): ghi từng bước thành file, duyệt từng lớp

--- a/plugins/eskill/skills/eskill/agents/openai.yaml
+++ b/plugins/eskill/skills/eskill/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: eSkill
+short_description: Meta-skill tạo Agent Skill chuẩn top-1 (spec agentskills.io + eval loop + naming e-family)
+default_prompt: Tạo một skill để ... và kiểm tra nó chạy được

--- a/plugins/eskill/skills/eskill/assets/eskill-icon.svg
+++ b/plugins/eskill/skills/eskill/assets/eskill-icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <rect width="256" height="256" rx="48" fill="#0f172a"/>
+  <circle cx="128" cy="128" r="84" fill="none" stroke="#38bdf8" stroke-width="14"/>
+  <text x="128" y="168" font-family="Arial, Helvetica, sans-serif" font-size="110" font-weight="bold" fill="#e2e8f0" text-anchor="middle">e</text>
+  <path d="M128 58 L196 128 L128 198" fill="none" stroke="#38bdf8" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/plugins/eskill/skills/eskill/eval-results.json
+++ b/plugins/eskill/skills/eskill/eval-results.json
@@ -1,0 +1,53 @@
+{
+  "skill": "eskill",
+  "version": "1.4.1",
+  "date": "2026-08-19",
+  "static_pass": true,
+  "test_cases": [
+    {
+      "id": 1,
+      "type": "chính",
+      "prompt": "Tạo skill để chuyển số tiền sang chữ tiếng Việt (125000 → một trăm hai mươi lăm nghìn) và kiểm tra nó chạy được",
+      "rubric": "artifact: eval-out/skill-dongtien/SKILL.md tồn tại, name = thư mục, <500 dòng | behavior: validate-skill.py PASS exit 0 | behavior: script chạy đúng 2 input mẫu | LLM-judge: báo cáo rõ 4 mục yêu cầu",
+      "verdict": "PASS",
+      "evidence": "Lần 1: FAIL — không tạo artifact, kẹt ở BƯỚC 0 và hiểu lầm broken-skill. Lần 2: PASS — SKILL.md 84 dòng + scripts/dongtien.py; validator PASS 0 lỗi (đã verify lại trực tiếp); 125000 → 'một trăm hai mươi lăm nghìn', 1000000 → 'một triệu' + ~20 edge case đúng.",
+      "notes": "BƯỚC 0 (hỏi user) chặn agent chạy tự động — đã patch SKILL.md thêm hướng dẫn auto-mode."
+    },
+    {
+      "id": 2,
+      "type": "biên",
+      "prompt": "Cải thiện skill echeck (examples/echeck/SKILL.md) — thêm timeout mặc định 10s + xử lý lỗi DNS/timeout",
+      "rubric": "artifact: eval-out/echeck-improved/SKILL.md tồn tại, <500 dòng, giữ cấu trúc quy tắc→code→checklist→Bẫy | behavior: code mẫu chạy thật 4 nhánh (200/DNS/timeout/refused) + input rỗng | LLM-judge: mỗi thay đổi nêu rõ lý do theo quy tắc eskill",
+      "verdict": "PASS",
+      "evidence": "timeout mặc định 10s, tách nhánh lỗi DNS/timeout/refused; 113 dòng; test thật: ✅ 200, ❌ DNS, ⚠️ timeout, ❌ refused, không crash input rỗng; file gốc không bị sửa.",
+      "notes": ""
+    },
+    {
+      "id": 3,
+      "type": "nhanh",
+      "prompt": "Validate skill này tại <skill-dir> (1 lệnh)",
+      "rubric": "behavior: chạy đúng lệnh validator | behavior: output đầy đủ + kết luận PASS 0 lỗi | LLM-judge: không sửa gì ngoài phạm vi",
+      "verdict": "PASS",
+      "evidence": "exit 0, output nguyên văn 5 mục ✅ + KẾT QUẢ: ✅ PASS (0 lỗi).",
+      "notes": ""
+    },
+    {
+      "id": 4,
+      "type": "sai",
+      "prompt": "Skill tại eval-out/broken-skill báo lỗi khi validate — debug giúp",
+      "rubric": "behavior: validator fail ban đầu (lỗi frontmatter thiếu description) | behavior: sửa xong validator PASS exit 0 | LLM-judge: báo cáo lỗi→fix→kết quả rõ ràng",
+      "verdict": "PASS",
+      "evidence": "FAIL 1 lỗi (frontmatter thiếu description) → thêm dòng 3 → PASS 0 lỗi. Lưu ý: ref khong-ton-tai.md (inline backtick) validator không bắt — gap tiềm năng.",
+      "notes": "Gap: validate-skill.py không bắt ref dạng inline backtick — cân nhắc bổ sung khi cải thiện validator."
+    },
+    {
+      "id": 5,
+      "type": "lớn",
+      "prompt": "Tạo 5 skill cùng lúc cho 5 việc khác nhau (case lớn — scale)",
+      "rubric": "LLM-judge: tạo được 5 skill độc lập, mỗi skill validate PASS | behavior: hoàn thành trong thời gian/chi phí hợp lý",
+      "verdict": "FAIL",
+      "evidence": "3 lần chạy, 13 agent: Chạy 1 (skill gốc, 5 agent) → PASS: tinhtuoi, camel / FAIL: chude, ngaythang, xoakhoang. Chạy 2 (patch 'Bắt tay tạo file NGAY', 3 agent) → PASS: chude / FAIL: ngaythang, xoakhoang. Chạy 3 (patch 'KHÔNG mở examples khi tạo mới', 2 agent) → FAIL: ngaythang, xoakhoang. Tổng 3/5 skill tạo được, 5 artifact PASS validator.",
+      "notes": "Kết luận: patch 1 cứu 1/3 (chude). ngaythang + xoakhoang fail GIỐNG HỆT ở cả 3 phiên bản skill — agent tự kết thúc chỉ sau 4-6 steps (agent PASS chạy 10-13 steps) sau khi đọc SKILL.md + template, không kịp viết. Đây là hành vi dừng sớm của sub-agent harness (thread mới, budget thấp, không có user), không phải lỗi nội dung skill. Với phiên làm việc thật (có user tương tác, budget cao hơn) khả năng hoàn thành cao hơn. Case này cần test trên phiên thật trước khi bán thương mại."
+    }
+  ]
+}

--- a/plugins/eskill/skills/eskill/examples/echeck/SKILL.md
+++ b/plugins/eskill/skills/eskill/examples/echeck/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: echeck
+description: >
+  Kiểm tra 1 URL còn hoạt động không (status + title + thời gian phản hồi).
+  Dùng khi cần verify trang web/link còn sống, kiểm tra link hỏng trong tài liệu,
+  hoặc xác nhận site đã deploy thành công. Trả kết quả 1 dòng: ✅/❌ + status + title.
+license: MIT
+metadata:
+  author: hedra
+  version: "1.0"
+---
+
+# echeck — Kiểm tra URL còn sống
+
+## Quickstart
+
+1. `Kiểm tra https://example.com còn chạy không` → trả ✅/❌ + status + title
+2. `Quét mọi link trong <file.md> xem link nào hỏng` → bảng link hỏng
+3. `Xác nhận site vừa deploy chưa` → 3 lần thử, 30s giãn cách
+
+## Quy tắc
+
+1. **Fetch bằng requests (timeout 15s)** — KHÔNG dùng browser trừ khi cần JS
+2. **Chuẩn hoá URL**: thêm `https://` nếu thiếu scheme; bỏ khoảng trắng
+3. **Phân loại kết quả**:
+   - 200 → `✅ 200 · <title>`
+   - 3xx → `🔁 <code> → <Location>` (đi tiếp tối đa 2 hop)
+   - 4xx/5xx → `❌ <code> · <lý do ngắn>`
+   - timeout/lỗi mạng → `⚠️ timeout/không kết nối được`
+4. **Cloudflare/403** (`cf-browser-verify`, "Just a moment") → báo `🔒 bị chặn (Cloudflare)` — KHÔNG coi là chết
+5. **JS-render**: nếu HTML rỗng nhưng site trả 200 → ghi chú "có thể cần JS" — không báo lỗi
+
+## Code mẫu
+
+```python
+import re, requests
+
+def check_url(url, timeout=15, max_hop=2):
+    url = url.strip()
+    if not url.startswith(("http://", "https://")):
+        url = "https://" + url
+    hop = 0
+    while hop <= max_hop:
+        try:
+            r = requests.get(url, timeout=timeout, allow_redirects=False,
+                             headers={"User-Agent": "Mozilla/5.0"})
+            if 300 <= r.status_code < 400 and r.headers.get("Location"):
+                url = r.headers["Location"]
+                hop += 1
+                continue
+            if "cf-browser-verify" in r.text or "Just a moment" in r.text:
+                return "🔒 bị chặn (Cloudflare)", r.status_code
+            title = re.search(r"<title[^>]*>([^<]+)</title>", r.text, re.I)
+            return ("✅" if r.status_code == 200 else "❌") + f" {r.status_code}", (title.group(1).strip()[:60] if title else "")
+        except requests.exceptions.Timeout:
+            return "⚠️ timeout", None
+        except Exception as e:
+            return f"⚠️ {str(e)[:40]}", None
+    return "🔁 quá nhiều redirect", None
+```
+
+## Ví dụ
+
+- `echeck("https://example.com")` → `✅ 200 · Example Domain`
+- `echeck("https://example.com/404")` → `❌ 404`
+- `echeck("https://example.com")` (Cloudflare) → `🔒 bị chặn (Cloudflare), 403`
+
+## Checklist
+
+- [ ] URL chuẩn hoá (https:// + trim)
+- [ ] 200/3xx/4xx/5xx/timeout/Cloudflare phân biệt rõ
+- [ ] Redirect tối đa 2 hop
+- [ ] Báo title khi có — HTML escape
+- [ ] Không crash với mọi input ('' · 'abc' · 'http://' trần)
+
+## Bẫy
+
+1. **Cloudflare ≠ chết** — "Just a moment" là chặn bot, site vẫn sống
+2. **Redirect về http** — giữ nguyên, đừng tự nâng lên https
+3. **Timeout là chậm, không phải hỏng** — ghi ⚠️, đề nghị thử lại sau 30s

--- a/plugins/eskill/skills/eskill/references/12-factor-skills.md
+++ b/plugins/eskill/skills/eskill/references/12-factor-skills.md
@@ -1,0 +1,32 @@
+# 12-Factor for Skills — Trụ 5: vận hành skill bền (theo 12-Factor App)
+
+Adapt chuẩn vận hành app (Heroku) sang bảo trì skill — skill sống lâu, không phải 1 file chết.
+
+## 12 nguyên tắc (chuyển nghĩa cho skill)
+
+1. **Codebase**: 1 skill = 1 thư mục, git-friendly — mọi thứ version control được
+2. **Dependencies**: skill TỰ CHỨA (self-contained) — không trỏ ra path/code ngoài thư mục (lỗi egram v1: references trỏ `sale/seeding/auto/` — vỡ)
+3. **Config**: mọi tham số có thể đổi → `.env`/frontmatter, KHÔNG hardcode trong SKILL.md (vd ngưỡng gate: MIN_VIEWS/PASS_DELTA)
+4. **Backing services**: state trên disk (file JSON) — không lệ thuộc session/trí nhớ
+5. **Build/release/run**: phân tách — SKILL.md (thiết kế) · references/ (tài liệu) · scripts/ (chạy) — đổi cái nào cũng không vỡ cái kia
+6. **Process**: 1 skill = 1 việc (single responsibility) — đừng gộp "tạo skill + đo ads + bán hàng" vào 1 skill
+7. **Port binding**: agent mới mở skill là tự đủ context — không cần hỏi lại lịch sử (progressive disclosure đủ)
+8. **Concurrency**: references/ tách theo chủ đề — 2 agent cùng đọc 2 file không cạnh tranh context
+9. **Disposability**: script chạy nhanh, thoát sạch — smoke test 1 lệnh, không giữ state
+10. **Dev/prod parity**: test trên máy THẬT của user — forward-test = môi trường thật
+11. **Logs**: bằng chứng = log — smoke test PASS/FAIL in ra, không "tin lời"
+12. **Admin process**: validator chạy định kỳ (validate-skill.py) như admin script
+
+## Quy tắc chốt
+
+- **Idempotent**: mọi patch/script chạy lại 100 lần an toàn (có `.bak` trước khi sửa)
+- **Đổi tên/version đồng bộ MỌI file**: SKILL.md frontmatter · README · openai.yaml — validate chéo
+- **State thật trên disk**: skill dạy hệ thống ghi state file, không dựa trí nhớ
+
+## Checklist
+
+- [ ] Skill tự chứa (không path ngoài)
+- [ ] Tham số đổi được qua env/frontmatter
+- [ ] Script idempotent + có backup
+- [ ] Smoke test chạy 1 lệnh
+- [ ] Tên/version đồng bộ mọi file

--- a/plugins/eskill/skills/eskill/references/apple-writing.md
+++ b/plugins/eskill/skills/eskill/references/apple-writing.md
@@ -1,0 +1,27 @@
+# Apple Writing — Trụ 7: viết SKILL.md theo chuẩn Apple
+
+Apple Writing Guidelines (bản HIG): câu ngắn · động từ · không thừa chữ · nói đúng việc. Áp vào skill: agent đọc skill là biết làm, không phải giải mã.
+
+## Quy tắc
+
+1. **Câu NGẮN, mệnh lệnh**: "Validate trước khi coi là xong" — không "bạn có thể cân nhắc việc..."
+2. **Động từ đầu câu**: Fetch → Lưu → Test → Đối chiếu. Việc nào ra việc đó.
+3. **Specific > generic**: số liệu thật, ví dụ thật ("field views trả 74.714 nhưng thật 7.400") — không "số liệu có thể sai"
+4. **Emoji = nhãn, không trang trí**: ✅ bắt đầu bước hợp lệ · ❌ dừng lại · ⚠️ cảnh báo. Không emoji làm đẹp.
+5. **Breathing room**: 1 ý 1 dòng, nhóm liên quan cạnh nhau, dòng trắng phân đoạn
+6. **Quickstart 3 câu** cho người mới — đừng bắt đầu bằng lý thuyết
+7. **Checklist cuối mỗi mảng** — agent tự verify được
+8. **Cấm**: mô tả lan man · tính từ thừa ("tuyệt vời", "mạnh mẽ") · giải thích điều hiển nhiên
+
+## Ví dụ
+
+❌ "Skill này sẽ giúp bạn tạo ra những Agent Skill tuyệt vời một cách dễ dàng và hiệu quả, bằng cách sử dụng các quy trình..."
+✅ "eskill — quy trình 6 bước tạo Agent Skill: hỏi → chuẩn → viết → bẫy → eval → pin."
+
+## Checklist
+
+- [ ] Câu ngắn, động từ đầu
+- [ ] Số liệu/ví dụ cụ thể
+- [ ] Không tính từ thừa
+- [ ] Quickstart 3 câu
+- [ ] Checklist cuối mỗi mảng

--- a/plugins/eskill/skills/eskill/references/ban-tren-github.md
+++ b/plugins/eskill/skills/eskill/references/ban-tren-github.md
@@ -1,0 +1,123 @@
+# Bán skill trên GitHub — quy trình publish + bán
+
+Phần này đi SAU `checklist-thuong-mai.md` (chuẩn bị skill). Ở đây là đưa skill lên GitHub và bán.
+
+## 1. Chuẩn bị xong chưa? (chạy trước khi push)
+
+```bash
+python3 scripts/validate-skill.py <skill-dir> --leak --brand "brand1,brand2"
+```
+PASS → mới push. FAIL → sửa (xem checklist-thuong-mai.md).
+
+## 2. Tạo repo + push (private mặc định)
+
+```bash
+cd <skill-dir>
+git init -b main && git add -A && git commit -m "Initial commit"
+gh repo create <tên> --private --source=. --push --description "<1 câu giá trị>"
+```
+
+- **`--private` MẶC ĐỊNH** — chưa sẵn sàng công khai thì giữ private
+- `.gitignore`: `.DS_Store`, `__pycache__/`, `*.pyc`, `*.zip` (zip bản phát hành không đẩy lên repo)
+- Tên repo = tên skill (e-family: `egram`, `eseed`, `eskill`)
+
+## 3. Bán PRIVATE — cấp quyền từng khách
+
+Bán skill = bán quyền truy cập repo. Mỗi khách cần username GitHub:
+
+```bash
+# Cấp quyền ĐỌC (clone về dùng — đủ cho người mua)
+gh api -X PUT repos/<owner>/<repo>/collaborators/<username> -f permission=pull
+
+# (nếu 2 bên cùng phát triển) nâng lên push
+gh api -X PUT repos/<owner>/<repo>/collaborators/<username> -f permission=push
+
+# Thu hồi khi khách không gia hạn / trả tiền
+gh api -X DELETE repos/<owner>/<repo>/collaborators/<username>
+```
+
+- Kiểm tra ai đang có quyền: `gh api repos/<owner>/<repo>/collaborators --paginate`
+- **Gửi kèm hướng dẫn cài**: `cp -R <skill> ~/.deepseek/skills/<skill>` (hoặc `~/.claude/skills/`)
+- Khách cần môi trường agent load skill (DeepSeek TUI / Claude Code) — nói rõ khi bán
+
+## 4. Phiên bản + cập nhật
+
+```bash
+# Mỗi bản bán — 3 bước: bump → notes → tag
+# 1) Sửa .version-bump.json (version mới) + đồng bộ version trong SKILL.md / README / eval-results.json / plugin.json
+# 2) Thêm mục [x.y.z] vào RELEASE-NOTES.md (định dạng Keep a Changelog)
+gh release create v1.0.1 --title "v1.0.1" --notes "Bản cập nhật — chi tiết trong RELEASE-NOTES.md"
+
+# Khách lấy bản mới
+cd <nơi clone> && git pull
+```
+
+- Version semver thống nhất: `SKILL.md metadata.version` = `eval-results.json` = `README` = `plugin.json` = tag — `.version-bump.json` liệt kê file phải đồng bộ
+- Mỗi bản đổi → cập nhật `RELEASE-NOTES.md` + README + agents/openai.yaml + tag mới (bài học đồng bộ egram)
+
+## 5. Chuyển PUBLIC (khi sẵn sàng bán rộng rãi)
+
+```bash
+gh repo edit <owner>/<repo> --visibility public
+```
+- Public = ai cũng tải được — chỉ khi skill đã sanitize + README EN + demo hoạt động
+- (Tùy chọn) đăng ký marketplace qua skills.sh / plugin marketplace — kênh phân phối thêm
+
+
+
+---
+
+## Funnel bán thực chiến — Telegram + OKX USDT + GitHub (access selling)
+
+Bán access repo = khách trả tiền → cấp quyền pull. GitHub KHÔNG có cổng thanh toán —
+tiền chạy ngoài (USDT/OKX), GitHub chỉ giao repo. Stack đề xuất đã có sẵn script trong `../scripts/sell/`.
+
+### Vận hành 3 mức (bắt đầu mức 1, nâng dần)
+
+1. **Mức 1 — thủ công**: khách chuyển USDT vào ví OKX → khách gửi TXID → check tronscan → `../scripts/sell/grant_access.sh grant <user>`
+2. **Mức 2 — bot Telegram**: `../scripts/sell/sales_bot.py` tự làm cả luồng /buy → /paid → verify → grant (xem dưới)
+3. **Mức 3 — webhook auto**: cổng thanh toán → webhook → GitHub Actions cấp quyền (khi khách đông)
+
+### Quy trình xác nhận thanh toán (4 bước — CHỈ tin blockchain, không tin ảnh chụp)
+
+1. Khách gửi: TXID (64 hex) + mạng + số tiền + nguồn gửi
+2. Tra tronscan: `python3 ../scripts/sell/verify_payment.py <TXID> <tiền> <địa_chỉ_nhận>`
+   - Địa chỉ nhận khớp 100% · token là USDT (TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t) · confirmed · tiền đủ
+3. Attribution (ai gửi — TXID không chứng minh người gửi):
+   - **Ví cá nhân** → khớp địa chỉ "From" trên explorer với địa chỉ khách khai
+   - **Sàn (OKX/Binance)** → "From" là ví hot sàn, vô nghĩa → dùng **số tiền độc nhất**: mỗi đơn 1 đuôi thập phân (vd 50.37, .37 = mã đơn) + ảnh lịch sử rút từ app sàn
+   - **Trả hộ / trung gian** → TỪ CHỐI (không định danh được)
+4. Khớp → cấp quyền. Thiếu 1 trong 3 (TXID · số tiền độc nhất · nguồn gửi khớp) → không cấp
+
+### Sales bot (../scripts/sell/) — chạy trên máy bán
+
+```bash
+cd <skill>/scripts/sell
+cp .env.mẫu .env   # điền: TELEGRAM_BOT_TOKEN (BotFather) · SELLER_CHAT_ID (userinfobot)
+                   #       OKX_USDT_ADDRESS · PRICE_USDT · REPO
+python3 sales_bot.py   # long-poll, chạy nền (nohup / launchd)
+```
+
+Lệnh khách: `/buy` (trả địa chỉ + số tiền độc nhất) → `/paid <TXID> <gh_username>` (tự verify + grant).
+Lệnh admin (whitelist SELLER_CHAT_ID): `/grant` `/revoke` `/sales`. State trên disk `sales.json`, log `sales.log`.
+
+### Ràng buộc vận hành (check trước khi bán)
+
+- **Private repo gói GitHub Free: giới hạn collaborators** — bán nhiều khách → cần GitHub Pro (xác nhận con số hiện tại trên docs.github.com)
+- `gh` phải auth trên máy bán (`gh auth login`) — grant_access.sh dựa vào `gh api`
+- Giá trị khách hàng = cập nhật định kỳ → thu hồi quyền khi hết hạn (`grant_access.sh revoke <user>`), gia hạn thì cấp lại
+- Không gửi `.env` thật lên git — `.gitignore` đã chặn
+
+### Mô hình kiếm tiền — bài học
+
+GitHub không có cổng thanh toán; người kiếm tiền trên GitHub chủ yếu từ: sản phẩm cloud (repo = marketing) ·
+open-core · việc làm/tư vấn · sponsors (nhỏ, VN không rút được) · bán add-on/access (mô hình này — trần thấp nếu thiếu discovery).
+Chiến lược hybrid: **public bản basic (MIT) lấy stars + discovery → bán bản Pro qua funnel trên**.
+
+## Checklist bán
+
+- [ ] validate `--leak --brand` PASS trước khi push
+- [ ] Repo private + `.gitignore` đúng
+- [ ] Khách có username GitHub → `gh api PUT collaborators -f permission=pull`
+- [ ] Gửi hướng dẫn cài + yêu cầu môi trường (agent có load skill)
+- [ ] Tag version khi bán bản mới · thu hồi quyền khi khách hết hạn

--- a/plugins/eskill/skills/eskill/references/checklist-thuong-mai.md
+++ b/plugins/eskill/skills/eskill/references/checklist-thuong-mai.md
@@ -1,0 +1,40 @@
+# Checklist Thương Mại — chuẩn bị skill bán / public
+
+Lỗi kinh điển egram v1: lộ chat_id thật, path home cá nhân, tên dịch vụ nội bộ trong code mẫu — phải sửa hàng loạt trước khi public — phải sửa hàng loạt trước khi public. Làm HỆ THỐNG, không làm tay.
+
+## 1. Sanitize rò rỉ (chạy script, không grep tay)
+
+```bash
+python3 scripts/validate-skill.py <skill-dir> --leak
+```
+
+Bắt: token (`bot\d+:` · `sk-...` · `api_key=...`) · path cá nhân (`/Users/`, `/home/`) · chat_id · brand nội bộ · tên dịch vụ riêng. Nếu dương tính → thay placeholder (`<your_chat_id>`, `<PROJECT_ROOT>`, tên generic).
+
+## 2. Kiểm tra từng file
+
+- [ ] `SKILL.md` — không hardcode path máy, brand nội bộ, ID thật
+- [ ] Version semver thống nhất trên mọi file (SKILL.md metadata.version · eval-results.json · README · plugin.json · tag) + `RELEASE-NOTES.md` có mục tương ứng
+- [ ] `references/*.py` — code mẫu không import thư viện nội bộ (`tg_ui`, `auto`), không token
+- [ ] `README.md` — **đồng bộ với SKILL.md**: số trụ, tên skill, cấu trúc thật (egram v1: README ghi 8 trụ/Hedragram khi skill đã 9 trụ/egram)
+- [ ] Không file rác: `.bak*`, `*.pyc`, `.DS_Store`, thư mục rỗng
+- [ ] `references/` không chứa symlink vỡ — xóa quy tắc symlink khỏi doc nếu không còn là symlink
+
+## 3. License + phân phối
+
+- [ ] `LICENSE` (MIT/BSD cho bán thương mại) + khai `license` trong frontmatter
+- [ ] **Bán quốc tế → dịch SKILL.md + README sang tiếng Anh** (spec gốc + marketplace đều EN)
+- [ ] Quyết định: private repo (bán theo quyền) hay public (mọi người tải)
+- [ ] Zip đóng gói: `zip -r` bỏ `.git/*` + `*.zip` — kiểm tra lại bằng `unzip -l` trước khi gửi
+- [ ] Xác minh code tham khảo từ nguồn khác (monitor.py kiểu Trung Quốc = rủi ro bản quyền → thay bằng code tự viết)
+- [ ] (Marketplace) Đăng chợ skill: tạo `agents/openai.yaml` (xem `references/openai-yaml.md`) + đăng ký repo qua skills.sh/plugin marketplace — ngoài zip bán tay
+
+## 4. Bằng chứng hoạt động
+
+- [ ] Smoke test đóng gói trong skill chạy PASS trên máy sạch (không có env nội bộ)
+- [ ] `validate-skill.py` chạy PASS
+- [ ] Test 1 lần trên máy khác / agent mới trước khi giới thiệu cho người mua
+
+## 5. An toàn khi CÀI skill từ nguồn lạ (phía người dùng)
+
+- Skill = script thực thi được — trước khi cài skill không tin cậy: **đọc hết `scripts/` trước khi chạy**
+- Không tự ý chạy script lạ; kiểm tra nó ghi/gửi gì ra ngoài (token, network call)

--- a/plugins/eskill/skills/eskill/references/docs-driven.md
+++ b/plugins/eskill/skills/eskill/references/docs-driven.md
@@ -1,0 +1,35 @@
+# Docs-Driven — docs là HARD GATE 100% (quy tắc vàng eskill)
+
+## Vì sao
+
+Model KHÔNG nhớ đúng API docs. Bẫy thật (Graph API, 18/08):
+- Field `views` trên Video object — model tin là có → đo sai lệch **10×** (74.714 vs 7.400 thật)
+- Thực tế: docs chính thức Video object KHÔNG có field `views` ("removed after v3.2")
+- `video_insights total_video_views` mới là metric chính thức — nhưng model cũng không biết cần `period=lifetime`
+
+→ Docs trong trí nhớ = rủi ro. Docs trong skill = bằng chứng. **KHÔNG docs = KHÔNG chạy.**
+
+## Quy trình 4 bước (bước 1 có nhánh bắt buộc)
+
+1. **FETCH docs chính thức** (URL official: developers.facebook.com, core.telegram.org, stripe.com/docs...)
+   - ✅ Fetch được → lưu excerpt vào `references/` → tiếp tục bước 2
+   - ❌ KHÔNG fetch được (chặn/403/không có quyền/không tìm thấy) → **DỪNG, yêu cầu USER đưa docs**:
+     "Cần docs chính thức của <API> để chạy đúng — bạn đưa file/URL/export docs vào, tôi lưu vào references/ rồi mới code."
+   - **BẮT BUỘC 100%**: chưa có docs = không code, không chạy, không đoán
+2. **LƯU excerpt vào `references/`** của skill: field list, permissions, period hợp lệ, error codes, URL gốc + ngày fetch — file gọn, 1 cấp
+3. **GHI CHÚ field/API KHÔNG TIN CẬY** nếu phát hiện (vd views field) — thành bẫy trong SKILL.md
+4. **TEST THẬT trước khi tin** — 1 API call so sánh với thực tế user thấy (đối chiếu Meta Business Suite / app thật) — nếu lệch → đào docs tiếp, không đoán
+
+## Khi nào bắt buộc
+
+- Lần ĐẦU dùng 1 API/field/service trong skill
+- API có version (Graph v22/v25/v26, Telegram Bot API) — version đổi = docs có thể đổi
+- Field trả số liệu được dùng cho QUYẾT ĐỊNH (gate, verdict, budget) — sai số = sai tiền
+
+## Checklist khi thêm API vào skill
+
+- [ ] Đã fetch docs chính thức (hoặc user đưa) + lưu excerpt vào references/ — **BẮT BUỘC**
+- [ ] Field list + permissions + periods ghi rõ
+- [ ] Field không tin cậy đã ghi thành bẫy
+- [ ] Đã test 1 API call thật + đối chiếu nguồn thật (user/app/UI)
+- [ ] URL docs ghi trong skill để fetch lại khi version đổi

--- a/plugins/eskill/skills/eskill/references/eval-loop.md
+++ b/plugins/eskill/skills/eskill/references/eval-loop.md
@@ -1,0 +1,70 @@
+# Eval Loop — test → đánh giá → sửa (theo skill-creator Anthropic)
+
+Vòng lặp này là trái tim của skill-creator chính thức. Đừng viết skill rồi "tin là chạy" — phải TEST bằng agent thật.
+
+## Vòng lặp
+
+```
+Viết draft
+   ↓
+Tạo test prompts (3-10 câu giả lập user thật)
+   ↓
+Chạy agent con với skill (forward-test)  ← KHÔNG lộ đáp án/bài học
+   ↓
+Đánh giá: qualitative (đọc output) + quantitative (đo được không?)
+   ↓
+Sửa skill theo phản hồi
+   ↓
+Lặp tới khi pass
+   ↓
+Mở rộng test set → chạy quy mô lớn hơn
+```
+
+## Quy tắc forward-test (quan trọng — đừng làm hỏng)
+
+- **Không cho agent test biết mình đang test skill**: prompt phải giống user thật yêu cầu công việc, ví dụ "Dùng skill X tại path Y giải quyết vấn đề Z" — KHÔNG phải "đánh giá skill X có tốt không"
+- **Không lộ đáp án / ý định sửa**: đưa artifact thô (prompt, file, log), không đưa kết luận
+- **Fresh thread cho mỗi lần pass** — không để agent test "nhớ" bài trước
+- **Dọn artifact giữa các lần** — agent test không được đọc output của lần trước (contamination)
+- **Forward-test thất bại mà chỉ pass khi có leaked context = skill chưa đủ**, tighten lại
+
+## Đánh giá
+
+- **Qualitative**: output có đúng format, đúng luồng, đúng giọng điệu?
+- **Quantitative** (nếu output khách quan): đếm được — số file tạo, độ dài, pass/fail test, token dùng
+- Kết hợp 2 loại — đừng chỉ "nhìn thấy ổn"
+
+## Description improver
+
+Sau khi skill hoạt động, tối ưu `description` để trigger chính xác:
+- Chống **undertrigger**: Claude có xu hướng không bật skill dù cần → viết description "pushy", liệt kê cả câu chữ user hay dùng
+- Test: đưa description mới cho agent mới → xem có tự bật skill với các prompt biên không
+
+## Khi nào cần test
+
+- Output khách quan (transform file, extract data, code, quy trình cố định) → **CẦN test case**
+- Output chủ quan (viết văn, nghệ thuật) → test nhẹ hoặc không, dựa cảm nhận user
+
+## Definition of Done — "pass" định nghĩa TRƯỚC
+
+Chạy `python3 eval-skill.py <skill-dir> --verify` để tổng kết. Pass khi:
+- Case chính + sai + nhanh: PASS 100%
+- Case biên (trigger): PASS ≥ 80% — fail biên = description chưa "pushy", sửa description không sửa body
+- Regression: pass-rate run mới KHÔNG giảm so với run trước (so 2 bản eval-results.json)
+- Mọi case có verdict + evidence — không để PENDING, case không khai rubric = chưa hợp lệ
+
+## Trigger rate — đo undertrigger bằng số
+
+```
+trigger rate = số case biên agent TỰ bật skill / tổng case biên
+```
+
+- Mục tiêu ≥ 80% · < 50% = description hỏng — ưu tiên sửa description trước
+- A/B: chạy test set biên với description cũ → sửa → chạy lại → so sánh % (ghi vào record)
+
+## Handoff verify — bàn giao cho user
+
+Skill không thay thế test trên máy thật. Sau khi pass eval, gửi user 3 dòng:
+1. Skill `<tên>` đã pass eval — chạy thử: `<lệnh thật>`
+2. Kỳ vọng: `<output đúng — 1 dòng>`
+3. Verify trên môi trường thật rồi báo lại

--- a/plugins/eskill/skills/eskill/references/market-research.md
+++ b/plugins/eskill/skills/eskill/references/market-research.md
@@ -1,0 +1,138 @@
+# Market Research — Trụ 11: research TRƯỚC, build SAU (top-1: JTBD + Mom Test + Demand Validation)
+
+Lỗi kinh điển: build skill xong mới hỏi có ai cần không. Trụ 11 đảo ngược: nghiên cứu trước, build sau. Bằng chứng 2026-08: top-1 skill thế giới = obra/superpowers (274K ⭐) và mattpocock/skills (223K ⭐) — cả hai bắt đầu từ nỗi đau của CHÍNH TÁC GIẢ, không phải đoán thị trường.
+
+## 1. Năm nỗi đau người dùng phổ biến nhất (research Reddit/HN/PromptBase/X/Google Trends 2026-08)
+
+1. **Skill bị model bỏ qua** — skill chỉ advisory, model không tự gọi → mất niềm tin. Fix: description trigger mạnh + script deterministic + test thật skill có được gọi không.
+2. **Nhầm lẫn khái niệm** — skills vs MCP vs subagents vs commands vs plugins. Fix: SKILL.md nêu rõ khi nào dùng / khi nào KHÔNG (mục Giới hạn).
+3. **Hoài nghi chỉ là markdown** — Fix: bằng chứng chạy thật (eval-results.json, smoke test). Điểm eskill ĐÃ có.
+4. **Decay** — skill cũ, docs lỗi thời. Fix: version + RELEASE-NOTES + cập nhật định kỳ.
+5. **Bảo mật** — skill = script thực thi, sợ RCE / prompt injection. Fix: code review sạch, tối giản quyền, mục an toàn khi cài.
+
+Nguồn bổ sung: X/Twitter (trend AI) · Product Hunt (test demand lúc launch) · Google Trends (đo volume tìm kiếm) · newsletter AI (The Rundown, Matt Wolfe).
+
+## 2. Kênh phân phối ngoài GitHub (research 2026-08 — có bằng chứng)
+
+- **PromptBase** — kênh DUY NHẤT bán skill.md end-to-end hiện tại: 450K+ users, 2,200+ sellers, 20% phí chợ / 0% link riêng, thanh toán Stripe
+- **skills.sh (Vercel)** — discovery + cài 1 lệnh: 8,420 skill, 1.26M installs all-time, miễn phí
+- **Claude Code / Codex / Cursor marketplace** — native-install; Codex qua review OpenAI, Cursor bắt buộc open-source, Claude mở marketplace.json không phí
+- **Gumroad** — storefront tự bán: 10% + $0.50 (30% nếu qua Discover)
+- **Lemon Squeezy / Paddle / Ko-fi / Buy Me a Coffee / AppSumo** — storefront thay thế: phí kiểm tra trên trang chủ khi dùng
+- Telegram Stars + MCP directories (mcp.so/Glama/Arcade.dev): CHỈ khi sản phẩm thật là bot/MCP — ngoài scope skill, không ưu tiên
+
+Kết luận: GitHub = trust + discovery. PromptBase = kênh bán skill.md sẵn có. Gumroad/Lemon Squeezy = bán trực tiếp khi có traffic. Bán access repo thì dùng funnel Telegram + OKX + GitHub (chi tiết: ban-tren-github.md). KHÔNG bán được ngay trên GitHub (không có cổng thanh toán).
+
+## 3. Top-1 làm gì đúng (benchmark obra/superpowers + mattpocock/skills)
+
+1. Skill QUY TRÌNH có ý kiến — không phải reference docs
+2. Cài 1 lệnh qua official plugin marketplace
+3. Dual install: subscribe (tự cập nhật) hoặc fork (kiểm soát)
+4. Tác giả tự dùng hằng ngày (eat own dogfood)
+5. Bắt đầu từ nỗi đau cá nhân thật
+6. Cộng đồng + newsletter (mattpocock ~60K subscribers)
+7. Repo sống: cập nhật liên tục
+8. README kể chuyện, positioning rõ: cho ai, giải quyết gì
+9. Enterprise path rõ ràng (obra: email sales)
+10. Registry-level distribution (skills.sh)
+
+5 GAP mọi ông lớn bỏ lỡ — chỗ skill mới ăn điểm:
+1. Không có install-time security verification (NVIDIA SkillSpector tồn tại nhưng ngoài luồng)
+2. Không có per-skill semver + changelog
+3. Không có usage telemetry (obra tự thú: không biết bao nhiêu người dùng)
+4. Không có skill-quality benchmark chung
+5. Không có paid distribution tích hợp vào install UX
+
+## 4. Pricing benchmark (research 2026)
+
+- Prompt lẻ: $5-15 · Bundle hệ thống (prompt + workflow + template): $29-69 · Membership: $9-19/tháng
+- Người mua trả tiền cho BUNDLE giải quyết 1 nỗi đau — không trả cho prompt lẻ
+- Thu nhập thực: beginner $100-500/tháng · niche + direct + subscription: $2K-15K/tháng
+- Margin: direct ~3% phí xử lý vs PromptBase 20% vs Gumroad 10%+$0.50 · mọi con số dùng quyết định PHẢI kèm URL nguồn
+
+## 5. Demand validation — 5 cách có bằng chứng
+
+1. Founder-pain test: chính tôi có dùng nó hằng tuần không? (PromptBase, superpowers đều từ đây)
+2. Pre-sale: bán trước khi build — có người trả tiền = demand thật (Marc Lou pattern)
+3. Signal scan: Reddit/HN/Google Trends/X/search — người ta có đang đau vì vấn đề này?
+4. Mom Test: hỏi CUỘC SỐNG, không hỏi anh có cần không (chi tiết: sales-discovery.md)
+5. Waitlist / landing page: đo conversion trước khi tốn công build
+
+## Checklist nghiên cứu thị trường (trước khi build skill BÁN)
+
+- [ ] 1 câu: người mua DUY NHẤT + nỗi đau cụ thể của họ
+- [ ] Founder-pain test: chính mình dùng hằng tuần không?
+- [ ] Scan 3 nơi: Reddit/HN + skills.sh + PromptBase — đã có skill nào chưa, gap gì
+- [ ] Benchmark 2 skill top cùng chủ đề — học điểm mạnh, né điểm yếu
+- [ ] Định giá theo bundle ($29-69), không theo prompt lẻ ($5)
+- [ ] Chọn kênh ≥2: GitHub (trust) + PromptBase (bán) + Gumroad (direct)
+- [ ] Demand test tối thiểu TRƯỚC khi build 200 dòng
+- [ ] Kế hoạch cập nhật (version + changelog) từ ngày đầu
+
+## 6. Post-launch measurement — đo sau khi ship (đừng tự xây telemetry, dùng thứ CÓ SẴN)
+
+Telemetry ĐÃ tồn tại, public, không cần tự làm:
+- **skills.sh** — install count dedup, trending 24h, hot view, weekly sparkline, README badge, public API /api/v1. Số thật 2026-08: npm skills CLI 38.6M downloads/30 ngày · mattpocock 16.7M installs / 51 skills · top skill find-skills 3.0M installs
+- **GitHub API** — stars/forks/open issues (public, không cần token) · traffic 14 ngày: clones/views/referrers (cần token)
+- **PromptBase** — sales + reviews (kênh bán duy nhất, số liệu bán thật)
+- **npm** — downloads/tháng cho package
+
+Feedback channel hiệu quả: GitHub Issues + Discussions (anthropics/skills 1,120 issues mở · mattpocock 370) · HN · r/ClaudeAI · Discord
+
+Nhịp review (tooling đã mã hóa sẵn):
+- Mỗi tuần: install sparkline + trending — có tăng không
+- Mỗi tháng: sales + issues mới + churn — ai gỡ cài / báo lỗi gì
+- Mỗi release: changelog + đối chiếu feedback cũ đã fix chưa
+
+Quyết định (tiếp tục / pivot / kill):
+- **Tiếp tục**: installs tăng 2 tuần liên tiếp + feedback tích cực + sales > 0
+- **Pivot**: installs ổn nhưng churn cao, hoặc 1 feature được hỏi lặp lại 3+ lần
+- **Kill**: 60 ngày không có install mới + không ai hỏi → đóng, học bài học, chuyển nguồn lực
+
+Thực tế top creator: ship liên tục — cả 3 repo đầu bảng đều có commit trong 7 ngày gần nhất. Repo chết = không cập nhật.
+
+## 7. Research → Plan — trình bày logic, dễ hiểu (top-1: Minto Pyramid Principle, McKinsey)
+
+Kết quả nghiên cứu phải thành 1 trang plan. Framework top-1: Pyramid Principle của Barbara Minto (McKinsey) — kết luận trước, nhóm luận điểm MECE, mở đầu SCQA, ngôn ngữ JTBD. SCQA + MECE + Pyramid là MỘT hệ (Minto phát triển MECE để phục vụ Pyramid).
+
+Cấu trúc 1 trang (đúng thứ tự):
+
+1. **ANSWER — kết luận trước** (1 câu): Làm X cho Y vì Z. Vd: làm skill X cho lập trình viên nhúng vì họ tốn 10h/tuần cho việc Y.
+2. **SCQA — mở đầu** (4 dòng):
+   - Situation: thị trường Agent Skills bùng nổ, cài bằng 1 lệnh
+   - Complication: hầu hết skill generic, không giải quyết nỗi đau cụ thể
+   - Question: làm skill gì để thắng được?
+   - Answer: chính là câu ở mục 1
+3. **Nhóm luận điểm MECE** (3-4 nhóm, không chồng lấn, đủ phủ):
+   - Thị trường & nhu cầu · Đối thủ & gap · Kênh & giá · Rủi ro
+   - Mỗi nhóm 2-3 dòng + số liệu + nguồn
+4. **Rủi ro + cách giảm** — 3 rủi ro lớn nhất, mỗi cái 1 hành động giảm
+5. **Next actions** — 3-5 bước, mỗi bước 1 dòng: việc + deadline + người làm
+
+3 quy tắc dễ hiểu:
+- **Kết luận trước** — người đọc biết đáp án trong 5 giây, chi tiết phía sau
+- **Ngôn ngữ đời thường** — không biệt ngữ; cần thuật ngữ thì định nghĩa 1 lần
+- **1 trang, số cụ thể** — không mô tả chung chung; mọi luận điểm có số hoặc nguồn
+
+MECE test sau khi viết xong: gộp 2 nhóm trùng → bỏ nhóm không liên quan → thêm nhóm thiếu → mỗi câu tự hỏi Vậy thì sao?
+
+## 8. Nghiên cứu INSIGHT — nỗi đau là TRIỆU CHỨNG, insight là GỐC RỄ
+
+Nỗi đau trả lời CÁI GÌ (skill bị model bỏ qua). Insight trả lời VÌ SAO (người dùng không TIN skill vì không thấy nó được gọi — vấn đề trust, không phải tính năng). Build theo pain = vá triệu chứng. Build theo insight = trúng gốc rễ.
+
+4 phương pháp đào insight (có bằng chứng):
+
+1. **JTBD — phỏng vấn theo JOB, không theo giải pháp**: hỏi KHI nào + MUỐN làm gì + ĐỂ đạt kết quả gì. Không hỏi anh muốn tính năng nào. Bằng chứng: obra/superpowers thắng vì bắt đúng job cải thiện quy trình code hằng ngày, không phải thêm tính năng X.
+2. **5 Whys — đào từ pain xuống gốc**: pain #1 (model bỏ qua skill) → vì sao → description không trigger → vì sao → skill viết chung chung, không nêu khi nào dùng → INSIGHT: skill phải có trigger mạnh + script deterministic + smoke test chứng minh.
+3. **Behavioral observation — nhìn họ LÀM, không hỏi họ MUỐN**: người ta không cài skill, họ copy-paste SKILL.md vào project → insight: friction khi cài là rào cản thật → fix: cài 1 lệnh.
+4. **Outcome-driven — hỏi kết quả đo được**: tiết kiệm bao nhiêu giờ/tuần, giảm bao nhiêu lỗi — không hỏi chức năng. Kết quả đo được = căn cứ định giá.
+
+Công thức câu insight (đủ 4 phần mới là insight):
+Khi [tình huống], người dùng muốn [job] để [kết quả đo được], nhưng bị chặn bởi [rào cản] vì [nguyên nhân gốc].
+
+Ví dụ: Khi tạo skill, người dùng muốn nó tự chạy đúng quy trình để tiết kiệm 2h/ngày, nhưng model không gọi skill vì description không trigger → giải pháp: description pushy + script deterministic + smoke test.
+
+Checklist insight:
+- [ ] Với MỖI pain: đã đào 1 insight (nguyên nhân gốc) chưa?
+- [ ] Câu insight đủ 4 phần theo công thức?
+- [ ] Quyết định build dựa trên insight, không chỉ pain?

--- a/plugins/eskill/skills/eskill/references/naming.md
+++ b/plugins/eskill/skills/eskill/references/naming.md
@@ -1,0 +1,30 @@
+# Naming — Đặt tên skill theo chuẩn Apple (đúc từ egram Trụ "Đặt tên dự án")
+
+Spec agentskills.io quy định quy tắc KỸ THUẬT (chữ thường + gạch nối, = tên thư mục).
+Lớp này là quy tắc THƯƠNG HIỆU — làm skill thành 1 gia đình nhận diện được.
+
+## Công thức Apple
+
+**tiền tố gia đình + 1 từ chính + (hậu tố phân cấp)** — `i` → iPhone/iPad/iMac · `Mac` → MacBook/Mac mini.
+
+## Quy tắc cho hệ e-family (prefix `e`)
+
+0. **2 tầng tên — brand ≠ prefix**: brand = **tên doanh nghiệp của bạn** (tên hiển thị) · prefix sản phẩm = **`e`** (tên dự án/skill). Khi cần nhấn brand: `Brand eSkill`. KHÔNG nhét brand vào tên skill (`brand-skill` = 4 âm tiết, hỏng).
+1. **Chọn 1 tiền tố gia đình DUY NHẤT** — 1-3 ký tự, dễ gõ, không dấu. Hệ này: **`e`** → egram, eSeed, eScan, eSkill, eShare...
+2. **Tên = tiền tố + 1 từ chính** — từ chính nói ĐÚNG việc: Skill (meta tạo skill), Seed, Scan, Gram (tin nhắn). KHÔNG 2 từ chính, không mô tả lan man.
+3. **Hậu tố phân cấp CHỈ KHI CẦN** — Air/Mini/Pro/Ultra. Đừng gắn Pro cho mọi thứ.
+4. **Cách viết nhất quán**: folder/repo = chữ thường (`eskill`) · tên hiển thị = camelCase (`eSkill`). KHÔNG gạch dưới, không số, không viết hoa lộn xộn.
+5. **Không số phiên bản trong tên** — version để sau (v2).
+6. **Kiểm tra trước khi đặt**: ≤3 âm tiết · gõ không dấu dễ dàng · không trùng skill khác · nghe 1 lần nhớ được.
+
+## Áp dụng vào SKILL.md
+
+- `name` frontmatter = folder = chữ thường (`eskill`) — khớp quy tắc spec
+- Nếu đăng marketplace: `metadata.display_name: eSkill` (camelCase hiển thị)
+
+## Checklist
+
+- [ ] Cùng tiền tố gia đình (`e-`)
+- [ ] 1 từ chính mô tả đúng việc
+- [ ] Không số, không gạch dưới, không 2 từ chính
+- [ ] Folder `eskill` · hiển thị `eSkill`

--- a/plugins/eskill/skills/eskill/references/numbered-output.md
+++ b/plugins/eskill/skills/eskill/references/numbered-output.md
@@ -1,0 +1,41 @@
+# Numbered Output — ghi từng bước thành file 0→n (học từ egram: hỏi → 0-logic → 1-menu → ... → 5-month)
+
+Pattern egram: hỏi người dùng → GHI NGAY câu trả lời vào 0-logic.txt → lần lượt sinh 1-menu → 2-seed → ... mỗi file 1 lớp, user duyệt từng cái. Kết quả: dễ dùng, không mất state, máy kiểm tra được.
+
+Áp dụng cho eskill — pipeline tạo skill BÁN thành file đánh số:
+
+- 0-goal.txt — GỐC: câu trả lời BƯỚC 0 (SPIN + Mom Test). Ghi NGAY từng câu khi user trả lời.
+- 1-market.txt — Trụ 11: người mua + nỗi đau + đối thủ + giá (research 1 trang)
+- 2-plan.txt — Section 7: kết luận 1 trang (ANSWER → SCQA → MECE → rủi ro → next actions)
+- 3-SKILL.md — draft theo spec (frontmatter, <500 dòng, refs 1 cấp)
+- 4-eval.md — 5 test prompt + rubric TRƯỚC khi chạy eval
+- 5-check.md — checklist thương mại (leak scan, LICENSE, README đồng bộ)
+
+6 quy tắc:
+1. Hỏi trước → ghi NGAY thành file 0 — không giữ câu trả lời trong hội thoại (state trên disk, restart không mất)
+2. File sau phụ thuộc file trước — duyệt TỪNG LỚP: user fix file 0 → điều chỉnh các lớp sau
+3. Skeleton trước, điền dần — sinh khung 6 file ngay, điền theo kết quả từng bước
+4. Số thứ tự = thứ tự build = thứ tự duyệt — user không cần hỏi tiếp theo làm gì
+5. Mỗi dự án 1 bộ file RIÊNG, độc lập — không mở/copy bộ file dự án khác
+6. Máy kiểm tra được: đủ 6 file? thiếu file nào? — quy trình thành checklist chạy được
+
+Code mẫu (khởi tạo bộ file):
+```bash
+touch 0-goal.txt 1-market.txt 2-plan.txt 3-SKILL.md 4-eval.md 5-check.md
+```
+
+Ví dụ nội dung 0-goal.txt (ghi khi user trả lời, 1 câu/câu):
+```
+# Mục tiêu
+- Bot/skill làm gì: ...
+- Ai dùng: ...
+- Nỗi đau đang giải quyết: ...
+```
+
+Checklist trước khi build:
+- [ ] 0-goal.txt có câu trả lời THẬT của user (không phải suy diễn model)
+- [ ] 1-market.txt đủ: người mua + nỗi đau + 2 đối thủ + giá
+- [ ] 2-plan.txt 1 trang: ANSWER đầu tiên + MECE + rủi ro + next actions
+- [ ] 3-SKILL.md draft xong → validate PASS
+- [ ] 4-eval.md có 5 test prompt + rubric
+- [ ] 5-check.md: leak scan + LICENSE + README đồng bộ

--- a/plugins/eskill/skills/eskill/references/openai-yaml.md
+++ b/plugins/eskill/skills/eskill/references/openai-yaml.md
@@ -1,0 +1,18 @@
+# agents/openai.yaml — metadata marketplace/UI (không bắt buộc spec, cần khi đăng chợ)
+
+Đặt tại `agents/openai.yaml` trong skill. Dùng cho UI hiển thị (danh sách skill, chips).
+Đọc SKILL.md rồi sinh 3 giá trị: `display_name` (tên hiển thị, camelCase kiểu e-family),
+`short_description` (1 câu, ≤ ~140 ký tự), `default_prompt` (câu user mở đầu điển hình).
+
+```yaml
+display_name: eSkill
+short_description: Quy trình tạo Agent Skill chuẩn top-1 (spec agentskills.io + eval loop)
+default_prompt: Tạo một skill để ... và kiểm tra nó chạy được
+```
+
+## Quy tắc
+
+- `display_name`: camelCase hiển thị (egram → egram, eseed → eSeed, eskill → eSkill)
+- `short_description`: 1 câu nêu giá trị + khi nào dùng — giống `description` nhưng ngắn
+- `default_prompt`: câu user thật hay gõ để bật skill
+- Cập nhật lại mỗi khi SKILL.md đổi (đừng để stale — bài học egram v1)

--- a/plugins/eskill/skills/eskill/references/rubric.md
+++ b/plugins/eskill/skills/eskill/references/rubric.md
@@ -1,0 +1,45 @@
+# Rubric — tiêu chí pass/fail mã hóa TRƯỚC (Trụ 6)
+
+Chấm "định tính nhìn thấy ổn" = không phải chứng minh. Mọi test case phải có **rubric pre-registered** (viết TRƯỚC khi chạy — chống confirmation bias).
+
+## 4 loại rubric
+
+### 1. Artifact — file/đầu ra phải tồn tại
+```
+PASS nếu: <path> tồn tại · chứa <chuỗi bắt buộc> · kích thước > 0
+FAIL nếu: thiếu file / thiếu chuỗi / file rỗng
+```
+
+### 2. String/Regex — nội dung phải khớp
+```
+PASS nếu: output chứa "✅ ..." · KHÔNG chứa "❌" · khớp regex ^SKILL
+FAIL nếu: chứa chuỗi cấm (vd token thật, path home cá nhân)
+```
+
+### 3. Behavior/Exit — chạy được, mã trả về đúng
+```
+PASS nếu: exit code = 0 · không exception · log có timestamp
+FAIL nếu: exit ≠ 0 · crash · treo > 60s
+```
+
+### 4. LLM-as-judge — agent mới chấm theo rubric cố định
+```
+Câu hỏi judge (đưa output + rubric):
+"Output có: (a) đúng format <X>? (b) đủ <N> phần? (c) không bịa số liệu?
+Chấm 1-5 mỗi mục + verdict PASS (≥4) / FAIL (<4). KHÔNG thương lượng."
+```
+
+## Quy tắc pre-registration
+
+1. **Viết rubric TRƯỚC khi chạy** — ghi vào file test case (vd `tests/rubric.md`), không viết sau khi thấy output
+2. **Mỗi case ≥ 1 rubric** — chọn loại phù hợp (artifact cho transform file · string cho format · behavior cho script · judge cho output mở)
+3. **Judge độc lập** — agent chấm không được biết kỳ vọng của người viết skill
+
+## Ví dụ thực tế (từ eseed forward-test)
+
+Case: "Xem hiệu suất 20 video — lấy views đúng"
+Rubric pre-registered:
+- ✅ Nhắc cảnh báo views không tin cậy (chuỗi "views" + "không tin cậy"/"đối chiếu")
+- ✅ Dùng post id = PAGE_ID_videoid (chuỗi "PAGE_ID" hoặc "pageid_videoid")
+- ❌ FAIL nếu: đề xuất batch /?ids= · đưa số views tuyệt đối không caveat
+→ Agent test pass cả 3 — rubric phát hiện được agent bịa (như đã từng: 74.714 vs 7.400)

--- a/plugins/eskill/skills/eskill/references/sales-discovery.md
+++ b/plugins/eskill/skills/eskill/references/sales-discovery.md
@@ -1,0 +1,57 @@
+# Sales Discovery — Trụ 10: hỏi đúng nỗi đau, skill theo đúng ý user (top-1: SPIN + Mom Test + Gap Selling)
+
+Skill chuẩn = 100% chuyên môn + **hỏi đúng người dùng thật sự cần gì**. Mỗi người mỗi ý —
+skill build theo giả định của model = sai. Build theo câu trả lời của user = chuẩn.
+
+## 3 nền tảng top-1
+
+1. **The Mom Test (Rob Fitzpatrick)** — cách hỏi KHÔNG bị nhiễu ý kiến: nói về cuộc sống họ, không nói về ý tưởng mình
+2. **SPIN Selling (Neil Rackham)** — chuỗi câu hỏi S→P→I→N: tình huống → vấn đề → hệ quả → giá trị
+3. **Gap Selling (Keenan)** — hiện tại → mong muốn → rào cản → giải pháp khép gap
+
+## 3 quy tắc Mom Test (bắt buộc khi hỏi)
+
+1. **Nói về CUỘC SỐNG của họ, không về ý tưởng của mình**
+   - ❌ "Anh thấy skill này thế nào?" (ý tưởng — ai cũng gật cho lịch sự)
+   - ✅ "Dạo này anh xử lý việc X thế nào?" (cuộc sống — câu trả lời thật)
+2. **Hỏi SỰ THẬT CỤ THỂ, không hỏi ý kiến tán thành**
+   - ❌ "Anh có cần tính năng Y không?" (ý kiến — vô giá trị)
+   - ✅ "Lần cuối anh gặp vấn đề Y là khi nào? Chuyện gì xảy ra?" (sự thật)
+3. **Lắng nghe, không bán** — commit thật = họ dùng thử/test thật, không phải "nghe hay đấy"
+
+## Chuỗi SPIN (áp vào phỏng vấn skill)
+
+- **S — Situation**: "Anh đang làm việc X như thế nào? Dùng tool gì?" → biết môi trường thật
+- **P — Problem**: "Chỗ nào đang khó nhất / tốn thời gian nhất?" → nỗi đau
+- **I — Implication**: "Khó đó khiến anh tốn bao nhiêu thời gian/tiền/mất cơ hội?" → định lượng nỗi đau
+- **N — Need-payoff**: "Nếu tự động hóa chỗ đó, anh được gì?" → giải pháp phải khép đúng đau
+
+## Gap (tóm tắt trước khi viết)
+
+```
+HIỆN TẠI: <cách họ đang làm>      → RÀO CẢN: <tại sao chưa tự động được>
+MONG MUỐN: <điều họ mô tả là "chuẩn">  → SKILL: <khép gap giữa 2 bên>
+```
+
+## Mẫu phỏng vấn 6 câu (tối đa — hỏi 1 câu/lượt)
+
+1. (S) "Anh đang xử lý <việc> thế nào hiện tại — làm tay hay có tool?"
+2. (S) "Mỗi lần làm mất bao lâu / tốn bao nhiêu?"
+3. (P) "Chỗ nào thấy khó chịu / lặp đi lặp lại nhất?"
+4. (I) "Nếu bỏ được chỗ đó, anh tiết kiệm được gì cụ thể?"
+5. (N) "Kết quả mong muốn nhìn như thế nào — anh mô tả 1 lần hoàn hảo?"
+6. (C) "Tôi hiểu là <tóm tắt gap>. Đúng ý anh chưa?" → **user xác nhận mới viết skill**
+
+## Quy tắc chốt
+
+- **Hỏi tối đa 6 câu, 1 câu/lượt** — không bắn loạt, không tự trả lời thay user
+- **Không hỏi**: "Anh có cần...?" (ý kiến) · "Anh thấy... thế nào?" (khen) · câu dẫn đến câu trả lời mong muốn
+- **Mỗi pain = 1 solution** — skill tạo ra phải map được về pain user nói, không phải tính năng model nghĩ ra
+- **Ghi đáp án → confirm → mới viết** — tóm tắt gap cho user xác nhận trước khi code (BƯỚC 0)
+
+## Checklist
+
+- [ ] Hỏi về cuộc sống họ, không về ý tưởng mình (Mom Test)
+- [ ] Có câu hỏi định lượng nỗi đau (I — SPIN)
+- [ ] Tóm tắt gap → user xác nhận
+- [ ] Mỗi tính năng skill map về 1 pain user nói

--- a/plugins/eskill/skills/eskill/references/spec-rules.md
+++ b/plugins/eskill/skills/eskill/references/spec-rules.md
@@ -1,0 +1,52 @@
+# Spec Rules — Agent Skills theo agentskills.io (spec chính thức)
+
+## Frontmatter
+
+| Field | Bắt buộc | Ràng buộc |
+|---|---|---|
+| `name` | ✅ | 1-64 ký tự · chỉ chữ thường + số + gạch nối `-` · không bắt đầu/kết thúc bằng `-` · không `--` · **PHẢI khớp tên thư mục** |
+| `description` | ✅ | 1-1024 ký tự · mô tả CẢ "làm gì" LẪN "khi nào dùng" · kèm trigger keyword |
+| `license` | tùy | tên license hoặc file LICENSE đính kèm |
+| `compatibility` | tùy | môi trường yêu cầu (≤500 ký tự) — chỉ khi thật cần |
+| `metadata` | tùy | key-value tùy ý (author, version...) |
+| `allowed-tools` | tùy | tool pre-approved (experimental) |
+
+Mẫu:
+```yaml
+---
+name: pdf-processing
+description: Trích text PDF, điền form, gộp file. Dùng khi xử lý tài liệu PDF.
+license: MIT
+metadata:
+  author: <your-name>
+  version: "1.0"
+---
+```
+
+## Body
+
+- Không giới hạn format — khuyến nghị: hướng dẫn từng bước · ví dụ input/output · edge cases
+- **Mỗi mảng kèm ví dụ input → output** (spec khuyến nghị) — người đọc biết chính xác vào ra
+- **Toàn bộ SKILL.md được load khi skill kích hoạt** → giữ < 500 dòng / < 5000 token
+- Cấu trúc lặp đều (kinh nghiệm egram): **quy tắc → code mẫu → checklist** mỗi mảng
+
+## Progressive disclosure (3 tầng)
+
+1. **Metadata** (~100 token): name + description — load ở startup MỌI session
+2. **SKILL.md body** (<5000 token): load khi skill được kích hoạt
+3. **Resources** (references/ scripts/ assets/): load theo nhu cầu — file nhỏ, focus 1 chủ đề
+
+## File references
+
+- Dùng đường dẫn **tương đối** từ gốc skill: `references/REFERENCE.md`
+- **1 cấp duy nhất** từ SKILL.md — cấm lồng sâu (references → con → cháu)
+- Không include file ngoài thư mục skill
+
+## Validation
+
+```bash
+skills-ref validate ./my-skill     # tool chính thức (npm)
+python3 scripts/validate-skill.py ./my-skill [--leak]   # bản tự viết (trong eskill)
+```
+
+Chạy validate TRƯỚC khi coi skill là xong — bắt: frontmatter hỏng, name sai quy tắc, ref vỡ, >500 dòng.

--- a/plugins/eskill/skills/eskill/references/test-prompts-template.md
+++ b/plugins/eskill/skills/eskill/references/test-prompts-template.md
@@ -1,0 +1,29 @@
+# Test Prompts Template — giả lập user thật (forward-test)
+
+Tạo 3-10 câu từ các kiểu dưới, thay `<nội dung>` theo skill. **KHÔNG lộ việc đang test skill.**
+
+## 5 kiểu test (mỗi skill nên có đủ)
+
+1. **Chính** — user yêu cầu ĐÚNG việc skill làm: "Dùng skill `<tên>` tại `<path>` để `<việc>` với `<input>`"
+2. **Biên (undertrigger)** — user yêu cầu gần giống, KHÔNG gõ tên skill — agent có tự bật skill không? Đây là test quan trọng nhất cho `description` "pushy"
+3. **Sai** — input không hợp lệ — skill báo lỗi gọn, không vỡ
+4. **Nhanh** — user vội, câu ngắn — output vẫn đúng format
+5. **Lớn** — input to (file dài, transcript) — có vượt context / progressive disclosure có được dùng không
+
+## Mẫu câu
+
+- `"Dùng skill <tên> tại <path> để <việc chính> với <input>"`
+- `"<input thật> — xử lý giúp tôi"` (không nhắc skill — test trigger)
+- `"Làm <việc lân cận có thể dùng skill>"` (test biên)
+- `"Input này sai/thiếu, báo lỗi rõ ràng"` (test sai)
+
+## Chấm pass
+
+- Agent TỰ tìm + dùng skill ĐÚNG cách (không làm tay qua loa)
+- Output đúng format, đúng luồng, đúng giọng điệu
+- Fail ở test biên = description chưa đủ "pushy" → sửa description, không sửa body
+
+## Quy tắc forward-test
+
+- Fresh thread mỗi lần · không lộ đáp án/bài học · dọn artifact giữa các lần (chống contamination)
+- Pass nhờ leaked context = skill chưa đủ → tighten lại

--- a/plugins/eskill/skills/eskill/scripts/eval-skill.py
+++ b/plugins/eskill/skills/eskill/scripts/eval-skill.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""eval-skill.py — Eval harness (Trụ 6): static check + test-set có version + trace verdict.
+
+Dùng:
+    python3 eval-skill.py <skill-dir> [--prompts <file.md>] [--record <file.json>]
+    python3 eval-skill.py <skill-dir> --verify   # tổng kết record: pass rate + trigger rate
+
+Chạy: 1) validate-skill.py (static) · 2) nạp test set (mặc định 5 loại hoặc file prompts)
+       3) ghi eval-results.json (trace — re-run được, đo regression sau mỗi lần sửa skill).
+
+BƯỚC TAY BẮT BUỘC (forward-test): với mỗi case, spawn agent MỚI (fork_context=false),
+đưa prompt giả lập user thật, đối chiếu rubric (references/rubric.md), điền rubric + verdict
++ evidence vào eval-results.json — không lộ đáp án cho agent test. Xong chạy --verify để tổng kết.
+"""
+import json
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+HERE = Path(__file__).parent
+VERSION = "1"
+
+
+def default_prompts():
+    return [
+        "Tạo skill để <việc X> và kiểm tra nó chạy được (case chính)",
+        "Cải thiện skill này tại <path> (case biên — skill có sẵn)",
+        "Validate skill này tại <path> (case nhanh — 1 lệnh)",
+        "Skill X báo lỗi khi chạy, debug giúp (case sai — error path)",
+        "Tạo 5 skill cùng lúc cho 5 việc khác nhau (case lớn — scale)",
+    ]
+
+
+def load_prompts(f, root):
+    if not f:
+        return []
+    text = f.read_text(encoding="utf-8")
+    return [ln.strip().lstrip("- ").strip() for ln in text.splitlines() if ln.strip().startswith("- ")]
+
+
+def _type(i):
+    return ["chính", "biên", "nhanh", "sai", "lớn"][i] if i < 5 else "mở rộng"
+
+
+def verify_run(record_file):
+    if not record_file.exists():
+        print(f"❌ Không có {record_file} — chạy eval-skill.py <skill-dir> trước (tạo record PENDING).")
+        sys.exit(1)
+    rec = json.loads(record_file.read_text(encoding="utf-8"))
+    cases = rec.get("test_cases", [])
+    n = len(cases)
+    passed = [c for c in cases if c.get("verdict") == "PASS"]
+    failed = [c for c in cases if c.get("verdict") == "FAIL"]
+    pending = [c for c in cases if c.get("verdict") not in ("PASS", "FAIL")]
+    no_rubric = [c for c in cases if not c.get("rubric")]
+    edge = [c for c in cases if c.get("type") == "biên"]
+    edge_pass = [c for c in edge if c.get("verdict") == "PASS"]
+    print(f"📊 {rec.get('skill')} · test-set v{rec.get('version', '?')} · {rec.get('date')}")
+    print(f"   Static validate: {'✅ PASS' if rec.get('static_pass') else '❌ FAIL'}")
+    for c in cases:
+        mark = "✅" if c.get("verdict") == "PASS" else ("❌" if c.get("verdict") == "FAIL" else "🔜")
+        print(f"   {mark} #{c['id']} [{c.get('type', '?')}] {str(c.get('verdict')):8s} {str(c.get('prompt', ''))[:55]}")
+    print(f"   — {len(passed)}/{n} PASS · {len(failed)} FAIL · {len(pending)} PENDING")
+    if no_rubric:
+        print(f"   ⚠️ {len(no_rubric)} case chưa khai rubric (bắt buộc pre-register — references/rubric.md)")
+    if edge:
+        pct = 100 * len(edge_pass) // len(edge)
+        verdict = "✅" if pct >= 80 else "❌"
+        print(f"   🎯 {verdict} Trigger rate (case biên): {len(edge_pass)}/{len(edge)} = {pct}% (mục tiêu ≥80%)")
+    if pending:
+        print("   🔜 Còn PENDING — điền verdict + evidence + rubric trong record rồi chạy lại --verify.")
+        sys.exit(2)
+    if failed or (edge and pct < 80):
+        print("   ❌ Chưa đạt Definition of Done (eval-loop.md) — sửa skill rồi lặp lại.")
+        sys.exit(3)
+    print("   ✅ Đạt Definition of Done — sang bước handoff verify cho user.")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Dùng: python3 eval-skill.py <skill-dir> [--prompts <file.md>] [--record <file.json>] [--verify]")
+        sys.exit(1)
+    root = Path(sys.argv[1]).resolve()
+    prompts_file = record_file = None
+    verify = False
+    args = sys.argv[2:]
+    if "--prompts" in args:
+        prompts_file = Path(args[args.index("--prompts") + 1])
+    if "--record" in args:
+        record_file = Path(args[args.index("--record") + 1])
+    if "--verify" in args:
+        verify = True
+    if record_file is None:
+        record_file = root / "eval-results.json"
+
+    if verify:
+        verify_run(record_file)
+        return
+
+    # 1. Static validate
+    val = subprocess.run(
+        [sys.executable, str(HERE / "validate-skill.py"), str(root)],
+        capture_output=True, text=True)
+    print(val.stdout)
+    static_ok = "✅ PASS" in val.stdout
+
+    # 2. Test set
+    prompts = load_prompts(prompts_file, root) or default_prompts()
+
+    # 3. Trace (versioned test set — re-run được)
+    rec = {"skill": root.name, "version": VERSION, "date": date.today().isoformat(),
+           "static_pass": static_ok,
+           "test_cases": [{"id": i + 1, "type": _type(i), "prompt": p[:100],
+                           "rubric": "", "verdict": "PENDING", "evidence": ""}
+                          for i, p in enumerate(prompts)]}
+    record_file.write_text(json.dumps(rec, ensure_ascii=False, indent=2))
+    print(f"📄 Test set {len(prompts)} case ghi: {record_file}")
+    print("🔜 BƯỚC TAY (bắt buộc): spawn agent MỚI cho từng case (không lộ đáp án),")
+    print("   đối chiếu rubric (references/rubric.md), điền rubric + verdict + evidence trong record,")
+    print("   rồi chạy: python3 eval-skill.py <skill-dir> --verify")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/eskill/skills/eskill/scripts/sell/.env.mẫu
+++ b/plugins/eskill/skills/eskill/scripts/sell/.env.mẫu
@@ -1,0 +1,12 @@
+# Copy file này thành .env rồi điền giá trị thật (không commit .env lên git)
+# Bot Telegram — tạo qua @BotFather
+TELEGRAM_BOT_TOKEN=<token_từ_botfather>
+# Chat ID của bạn (admin) — lấy qua @userinfobot
+SELLER_CHAT_ID=<chat_id_của_bạn>
+# Địa chỉ ví USDT của bạn trên OKX (chỉ nhận TRC20)
+OKX_USDT_ADDRESS=<địa_chỉ_ví_trc20>
+# Mạng + giá bán (USDT) — đuôi thập phân tự động thành mã đơn
+NETWORK=TRC20
+PRICE_USDT=50
+# Repo bán access
+REPO=<owner>/<repo>

--- a/plugins/eskill/skills/eskill/scripts/sell/grant_access.sh
+++ b/plugins/eskill/skills/eskill/scripts/sell/grant_access.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# grant_access.sh — Cấp / thu hồi quyền truy cập repo cho khách (bán access)
+# Chạy: bash grant_access.sh grant <username>        # cấp quyền đọc
+#       bash grant_access.sh revoke <username>       # thu hồi
+#       bash grant_access.sh list                    # danh sách người có quyền
+# Config qua .env cạnh script này (REPO=owner/name)
+set -e
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ENV_FILE="$HERE/.env"
+REPO=""
+
+[ -f "$ENV_FILE" ] && . "$ENV_FILE"
+[ -z "$REPO" ] && { echo "LỖI: thiếu REPO trong $ENV_FILE (vd REPO=<owner>/<repo>)"; exit 1; }
+
+action="${1:-}"
+user="${2:-}"
+
+case "$action" in
+  grant)
+    [ -z "$user" ] && { echo "Dùng: grant_access.sh grant <username>"; exit 2; }
+    gh api -X PUT "repos/$REPO/collaborators/$user" -f permission=pull >/dev/null
+    echo "[$(date +%Y-%m-%dT%H:%M:%S)] GRANT $user pull -> $REPO" >> "$HERE/access.log"
+    echo "✅ Đã cấp quyền pull cho $user trên $REPO"
+    ;;
+  revoke)
+    [ -z "$user" ] && { echo "Dùng: grant_access.sh revoke <username>"; exit 2; }
+    gh api -X DELETE "repos/$REPO/collaborators/$user" >/dev/null || true
+    echo "[$(date +%Y-%m-%dT%H:%M:%S)] REVOKE $user <- $REPO" >> "$HERE/access.log"
+    echo "✅ Đã thu hồi quyền của $user"
+    ;;
+  list)
+    gh api "repos/$REPO/collaborators?per_page=100" --jq '.[] | "\(.login) | \(.permissions.pull == true)"'
+    ;;
+  *)
+    echo "Dùng: grant_access.sh {grant|revoke|list} [username]"
+    exit 2
+    ;;
+esac

--- a/plugins/eskill/skills/eskill/scripts/sell/sales_bot.py
+++ b/plugins/eskill/skills/eskill/scripts/sell/sales_bot.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""sales_bot.py — Bot Telegram bán quyền truy cập repo (access selling).
+
+Luồng:
+    /buy                          → tạo đơn + gửi địa chỉ OKX USDT + số tiền độc nhất
+    /paid <TXID> <gh_username>    → verify blockchain → PASS thì cấp quyền repo
+    (admin) /grant <u> · /revoke <u> · /sales
+
+Chạy: python3 sales_bot.py            (cần .env cạnh script — xem .env.mẫu)
+Config: TELEGRAM_BOT_TOKEN · SELLER_CHAT_ID (admin) · OKX_USDT_ADDRESS ·
+        NETWORK=TRC20 · PRICE_USDT=50 · REPO=owner/name · MIN_CONFIRMATIONS=19
+
+An toàn (trụ 1 egram): lệnh admin whitelist theo chat_id · log mọi lỗi kèm timestamp ·
+chỉ tin kết quả verify_payment.py (blockchain), không tin ảnh chụp.
+"""
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / "sales.json"
+LOG = HERE / "sales.log"
+
+# ── .env loader (12-factor: không hardcode) ──
+def load_env():
+    env = {}
+    p = HERE / ".env"
+    if p.exists():
+        for line in p.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            env[k.strip()] = v.strip().strip("\"'")
+    return env
+
+ENV = load_env()
+TOKEN = ENV.get("TELEGRAM_BOT_TOKEN", "")
+ADMIN = ENV.get("SELLER_CHAT_ID", "")
+ADDRESS = ENV.get("OKX_USDT_ADDRESS", "")
+PRICE = float(ENV.get("PRICE_USDT", "50"))
+REPO = ENV.get("REPO", "")
+API = f"https://api.telegram.org/bot{TOKEN}"
+
+def log(msg):
+    line = f"[{time.strftime('%Y-%m-%dT%H:%M:%S')}] {msg}"
+    print(line)
+    with LOG.open("a", encoding="utf-8") as f:
+        f.write(line + "\n")
+
+# ── state (nguồn sự thật trên disk — trụ 6) ──
+def load_state():
+    if STATE.exists():
+        return json.loads(STATE.read_text(encoding="utf-8"))
+    return {"orders": [], "seq": 1}
+
+def save_state(state):
+    STATE.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
+
+def tg(method, payload):
+    req = urllib.request.Request(f"{API}/{method}", data=json.dumps(payload).encode(),
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+def reply(chat_id, text):
+    try:
+        tg("sendMessage", {"chat_id": chat_id, "text": text, "parse_mode": "HTML"})
+    except Exception as e:
+        log(f"LỖI gửi tin tới {chat_id}: {e}")
+
+# ── số tiền độc nhất: giá + đuôi mã đơn (vd 50.37) ──
+def order_amount(order_id):
+    return round(PRICE + (order_id % 100) / 100, 2)
+
+def find_order(state, chat_id):
+    return next((o for o in state["orders"] if o["chat_id"] == chat_id), None)
+
+# ── verify + grant ──
+def verify_payment(txid, amount):
+    """Gọi verify_payment.py — trả (ok, message)."""
+    r = subprocess.run([sys.executable, str(HERE / "verify_payment.py"),
+                        txid, str(amount), ADDRESS], capture_output=True, text=True, timeout=60)
+    out = (r.stdout or "").strip().splitlines()
+    last = out[-1] if out else r.stderr.strip()
+    return r.returncode == 0, last
+
+def grant(user):
+    r = subprocess.run(["bash", str(HERE / "grant_access.sh"), "grant", user],
+                       capture_output=True, text=True, timeout=60)
+    return r.returncode == 0, (r.stdout or r.stderr).strip()
+
+# ── xử lý lệnh ──
+def handle(cmd, args, chat_id):
+    state = load_state()
+    if cmd == "/buy":
+        order = find_order(state, chat_id)
+        if order and order["status"] in ("awaiting", "paid"):
+            return f"⏳ Bạn có đơn <b>#{order['order_id']}</b> ({order['amount']:.2f} USDT) chưa hoàn tất. Gửi /paid để tiếp tục."
+        seq = state["seq"]; state["seq"] += 1
+        amt = order_amount(seq)
+        state["orders"].append({"order_id": seq, "chat_id": chat_id, "amount": amt,
+                                "status": "awaiting", "txid": "", "gh_user": "", "created": time.time()})
+        save_state(state)
+        return (f"🧾 Đơn <b>#{seq}</b> — {amt:.2f} USDT (TRC20)\n\n"
+                f"📮 Chuyển đúng số tiền <b>{amt:.2f}</b> USDT tới:\n"
+                f"<code>{ADDRESS}</code>\n"
+                f"🌐 Mạng: <b>TRC20</b> (gửi nhầm mạng = mất tiền)\n\n"
+                f"Sau khi chuyển, gửi: /paid &lt;TXID&gt; &lt;github_username&gt;")
+    if cmd == "/paid":
+        order = find_order(state, chat_id)
+        if not order or order["status"] != "awaiting":
+            return "Không có đơn đang chờ — gửi /buy trước."
+        parts = args.split()
+        if len(parts) < 2:
+            return "Dùng: /paid &lt;TXID&gt; &lt;github_username&gt;"
+        txid, user = parts[0], parts[1]
+        order["txid"], order["gh_user"], order["status"] = txid, user, "paid"
+        save_state(state)
+        ok, msg = verify_payment(txid, order["amount"])
+        order["status"] = "verified" if ok else "paid"
+        order["verify_msg"] = msg
+        save_state(state)
+        if ok:
+            gok, gmsg = grant(user)
+            order["status"] = "granted" if gok else "verified"
+            save_state(state)
+            log(f"ĐƠN #{order['order_id']} khách {chat_id} trả {order['amount']:.2f} USDT — grant {user}: {'OK' if gok else gmsg}")
+            if ADMIN and str(chat_id) != ADMIN:
+                reply(ADMIN, f"💰 Đơn #{order['order_id']} — {order['amount']:.2f} USDT\nTXID: {txid[:16]}…\nGH: @{user}\n→ {'Đã cấp quyền' if gok else 'CẦN XỬ LÝ: ' + gmsg}")
+            return (f"✅ <b>Thanh toán xác nhận</b> — {msg}\n"
+                    f"→ Đã cấp quyền truy cập <b>{REPO}</b> cho @{user}\n"
+                    f"Hướng dẫn: <code>git clone https://github.com/{REPO}.git</code> (cần đăng nhập GH bằng tài khoản @{user})")
+        log(f"ĐƠN #{order['order_id']} verify FAIL: {msg}")
+        return f"❌ {msg}\nKiểm tra lại TXID hoặc chờ confirmed rồi gửi lại /paid."
+    if str(chat_id) == ADMIN:
+        if cmd == "/grant" and args.strip():
+            u = args.strip().split()[0]
+            ok, m = grant(u)
+            return ("✅ " if ok else "❌ ") + m
+        if cmd == "/revoke" and args.strip():
+            u = args.strip().split()[0]
+            r = subprocess.run(["bash", str(HERE / "grant_access.sh"), "revoke", u],
+                               capture_output=True, text=True, timeout=60)
+            return (r.stdout or r.stderr).strip()
+        if cmd == "/sales":
+            orders = state["orders"]
+            if not orders:
+                return "Chưa có đơn nào."
+            lines = [f"🧾 {len(orders)} đơn — {sum(o['amount'] for o in orders if o['status'] == 'granted'):.2f} USDT đã thu"]
+            for o in orders[-10:]:
+                lines.append(f"#{o['order_id']} {o['status']} {o['amount']:.2f}U @{o['gh_user'] or '-'} {o['txid'][:10] if o['txid'] else ''}")
+            return "\n".join(lines)
+    return ("Lệnh: /buy · /paid &lt;TXID&gt; &lt;username&gt;\n"
+            "Liên hệ hỗ trợ: admin")
+
+def main():
+    if not TOKEN or not ADMIN or not ADDRESS or not REPO:
+        log("LỖI: thiếu config — copy .env.mẫu thành .env và điền TELEGRAM_BOT_TOKEN/SELLER_CHAT_ID/OKX_USDT_ADDRESS/REPO")
+        sys.exit(1)
+    log(f"Sales bot chạy — repo {REPO} · giá {PRICE:.2f} USDT · admin {ADMIN}")
+    offset = 0
+    while True:
+        try:
+            updates = tg("getUpdates", {"offset": offset, "timeout": 30})
+            for u in updates.get("result", []):
+                offset = u["update_id"] + 1
+                msg = u.get("message") or {}
+                text = (msg.get("text") or "").strip()
+                chat_id = (msg.get("chat") or {}).get("id")
+                if not text or chat_id is None:
+                    continue
+                cmd, _, args = text.partition(" ")
+                if cmd in ("/buy", "/paid", "/grant", "/revoke", "/sales"):
+                    try:
+                        reply(chat_id, handle(cmd, args.strip(), chat_id))
+                    except Exception as e:
+                        log(f"LỖI xử lý {cmd} từ {chat_id}: {e}")
+                        reply(chat_id, "Lỗi hệ thống — thử lại sau.")
+        except Exception as e:
+            log(f"LỖI long-poll: {e}")
+            time.sleep(5)
+
+if __name__ == "__main__":
+    main()

--- a/plugins/eskill/skills/eskill/scripts/sell/verify_payment.py
+++ b/plugins/eskill/skills/eskill/scripts/sell/verify_payment.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""verify_payment.py — Xác minh thanh toán USDT (TRC20) qua tronscan public API.
+
+Chạy:
+    python3 verify_payment.py <TXID> <số_tiền_kỳ_vọng> [địa_chỉ_nhận_kỳ_vọng]
+
+Output: PASS nếu địa chỉ nhận + số tiền + confirmations đều khớp, FAIL kèm lý do.
+Chỉ tin bằng chứng blockchain — không tin ảnh chụp.
+
+Không cần API key — dùng tronscan public endpoint.
+"""
+import json
+import sys
+import urllib.request
+
+TRONSCAN_API = "https://apilist.tronscanapi.com/api/transaction-info?hash={txid}"
+MIN_CONFIRMATIONS = 19  # TRC20 an toàn sau ~19 blocks (~1-2 phút)
+
+
+def fetch_tx(txid: str) -> dict:
+    url = TRONSCAN_API.format(txid=txid.strip())
+    req = urllib.request.Request(url, headers={"User-Agent": "eskill-sell/1.0"})
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def verify(txid: str, expected_amount: float, expected_to: str = "") -> tuple[bool, str]:
+    txid = txid.strip()
+    if len(txid) != 64 or not all(c in "0123456789abcdefABCDEF" for c in txid):
+        return False, f"TXID không hợp lệ (cần 64 ký tự hex): {txid[:20]}…"
+    try:
+        data = fetch_tx(txid)
+    except Exception as e:
+        return False, f"Lỗi tra cứu tronscan: {e}"
+
+    # TXID tồn tại không?
+    if not data.get("hash"):
+        return False, "TXID không tồn tại trên blockchain (khách gửi TXID giả?)"
+
+    # Token phải là USDT (TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t) — tránh token scam
+    if data.get("contractData", {}).get("contract_address", "").lower() != "tr7nhqjekqxgtci8q8zy4pl8otszgjlj6t":
+        return False, "Token KHÔNG phải USDT TRC20 — từ chối"
+
+    # Địa chỉ nhận
+    to_addr = data.get("toAddress", "")
+    if expected_to:
+        expected_to = expected_to.strip().lower()
+        if to_addr.lower() != expected_to:
+            return False, f"Địa chỉ nhận không khớp: {to_addr} ≠ {expected_to}"
+
+    # Số tiền (đơn vị sun, 1 USDT = 1e6 sun)
+    try:
+        amount = int(data.get("contractData", {}).get("amount", 0)) / 1e6
+    except (TypeError, ValueError):
+        amount = 0.0
+    if amount < expected_amount - 0.01:  # sai số 0.01 USDT
+        return False, f"Số tiền không đủ: {amount:.2f} < {expected_amount:.2f}"
+
+    # Confirmations
+    confirmed = data.get("confirmed", False)
+    if not confirmed:
+        return False, "Giao dịch chưa confirmed — chờ vài phút rồi thử lại"
+
+    return True, (
+        f"PASS — USDT {amount:.2f} → {to_addr[:8]}…{to_addr[-6:]} | "
+        f"from {data.get('ownerAddress', '')[:8]}… | confirmed"
+    )
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Dùng: python3 verify_payment.py <TXID> <số_tiền_kỳ_vọng> [địa_chỉ_nhận_kỳ_vọng]")
+        sys.exit(2)
+    ok, msg = verify(sys.argv[1], float(sys.argv[2]), sys.argv[3] if len(sys.argv) > 3 else "")
+    print(("✅ " if ok else "❌ ") + msg)
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/eskill/skills/eskill/scripts/validate-skill.py
+++ b/plugins/eskill/skills/eskill/scripts/validate-skill.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""validate-skill.py — Kiểm tra Agent Skill theo spec agentskills.io + kinh nghiệm eskill.
+
+Chạy:
+    python3 validate-skill.py <skill-dir>                       # validate cơ bản
+    python3 validate-skill.py <skill-dir> --leak                # + quét rò rỉ thương mại
+    python3 validate-skill.py <skill-dir> --leak --brand "name1,name2"   # + quét brand/dịch vụ nội bộ
+
+Check: frontmatter (name/description) · quy tắc name (khớp thư mục) · description ≤1024 ·
+SKILL.md < 500 dòng · refs 1 cấp + file tồn tại · (--leak) secret/path/brand/chat_id.
+"""
+import re
+import sys
+from pathlib import Path
+
+FAILS = 0
+
+def ok(msg):
+    print(f"  ✅ {msg}")
+
+def bad(msg):
+    global FAILS
+    FAILS += 1
+    print(f"  ❌ {msg}")
+
+def main():
+    if len(sys.argv) < 2:
+        print("Dùng: python3 validate-skill.py <skill-dir> [--leak] [--brand \"a,b\"]")
+        sys.exit(1)
+    root = Path(sys.argv[1]).resolve()
+    leak = "--leak" in sys.argv
+    brands = []
+    if "--brand" in sys.argv:
+        i = sys.argv.index("--brand")
+        if i + 1 < len(sys.argv):
+            brands = [b.strip().lower() for b in sys.argv[i + 1].split(",") if b.strip()]
+    skill = root / "SKILL.md"
+
+    if not skill.exists():
+        bad(f"thiếu SKILL.md trong {root}")
+        sys.exit(1)
+    ok("có SKILL.md")
+
+    text = skill.read_text(encoding="utf-8")
+
+    # ── Frontmatter ──
+    m = re.match(r"^---\n(.*?)\n---\n", text, re.DOTALL)
+    if not m:
+        bad("thiếu YAML frontmatter (--- name/description ---)")
+    else:
+        fm = m.group(1)
+        has_name = re.search(r"^name\s*:\s*\S+", fm, re.M)
+        has_desc = re.search(r"^description\s*:", fm, re.M)
+        if has_name and has_desc:
+            ok("frontmatter có name + description")
+        else:
+            bad("frontmatter thiếu name hoặc description")
+
+        nm = re.search(r"^name\s*:\s*(\S+)", fm, re.M)
+        if nm:
+            name = nm.group(1)
+            if re.fullmatch(r"[a-z0-9]+(-[a-z0-9]+)*", name):
+                ok(f"name hợp lệ: {name}")
+            else:
+                bad(f"name sai quy tắc (chữ thường + gạch nối): {name}")
+            if root.name != name:
+                bad(f"name ({name}) KHÔNG khớp tên thư mục ({root.name})")
+            else:
+                ok(f"name = thư mục ({root.name})")
+
+        desc = re.search(r"^description\s*:\s*(.+)$", fm, re.M)
+        if desc and len(desc.group(1)) > 1024:
+            bad(f"description > 1024 ký tự ({len(desc.group(1))})")
+
+    # ── Body < 500 dòng ──
+    body = text.split("---", 2)[-1] if text.startswith("---") else text
+    n_lines = len(body.splitlines())
+    if n_lines > 500:
+        bad(f"SKILL.md > 500 dòng ({n_lines}) — đẩy chi tiết xuống references/")
+    else:
+        ok(f"SKILL.md {n_lines} dòng (< 500)")
+
+    # ── Refs 1 cấp + tồn tại ──
+    refs = re.findall(r"\]\(([^)]+)\)", body)
+    deep = [r for r in refs if r.startswith(("../", "../../", "/"))]
+    for r in deep:
+        bad(f"ref ngoài skill hoặc > 1 cấp: {r}")
+    local = [r for r in refs if r.startswith(("references/", "scripts/", "assets/"))]
+    missing = [r for r in local if not (root / r).exists()]
+    for r in missing:
+        bad(f"ref hỏng (file không tồn tại): {r}")
+    if local and not missing and not deep:
+        ok(f"{len(local)} ref cục bộ — 1 cấp + tồn tại")
+
+    # ── Leak mode ──
+    if leak:
+        patterns = {
+            "token bot": r"bot\d{8,}:[A-Za-z0-9_-]{20,}",
+            "API key": r"(sk-[A-Za-z0-9]{16,}|api[_-]?key\s*=\s*['\"]?[A-Za-z0-9]{12,}|AKIA[A-Z0-9]{16})",
+            "path cá nhân": r"/(Users|home)/",
+            "chat_id dài": r"\b\d{9,11}\b",
+            "access token Meta": r"EAA[A-Za-z0-9]{20,}",
+        }
+        hits = set()
+        for label, pat in patterns.items():
+            for mm in re.finditer(pat, text, re.IGNORECASE):
+                hits.add(f"{label}: {mm.group(0)[:20]}…")
+        if hits:
+            bad(f"RÒ RỈ ({len(hits)}): " + " · ".join(sorted(hits)))
+        else:
+            ok("không rò rỉ secret/path/chat_id")
+
+        if brands:
+            low = text.lower()
+            found = [b for b in brands if b in low]
+            if found:
+                bad(f"RÒ RỈ brand/dịch vụ nội bộ: {', '.join(found)}")
+            else:
+                ok(f"không dính brand nội bộ ({', '.join(brands)})")
+
+    print(f"\nKẾT QUẢ: {'❌ FAIL' if FAILS else '✅ PASS'} ({FAILS} lỗi)")
+    sys.exit(1 if FAILS else 0)
+
+if __name__ == "__main__":
+    main()

--- a/plugins/eskill/skills/eskill/template/SKILL.md
+++ b/plugins/eskill/skills/eskill/template/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: template-skill          # ← ĐỔI: chữ thường + gạch nối, PHẢI = tên thư mục (xem references/naming.md)
+description: >               # ← ĐỔI: ≤1024 ký tự — "làm gì" + "khi nào dùng" + trigger keyword, viết PUSHY
+  Mô tả skill làm gì và khi nào dùng. Nêu rõ trigger: câu chữ user hay dùng, context đi kèm.
+  Dùng khi user nói: "...", "...", hoặc làm việc với .... Dù user không gõ đúng tên skill vẫn phải bật
+  (chống undertrigger).
+# license: MIT              # ← tùy chọn: tên license (bán thương mại thì BẮT BUỘC)
+# compatibility:            # ← tùy chọn: yêu cầu môi trường (chỉ khi thật cần)
+# metadata:                 # ← tùy chọn: author, version... (đăng chợ: display_name eFamily)
+#   author: <your-name>
+#   version: "1.0"
+---
+
+# <Tên skill> — 1 dòng giá trị
+
+## <Mảng 1 — theo kim chỉ nam đã chọn>
+
+**Quy tắc:**
+1. ...
+2. ...
+
+**Code mẫu:**
+```python
+# ví dụ ngắn chạy được
+```
+
+**Ví dụ input → output:**
+```
+Input: ...
+Output: ...
+```
+
+**Checklist:**
+- [ ] ...
+
+## <Mảng 2>
+
+...
+
+## Bẫy — đừng lặp (tài sản lớn nhất của skill)
+
+1. **Triệu chứng lỗi** — fix: ...
+2. **Triệu chứng lỗi** — fix: ...
+
+## References (nếu cần — ref 1 cấp, đường dẫn tương đối)
+
+- `references/xxx.md` — mô tả ngắn khi nào mở file này


### PR DESCRIPTION
## What

Adds **eskill** as a plugin: a meta-skill (SKILL.md) that guides agents through building spec-compliant Agent Skills — interview first, market/insight research, one-page plan (Pyramid), numbered-file pipeline, eval loop, validator, commercialization checklist.

## Details

- plugins/eskill/ — plugin manifest (.claude-plugin/plugin.json) + full skill at skills/eskill/ (SKILL.md, references/, scripts/, template/, examples/, eval-results.json)
- Registered in .claude-plugin/marketplace.json (category: development)
- Regenerated all harness registries via tools/generate.py (codex, copilot, cursor, opencode, antigravity)
- tools/validate_generated.py passes: OK, no issues across 5 harness(es)

MIT-licensed, free (no paid funnel). Repo: https://github.com/hedralab/eskill
