### PR TITLE
feat: add superself plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1107,6 +1107,19 @@
       "category": "Coding"
     },
     {
+      "name": "superself",
+      "description": "Drive the Superself `self` CLI: version control for a project's state \u2014 goals, decisions, work units, reports \u2014 kept as an append-only event log outside the code repo, so a session reads `self context` at start, attaches work to a unit, reports with evidence, and the next session picks up where this one left off.",
+      "source": {
+        "source": "local",
+        "path": "./plugins/superself"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_USE"
+      },
+      "category": "Coding"
+    },
+    {
       "name": "systems-programming",
       "description": "Systems programming with Rust, Go, C, and C++ for performance-critical and low-level development",
       "source": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1012,6 +1012,19 @@
       "license": "Apache-2.0"
     },
     {
+      "name": "superself",
+      "source": "./plugins/superself",
+      "description": "Drive the Superself `self` CLI: version control for a project's state (goals, decisions, work units, reports) kept outside the code repo, so a session reads context at start, reports with evidence, and the next session picks up where this one left off",
+      "version": "1.0.0",
+      "author": {
+        "name": "fxylabs",
+        "url": "https://github.com/fxylabs"
+      },
+      "homepage": "https://github.com/fxylabs/superself",
+      "license": "Apache-2.0",
+      "category": "workflows"
+    },
+    {
       "name": "ui-design",
       "description": "Comprehensive UI/UX design plugin for mobile (iOS, Android, React Native) and web applications with design systems, accessibility, and modern patterns",
       "version": "1.0.5",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -950,6 +950,18 @@
       "license": "MIT"
     },
     {
+      "name": "superself",
+      "source": "./plugins/superself",
+      "version": "1.0.0",
+      "description": "Drive the Superself `self` CLI: version control for a project's state \u2014 goals, decisions, work units, reports \u2014 kept as an append-only event log outside the code repo, so a session reads `self context` at start, attaches work to a unit, reports with evidence, and the next session picks up where this one left off.",
+      "author": {
+        "name": "fxylabs",
+        "email": ""
+      },
+      "homepage": "https://github.com/fxylabs/superself",
+      "license": "Apache-2.0"
+    },
+    {
       "name": "systems-programming",
       "source": "./plugins/systems-programming",
       "version": "1.2.3",

--- a/.cursor-plugin/plugins/superself.json
+++ b/.cursor-plugin/plugins/superself.json
@@ -1,0 +1,12 @@
+{
+  "name": "superself",
+  "displayName": "Superself",
+  "version": "1.0.0",
+  "description": "Drive the Superself `self` CLI: version control for a project's state \u2014 goals, decisions, work units, reports \u2014 kept as an append-only event log outside the code repo, so a session reads `self context` at start, attaches work to a unit, reports with evidence, and the next session picks up where this one left off.",
+  "author": {
+    "name": "fxylabs",
+    "email": ""
+  },
+  "homepage": "https://github.com/fxylabs/superself",
+  "license": "Apache-2.0"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # claude-agents — multi-harness agentic plugin marketplace
 
-Production-ready agentic-workflow building blocks: **92 plugins** (91 local + 1 external), **202 agents**, **181 skills**, **105 commands**. Native source-of-truth for Claude Code; also consumed by OpenAI Codex CLI, Cursor, OpenCode, and the Google Antigravity CLI (`agy`) from a single Markdown source.
+Production-ready agentic-workflow building blocks: **93 plugins** (92 local + 1 external), **202 agents**, **182 skills**, **105 commands**. Native source-of-truth for Claude Code; also consumed by OpenAI Codex CLI, Cursor, OpenCode, and the Google Antigravity CLI (`agy`) from a single Markdown source.
 
 This file is the canonical context file. Codex / Cursor / OpenCode / Antigravity CLI read it directly. Claude Code reads it via `CLAUDE.md`, a symlink to this file.
 
@@ -10,7 +10,7 @@ This file is the canonical context file. Codex / Cursor / OpenCode / Antigravity
 
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — top-level architectural overview (adapter framework, source-of-truth invariant, capability matrix summary)
 - **[docs/architecture.md](docs/architecture.md)** — detailed design principles
-- **[docs/plugins.md](docs/plugins.md)** — full plugin catalog (92 plugins by category)
+- **[docs/plugins.md](docs/plugins.md)** — full plugin catalog (93 plugins by category)
 - **[docs/agents.md](docs/agents.md)** — agent reference (202 agents, model tiers)
 - **[docs/agent-skills.md](docs/agent-skills.md)** — skill reference (progressive disclosure model)
 - **[docs/usage.md](docs/usage.md)** — commands, workflows, examples
@@ -52,7 +52,7 @@ Generated artifacts are **committed** so each harness installs natively from a c
 
 ## Skills (cross-harness)
 
-181 skills under `plugins/*/skills/<n>/SKILL.md` — discoverable by every harness:
+182 skills under `plugins/*/skills/<n>/SKILL.md` — discoverable by every harness:
 
 - **Claude Code**: auto-discovery via Anthropic's SKILL.md spec
 - **Codex CLI**: mirrored to `.codex/skills/<plugin>__<skill>/` (8 KB body cap; detail in `references/details.md`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # claude-agents — multi-harness agentic plugin marketplace
 
-Production-ready agentic-workflow building blocks: **93 plugins** (91 local + 2 external), **202 agents**, **181 skills**, **105 commands**. Native source-of-truth for Claude Code; also consumed by OpenAI Codex CLI, Cursor, OpenCode, and the Google Antigravity CLI (`agy`) from a single Markdown source.
+Production-ready agentic-workflow building blocks: **94 plugins** (92 local + 2 external), **202 agents**, **182 skills**, **105 commands**. Native source-of-truth for Claude Code; also consumed by OpenAI Codex CLI, Cursor, OpenCode, and the Google Antigravity CLI (`agy`) from a single Markdown source.
 
 This file is the canonical context file. Codex / Cursor / OpenCode / Antigravity CLI read it directly. Claude Code reads it via `CLAUDE.md`, a symlink to this file.
 
@@ -10,7 +10,7 @@ This file is the canonical context file. Codex / Cursor / OpenCode / Antigravity
 
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — top-level architectural overview (adapter framework, source-of-truth invariant, capability matrix summary)
 - **[docs/architecture.md](docs/architecture.md)** — detailed design principles
-- **[docs/plugins.md](docs/plugins.md)** — full plugin catalog (93 plugins by category)
+- **[docs/plugins.md](docs/plugins.md)** — full plugin catalog (94 plugins by category)
 - **[docs/agents.md](docs/agents.md)** — agent reference (202 agents, model tiers)
 - **[docs/agent-skills.md](docs/agent-skills.md)** — skill reference (progressive disclosure model)
 - **[docs/usage.md](docs/usage.md)** — commands, workflows, examples
@@ -52,7 +52,7 @@ The small per-harness registries are **committed** so each harness installs nati
 
 ## Skills (cross-harness)
 
-181 skills under `plugins/*/skills/<n>/SKILL.md` — discoverable by every harness:
+182 skills under `plugins/*/skills/<n>/SKILL.md` — discoverable by every harness:
 
 - **Claude Code**: auto-discovery via Anthropic's SKILL.md spec
 - **Codex CLI**: mirrored to `.codex/skills/<plugin>__<skill>/` (8 KB body cap; detail in `references/details.md`)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,7 +25,7 @@ claude-agents/
 ├── CONTRIBUTING.md                 # Contributor entry point
 ├── .claude-plugin/marketplace.json # Plugin registry (source of truth)
 ├── .antigravity/plugins/<p>/       # Generated Antigravity CLI plugins (gitignored)
-├── plugins/                        # SOURCE OF TRUTH (91 local plugins; 2 external in marketplace)
+├── plugins/                        # SOURCE OF TRUTH (92 local plugins; 2 external in marketplace)
 │   └── <name>/
 │       ├── .claude-plugin/plugin.json
 │       ├── agents/*.md

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Agentic Plugin Marketplace
 
-> Production-ready agentic workflow building blocks: **93 plugins**, **202 agents**,
-> **181 skills**, **105 commands** — built for Claude Code and consumed natively by
+> Production-ready agentic workflow building blocks: **94 plugins**, **202 agents**,
+> **182 skills**, **105 commands** — built for Claude Code and consumed natively by
 > OpenAI Codex CLI, Cursor, OpenCode, the Antigravity CLI, and GitHub Copilot from a single Markdown source.
 
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-native-blueviolet)](#claude-code) [![Codex CLI](https://img.shields.io/badge/Codex%20CLI-supported-black)](docs/harnesses.md) [![Cursor](https://img.shields.io/badge/Cursor-supported-purple)](docs/harnesses.md) [![OpenCode](https://img.shields.io/badge/OpenCode-supported-green)](docs/harnesses.md) [![Antigravity CLI](https://img.shields.io/badge/Antigravity%20CLI-supported-blue)](docs/harnesses.md) [![Copilot](https://img.shields.io/badge/Copilot-supported-lightgrey)](docs/harnesses.md)
@@ -19,7 +19,7 @@ Pick your harness:
 
 ```bash
 /plugin marketplace add wshobson/agents
-/plugin install python-development          # or any of 93 plugins
+/plugin install python-development          # or any of 94 plugins
 ```
 
 [→ Full Claude Code setup, troubleshooting, and plugin catalog](docs/usage.md)
@@ -47,9 +47,9 @@ Setup details and per-harness gotchas: [docs/harnesses.md](docs/harnesses.md).
 
 | | Count | What it is |
 |---|---:|---|
-| **Plugins** | 93 | Granular, single-purpose installable units (91 local + 2 external via git-subdir) |
+| **Plugins** | 94 | Granular, single-purpose installable units (92 local + 2 external via git-subdir) |
 | **Agents** | 202 | Domain experts (architecture, languages, infra, security, data, ML, docs, business, SEO) |
-| **Skills** | 181 | Modular knowledge packages with progressive disclosure (load when activated) |
+| **Skills** | 182 | Modular knowledge packages with progressive disclosure (load when activated) |
 | **Commands** | 105 | Slash commands: scaffolding, security scans, test gen, infrastructure setup |
 | **Orchestrators** | 16 | Multi-agent coordination workflows (full-stack, security, ML, incident response) |
 
@@ -125,9 +125,9 @@ uv run plugin-eval certify path/to/skill
 
 Detail lives in `docs/`. Read in this order:
 
-- **[docs/plugins.md](docs/plugins.md)** — full catalog of all 93 plugins
+- **[docs/plugins.md](docs/plugins.md)** — full catalog of all 94 plugins
 - **[docs/agents.md](docs/agents.md)** — all 202 agents by category
-- **[docs/agent-skills.md](docs/agent-skills.md)** — 181 skills with progressive disclosure
+- **[docs/agent-skills.md](docs/agent-skills.md)** — 182 skills with progressive disclosure
 - **[docs/usage.md](docs/usage.md)** — commands, workflows, examples
 - **[docs/architecture.md](docs/architecture.md)** — design principles
 - **[docs/harnesses.md](docs/harnesses.md)** — cross-harness capability matrix

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Agentic Plugin Marketplace
 
-> Production-ready agentic workflow building blocks: **92 plugins**, **202 agents**,
-> **181 skills**, **105 commands** — built for Claude Code and consumed natively by
+> Production-ready agentic workflow building blocks: **93 plugins**, **202 agents**,
+> **182 skills**, **105 commands** — built for Claude Code and consumed natively by
 > OpenAI Codex CLI, Cursor, OpenCode, the Antigravity CLI, and GitHub Copilot from a single Markdown source.
 
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-native-blueviolet)](#claude-code) [![Codex CLI](https://img.shields.io/badge/Codex%20CLI-supported-black)](docs/harnesses.md) [![Cursor](https://img.shields.io/badge/Cursor-supported-purple)](docs/harnesses.md) [![OpenCode](https://img.shields.io/badge/OpenCode-supported-green)](docs/harnesses.md) [![Antigravity CLI](https://img.shields.io/badge/Antigravity%20CLI-supported-blue)](docs/harnesses.md) [![Copilot](https://img.shields.io/badge/Copilot-supported-lightgrey)](docs/harnesses.md)
@@ -19,7 +19,7 @@ Pick your harness:
 
 ```bash
 /plugin marketplace add wshobson/agents
-/plugin install python-development          # or any of 92 plugins
+/plugin install python-development          # or any of 93 plugins
 ```
 
 [→ Full Claude Code setup, troubleshooting, and plugin catalog](docs/usage.md)
@@ -47,9 +47,9 @@ Setup details and per-harness gotchas: [docs/harnesses.md](docs/harnesses.md).
 
 | | Count | What it is |
 |---|---:|---|
-| **Plugins** | 92 | Granular, single-purpose installable units (91 local + 1 external via git-subdir) |
+| **Plugins** | 93 | Granular, single-purpose installable units (92 local + 1 external via git-subdir) |
 | **Agents** | 202 | Domain experts (architecture, languages, infra, security, data, ML, docs, business, SEO) |
-| **Skills** | 181 | Modular knowledge packages with progressive disclosure (load when activated) |
+| **Skills** | 182 | Modular knowledge packages with progressive disclosure (load when activated) |
 | **Commands** | 105 | Slash commands: scaffolding, security scans, test gen, infrastructure setup |
 | **Orchestrators** | 16 | Multi-agent coordination workflows (full-stack, security, ML, incident response) |
 
@@ -125,9 +125,9 @@ uv run plugin-eval certify path/to/skill
 
 Detail lives in `docs/`. Read in this order:
 
-- **[docs/plugins.md](docs/plugins.md)** — full catalog of all 92 plugins
+- **[docs/plugins.md](docs/plugins.md)** — full catalog of all 93 plugins
 - **[docs/agents.md](docs/agents.md)** — all 202 agents by category
-- **[docs/agent-skills.md](docs/agent-skills.md)** — 181 skills with progressive disclosure
+- **[docs/agent-skills.md](docs/agent-skills.md)** — 182 skills with progressive disclosure
 - **[docs/usage.md](docs/usage.md)** — commands, workflows, examples
 - **[docs/architecture.md](docs/architecture.md)** — design principles
 - **[docs/harnesses.md](docs/harnesses.md)** — cross-harness capability matrix

--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -1,6 +1,6 @@
 # Agent Skills
 
-Agent Skills are modular packages that extend Claude's capabilities with specialized domain knowledge, following Anthropic's [Agent Skills Specification](https://github.com/anthropics/skills/blob/main/agent_skills_spec.md). This plugin ecosystem includes **181 local specialized skills** across 50 plugins, enabling progressive disclosure and efficient token usage.
+Agent Skills are modular packages that extend Claude's capabilities with specialized domain knowledge, following Anthropic's [Agent Skills Specification](https://github.com/anthropics/skills/blob/main/agent_skills_spec.md). This plugin ecosystem includes **182 local specialized skills** across 51 plugins, enabling progressive disclosure and efficient token usage.
 
 ## Overview
 
@@ -188,6 +188,12 @@ Skills provide Claude with deep expertise in specific domains without loading ev
 | Skill                | Description                                                                                                 |
 | -------------------- | ----------------------------------------------------------------------------------------------------------- |
 | **avoid-ai-writing** | Audit and rewrite prose that reads as machine-generated, with detect-only, rewrite, and edit-in-place modes   |
+
+### Superself (1 skill)
+
+| Skill         | Description                                                                                                                   |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| **superself** | Drive the Superself `self` CLI: read `self context` at session start, attach work to a unit, report with evidence, close with proof |
 
 ### Data Engineering (4 skills)
 
@@ -431,7 +437,7 @@ fastapi-templates skill → Supplies production-ready templates
 
 ## Specification Compliance
 
-All 181 skills follow the [Agent Skills Specification](https://agentskills.io/specification):
+All 182 skills follow the [Agent Skills Specification](https://agentskills.io/specification):
 
 - ✓ Required `name` field (hyphen-case)
 - ✓ Required `description` field with "Use when" clause

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,7 +36,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 
 ### Plugin Distribution
 
-- **93 marketplace plugins** (91 local + 2 external via git-subdir) optimized for specific use cases
+- **94 marketplace plugins** (92 local + 2 external via git-subdir) optimized for specific use cases
 - **26 clear categories** with 1-10 plugins each for easy discovery
 - Organized by domain:
   - **Development**: 6 plugins (debugging, backend, frontend, UI, multi-platform, essentials)
@@ -69,11 +69,11 @@ This marketplace follows industry best practices with a focus on granularity, co
   - Component scaffolding (React, React Native)
   - Infrastructure setup (Terraform, Kubernetes)
 
-**181 Local Agent Skills**
+**182 Local Agent Skills**
 
 - Modular knowledge packages
 - Progressive disclosure architecture
-- Domain-specific expertise across 49 plugins
+- Domain-specific expertise across 51 plugins
 - Spec-compliant (Anthropic Agent Skills Specification)
 
 ## Repository Structure
@@ -81,7 +81,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 ```
 claude-agents/
 ├── .claude-plugin/
-│   └── marketplace.json          # Marketplace catalog (93 plugins)
+│   └── marketplace.json          # Marketplace catalog (94 plugins)
 ├── plugins/                       # Isolated plugin directories
 │   ├── python-development/
 │   │   ├── agents/               # Python language agents
@@ -194,7 +194,7 @@ description: What the skill does. Use when [trigger]. # Required: < 1024 chars
 - **Composability**: Mix and match skills across workflows
 - **Maintainability**: Isolated updates don't affect other skills
 
-See [Agent Skills](./agent-skills.md) for complete details on the 181 skills.
+See [Agent Skills](./agent-skills.md) for complete details on the 182 skills.
 
 ## Model Configuration Strategy
 
@@ -393,5 +393,5 @@ Feature Development Workflow:
 
 - [Agent Skills](./agent-skills.md) - Modular knowledge packages
 - [Agent Reference](./agents.md) - Complete agent catalog
-- [Plugin Reference](./plugins.md) - All 93 marketplace plugins
+- [Plugin Reference](./plugins.md) - All 94 marketplace plugins
 - [Usage Guide](./usage.md) - Commands and workflows

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,7 +36,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 
 ### Plugin Distribution
 
-- **92 marketplace plugins** (91 local + 1 external via git-subdir) optimized for specific use cases
+- **93 marketplace plugins** (92 local + 1 external via git-subdir) optimized for specific use cases
 - **26 clear categories** with 1-10 plugins each for easy discovery
 - Organized by domain:
   - **Development**: 6 plugins (debugging, backend, frontend, UI, multi-platform, essentials)
@@ -69,7 +69,7 @@ This marketplace follows industry best practices with a focus on granularity, co
   - Component scaffolding (React, React Native)
   - Infrastructure setup (Terraform, Kubernetes)
 
-**181 Local Agent Skills**
+**182 Local Agent Skills**
 
 - Modular knowledge packages
 - Progressive disclosure architecture
@@ -81,7 +81,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 ```
 claude-agents/
 ├── .claude-plugin/
-│   └── marketplace.json          # Marketplace catalog (92 plugins)
+│   └── marketplace.json          # Marketplace catalog (93 plugins)
 ├── plugins/                       # Isolated plugin directories
 │   ├── python-development/
 │   │   ├── agents/               # Python language agents
@@ -194,7 +194,7 @@ description: What the skill does. Use when [trigger]. # Required: < 1024 chars
 - **Composability**: Mix and match skills across workflows
 - **Maintainability**: Isolated updates don't affect other skills
 
-See [Agent Skills](./agent-skills.md) for complete details on the 181 skills.
+See [Agent Skills](./agent-skills.md) for complete details on the 182 skills.
 
 ## Model Configuration Strategy
 
@@ -393,5 +393,5 @@ Feature Development Workflow:
 
 - [Agent Skills](./agent-skills.md) - Modular knowledge packages
 - [Agent Reference](./agents.md) - Complete agent catalog
-- [Plugin Reference](./plugins.md) - All 92 marketplace plugins
+- [Plugin Reference](./plugins.md) - All 93 marketplace plugins
 - [Usage Guide](./usage.md) - Commands and workflows

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,6 +1,6 @@
 # Complete Plugin Reference
 
-Browse all **93 marketplace plugins** organized by category: 91 local plugins plus 2 externally hosted `git-subdir` entries (`pensyve` and `hol-guard`).
+Browse all **94 marketplace plugins** organized by category: 92 local plugins plus 2 externally hosted `git-subdir` entries (`pensyve` and `hol-guard`).
 
 ## Quick Start - Essential Plugins
 
@@ -129,7 +129,7 @@ Next.js, React + Vite, and Node.js project setup with pnpm and TypeScript best p
 | **c4-architecture**          | Comprehensive C4 architecture documentation workflow with bottom-up code analysis, component synthesis, container mapping, and context diagrams | `/plugin install c4-architecture`          |
 | **avoid-ai-writing**         | Audit and rewrite prose that reads as machine-generated across READMEs, changelogs, PR descriptions, and docs                                    | `/plugin install avoid-ai-writing`         |
 
-### 🔄 Workflows (7 plugins)
+### 🔄 Workflows (8 plugins)
 
 | Plugin                       | Description                                                                    | Install                                    |
 | ---------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------ |
@@ -140,6 +140,7 @@ Next.js, React + Vite, and Node.js project setup with pnpm and TypeScript best p
 | **tdd-workflows**            | Test-driven development methodology                                            | `/plugin install tdd-workflows`            |
 | **agent-teams**              | Parallel code review, debugging, feature, and research teams                   | `/plugin install agent-teams`              |
 | **ship-mate**                | Story-file to reviewed, tested PR workflow orchestration                       | `/plugin install ship-mate`                |
+| **superself**                | Drive the Superself `self` CLI: project state (goals, decisions, work units, reports) outside the code repo, context at session start, done gated by evidence | `/plugin install superself`                |
 
 ### ✅ Testing (1 plugin)
 
@@ -364,7 +365,7 @@ plugins/python-development/
 /plugin marketplace add wshobson/agents
 ```
 
-This makes all 93 marketplace plugins available for installation, but **does not load any agents or tools** into your context.
+This makes all 94 marketplace plugins available for installation, but **does not load any agents or tools** into your context.
 
 ### Step 2: Install Specific Plugins
 
@@ -407,7 +408,7 @@ Each installed plugin loads **only its specific agents, commands, and skills** i
 
 ## See Also
 
-- [Agent Skills](./agent-skills.md) - 181 specialized skills across plugins
+- [Agent Skills](./agent-skills.md) - 182 specialized skills across plugins
 - [Agent Reference](./agents.md) - Complete agent catalog
 - [Usage Guide](./usage.md) - Commands and workflows
 - [Architecture](./architecture.md) - Design principles

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,6 +1,6 @@
 # Complete Plugin Reference
 
-Browse all **92 marketplace plugins** organized by category: 91 local plugins plus 1 externally hosted `git-subdir` entry (`pensyve`).
+Browse all **93 marketplace plugins** organized by category: 92 local plugins plus 1 externally hosted `git-subdir` entry (`pensyve`).
 
 ## Quick Start - Essential Plugins
 
@@ -129,7 +129,7 @@ Next.js, React + Vite, and Node.js project setup with pnpm and TypeScript best p
 | **c4-architecture**          | Comprehensive C4 architecture documentation workflow with bottom-up code analysis, component synthesis, container mapping, and context diagrams | `/plugin install c4-architecture`          |
 | **avoid-ai-writing**         | Audit and rewrite prose that reads as machine-generated across READMEs, changelogs, PR descriptions, and docs                                    | `/plugin install avoid-ai-writing`         |
 
-### 🔄 Workflows (7 plugins)
+### 🔄 Workflows (8 plugins)
 
 | Plugin                       | Description                                                                    | Install                                    |
 | ---------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------ |
@@ -140,6 +140,7 @@ Next.js, React + Vite, and Node.js project setup with pnpm and TypeScript best p
 | **tdd-workflows**            | Test-driven development methodology                                            | `/plugin install tdd-workflows`            |
 | **agent-teams**              | Parallel code review, debugging, feature, and research teams                   | `/plugin install agent-teams`              |
 | **ship-mate**                | Story-file to reviewed, tested PR workflow orchestration                       | `/plugin install ship-mate`                |
+| **superself**                | Drive the Superself `self` CLI: project state (goals, decisions, work units, reports) outside the code repo, context at session start, done gated by evidence | `/plugin install superself`                |
 
 ### ✅ Testing (1 plugin)
 
@@ -363,7 +364,7 @@ plugins/python-development/
 /plugin marketplace add wshobson/agents
 ```
 
-This makes all 92 marketplace plugins available for installation, but **does not load any agents or tools** into your context.
+This makes all 93 marketplace plugins available for installation, but **does not load any agents or tools** into your context.
 
 ### Step 2: Install Specific Plugins
 
@@ -406,7 +407,7 @@ Each installed plugin loads **only its specific agents, commands, and skills** i
 
 ## See Also
 
-- [Agent Skills](./agent-skills.md) - 181 specialized skills across plugins
+- [Agent Skills](./agent-skills.md) - 182 specialized skills across plugins
 - [Agent Reference](./agents.md) - Complete agent catalog
 - [Usage Guide](./usage.md) - Commands and workflows
 - [Architecture](./architecture.md) - Design principles

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -403,11 +403,11 @@ User: "Implement Kubernetes deployment with Helm"
 → Result: Production-grade K8s manifests with Helm charts
 ```
 
-See [Agent Skills](./agent-skills.md) for details on the 181 specialized skills.
+See [Agent Skills](./agent-skills.md) for details on the 182 specialized skills.
 
 ## See Also
 
 - [Agent Skills](./agent-skills.md) - Specialized knowledge packages
 - [Agent Reference](./agents.md) - Complete agent catalog
-- [Plugin Reference](./plugins.md) - All 92 marketplace plugins
+- [Plugin Reference](./plugins.md) - All 93 marketplace plugins
 - [Architecture](./architecture.md) - Design principles

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -403,11 +403,11 @@ User: "Implement Kubernetes deployment with Helm"
 → Result: Production-grade K8s manifests with Helm charts
 ```
 
-See [Agent Skills](./agent-skills.md) for details on the 181 specialized skills.
+See [Agent Skills](./agent-skills.md) for details on the 182 specialized skills.
 
 ## See Also
 
 - [Agent Skills](./agent-skills.md) - Specialized knowledge packages
 - [Agent Reference](./agents.md) - Complete agent catalog
-- [Plugin Reference](./plugins.md) - All 93 marketplace plugins
+- [Plugin Reference](./plugins.md) - All 94 marketplace plugins
 - [Architecture](./architecture.md) - Design principles

--- a/plugins/superself/.claude-plugin/plugin.json
+++ b/plugins/superself/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "superself",
+  "version": "1.0.0",
+  "description": "Drive the Superself `self` CLI: version control for a project's state — goals, decisions, work units, reports — kept as an append-only event log outside the code repo, so a session reads `self context` at start, attaches work to a unit, reports with evidence, and the next session picks up where this one left off.",
+  "author": {
+    "name": "fxylabs",
+    "url": "https://github.com/fxylabs"
+  },
+  "homepage": "https://github.com/fxylabs/superself",
+  "license": "Apache-2.0"
+}

--- a/plugins/superself/.codex-plugin/plugin.json
+++ b/plugins/superself/.codex-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "superself",
+  "version": "1.0.0",
+  "description": "Drive the Superself `self` CLI: version control for a project's state \u2014 goals, decisions, work units, reports \u2014 kept as an append-only event log outside the code repo, so a session reads `self context` at start, attaches work to a unit, reports with evidence, and the next session picks up where this one left off.",
+  "skills": "./skills/",
+  "author": {
+    "name": "fxylabs",
+    "url": "https://github.com/fxylabs"
+  },
+  "homepage": "https://github.com/fxylabs/superself",
+  "license": "Apache-2.0",
+  "interface": {
+    "displayName": "Superself",
+    "shortDescription": "Drive the Superself `self` CLI: version control for a project's state \u2014 goals, decisions, work units, reports \u2014 kept\u2026",
+    "category": "Coding"
+  }
+}

--- a/plugins/superself/README.md
+++ b/plugins/superself/README.md
@@ -1,0 +1,17 @@
+# Superself
+
+One skill that teaches an agent to drive the [Superself](https://github.com/fxylabs/superself) `self` CLI when a project keeps its state there.
+
+Superself is a free, Apache-2.0, local-first CLI (`npm install -g superself@0.6.1`, Node 22.12+, no account or service) that version-controls a project's state — goals, decisions, work units, reports — as an append-only event log in a git repository separate from the code. `self connect` **writes a managed block** (between `<!-- superself:begin` and `<!-- superself:end -->`) **into the project's `AGENTS.md` or `CLAUDE.md`** — the skill never runs it or `self project init` without asking the user first; `self context` prints the derived context a session reads at start; `self work done` refuses a claim that carries no evidence.
+
+**Disclosure:** this plugin is maintained by the Superself authors (fxylabs). It wraps our own open-source CLI. It contains no hooks and no MCP server; the skill only issues `self` commands in the shell.
+
+**Hosted tier:** the pinned `superself@0.6.1` contains no network code and talks to no service. Superself 0.7.0 and later add an optional hosted service (`self login`, `self app`, at app.superselfs.com) for installing signed mini-apps; the core verbs this skill documents stay local and free, and the pin keeps this listing on the version that was reviewed. A version bump goes through a PR here.
+
+## Skill
+
+- `superself` — Use when a project keeps its state in Superself (a `<!-- superself:begin` block in AGENTS.md or CLAUDE.md, or `self setup` resolves the directory to a registered project). Covers session start (`self context`), working (`self work add/start`, `self report`, `self decide`), closing (`self work done` with evidence), and the rules that keep the record trustworthy.
+
+## Requirements
+
+- The `self` CLI on PATH (`npm install -g superself@0.6.1` — pinned; bumps go through a PR to this catalog). The skill tells the agent to skip itself when `self --version` fails.

--- a/plugins/superself/README.md
+++ b/plugins/superself/README.md
@@ -1,0 +1,15 @@
+# Superself
+
+One skill that teaches an agent to drive the [Superself](https://github.com/fxylabs/superself) `self` CLI when a project keeps its state there.
+
+Superself is a free, Apache-2.0, local-first CLI (`npm install -g superself`, Node 22.12+, no account or service) that version-controls a project's state — goals, decisions, work units, reports — as an append-only event log in a git repository separate from the code. `self connect` renders a managed block into `AGENTS.md`/`CLAUDE.md`; `self context` prints the derived context a session reads at start; `self work done` refuses a claim that carries no evidence.
+
+**Disclosure:** this plugin is maintained by the Superself authors (fxylabs). It wraps our own open-source CLI. It contains no hooks and no MCP server; the skill only issues `self` commands in the shell.
+
+## Skill
+
+- `superself` — Use when a project keeps its state in Superself (a `<!-- superself:begin` block in AGENTS.md or CLAUDE.md, or `self setup` resolves the directory to a registered project). Covers session start (`self context`), working (`self work add/start`, `self report`, `self decide`), closing (`self work done` with evidence), and the rules that keep the record trustworthy.
+
+## Requirements
+
+- The `self` CLI on PATH (`npm install -g superself`). The skill tells the agent to skip itself when `self --version` fails.

--- a/plugins/superself/skills/superself/SKILL.md
+++ b/plugins/superself/skills/superself/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: superself
+description: 'Use when a project keeps its state in Superself (a `<!-- superself:begin` block in AGENTS.md or CLAUDE.md, or `self setup` resolves the directory to a registered project): read `self context` at session start, attach work to a work unit, report with evidence, and record confirmed decisions so the next session picks up where this one left off.'
+---
+
+# Superself
+
+Superself is an Apache-2.0 CLI (`npm install -g superself@0.6.1`, Node 22.12+) that
+version-controls a project's state — goals, decisions, work units, reports —
+as an append-only event log in a git repository separate from the code. The
+state is derived on demand, so nothing in it is hand-maintained. This skill
+tells an agent how to read and write that state through the `self` CLI. It is
+maintained by the Superself authors: https://github.com/fxylabs/superself
+
+## When this skill applies
+
+- The project's `AGENTS.md` or `CLAUDE.md` contains a block between
+  `<!-- superself:begin` and `<!-- superself:end -->`, or `self setup` prints
+  the workspace, project, and store this directory resolves to.
+- Skip the skill when `self --version` fails: the project does not use
+  Superself, and nothing below should be invented by hand. This skill is
+  written against `superself@0.6.1`; a different major or minor version may
+  have moved a verb or flag, so check `self <command> --help` before relying
+  on one.
+
+## Session start
+
+1. Run `self context` and treat its output as current truth: the goal, active
+   decisions and conventions, open work, recent reports. It is folded from the
+   log, never written by hand.
+2. Something missing from context was placed out of the rendered set on
+   purpose; `self search <query>` finds live records context left out, and
+   `self work show <id>` prints one unit's full brief and report history.
+
+## While working
+
+- Substantive work attaches to a work unit. Create one with
+  `self work add "<required outcome>"` — the outcome is what must become true,
+  not the task — then `self work start <id>`. `start` reads the brief and
+  records that this session picked the unit up; if another session holds it,
+  the CLI says who and since when and does not refuse. Judge and proceed.
+- After committing, report progress: `self report <id> "<what happened>"`. The
+  current HEAD commit is attached as evidence automatically; `--evidence
+  <commit|note>` attaches something else, `--file <path>` attaches a longer
+  brief.
+- Record a decision the user confirmed: `self decide "<text>" --why "<reason>"`.
+  Use `--proposed` when the user has not confirmed it. One decision per event.
+- Blocked? `self work block <id> --on decision|dependency|external --why "..."`.
+  Superseded or moved? `self work retire <id> --why "..." [--successor <id>]`.
+  Never mark such a unit done, and never leave it falsely blocked.
+- Found a gap between an objective and the current state? Propose the work with
+  `self work propose` and its brief; the user accepts or declines it.
+- The user approved a next step or a continuation? Register it at once with
+  `self work add` and the context behind it. A plan that lives only in the
+  conversation is lost when the conversation ends.
+
+## Closing
+
+- `self work done <id>` closes a unit only when a report carries a commit or an
+  artifact, or the done itself states what verifiably happened:
+  `self work done <id> --report "<what verifiably happened>"`. A bare claim is
+  refused, and declared criteria gate it until each is covered.
+- A record's text is immutable once confirmed. Correct it by restating:
+  `--supersedes <id>` on any add verb records the new wording and keeps the
+  lineage. `retract` withdraws a record with nothing replacing it.
+
+## Rules that keep the state trustworthy
+
+- Records — events, decisions, reports, conventions — are written in English
+  so whoever opens them next can read them; answer the person in their own
+  language.
+- A branch reaches main through a pull request: PR review and CI own merge
+  control. Superself owns context and the work graph, not the merge gate.
+- Never hand-edit generated state files or anything under `.superself/`.
+- In a project without a superself block, run `self setup` first. If it
+  resolves the directory to a registered project, ask the user once whether
+  to run `self connect`, which writes the managed block into `AGENTS.md` or
+  `CLAUDE.md`. If it resolves no project, ask once whether to register it with
+  `self project init`. Never register or connect a project on your own.
+
+## Going deeper
+
+`self --help` lists every verb; `self <command> --help` prints one command's
+flags without touching state. Topic guides ship with the CLI:
+
+- `self help agents` — how a session drives this CLI, start to finish
+- `self help context` — what `self context` renders, and why something is missing from it
+- `self help records` — one entity behind every record kind, and how a record is corrected
+- `self help placement` — scope, priority and exposure — how a record earns its place in context
+- `self help work` — the work graph: outcomes, evidence, criteria, and proposals
+- `self help goals` — long-term goals, objectives, milestones, and what reaching one takes
+- `self help workspace` — the store, the projects in it, and moving it between machines

--- a/plugins/superself/skills/superself/SKILL.md
+++ b/plugins/superself/skills/superself/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: superself
+description: 'Use when a project keeps its state in Superself (a `<!-- superself:begin` block in AGENTS.md or CLAUDE.md, or `self setup` resolves the directory to a registered project): read `self context` at session start, attach work to a work unit, report with evidence, and record confirmed decisions so the next session picks up where this one left off.'
+---
+
+# Superself
+
+Superself is an Apache-2.0 CLI (`npm install -g superself`, Node 22.12+) that
+version-controls a project's state — goals, decisions, work units, reports —
+as an append-only event log in a git repository separate from the code. The
+state is derived on demand, so nothing in it is hand-maintained. This skill
+tells an agent how to read and write that state through the `self` CLI. It is
+maintained by the Superself authors: https://github.com/fxylabs/superself
+
+## When this skill applies
+
+- The project's `AGENTS.md` or `CLAUDE.md` contains a block between
+  `<!-- superself:begin` and `<!-- superself:end -->`, or `self setup` prints
+  the workspace, project, and store this directory resolves to.
+- Skip the skill when `self --version` fails: the project does not use
+  Superself, and nothing below should be invented by hand.
+
+## Session start
+
+1. Run `self context` and treat its output as current truth: the goal, active
+   decisions and conventions, open work, recent reports. It is folded from the
+   log, never written by hand.
+2. Something missing from context was placed out of the rendered set on
+   purpose; `self search <query>` finds live records context left out, and
+   `self work show <id>` prints one unit's full brief and report history.
+
+## While working
+
+- Substantive work attaches to a work unit. Create one with
+  `self work add "<required outcome>"` — the outcome is what must become true,
+  not the task — then `self work start <id>`. `start` reads the brief and
+  records that this session picked the unit up; if another session holds it,
+  the CLI says who and since when and does not refuse. Judge and proceed.
+- After committing, report progress: `self report <id> "<what happened>"`. The
+  current HEAD commit is attached as evidence automatically; `--evidence
+  <commit|note>` attaches something else, `--file <path>` attaches a longer
+  brief.
+- Record a decision the user confirmed: `self decide "<text>" --why "<reason>"`.
+  Use `--proposed` when the user has not confirmed it. One decision per event.
+- Blocked? `self work block <id> --on decision|dependency|external --why "..."`.
+  Superseded or moved? `self work retire <id> --why "..." [--successor <id>]`.
+  Never mark such a unit done, and never leave it falsely blocked.
+- Found a gap between an objective and the current state? Propose the work with
+  `self work propose` and its brief; the user accepts or declines it.
+- The user approved a next step or a continuation? Register it at once with
+  `self work add` and the context behind it. A plan that lives only in the
+  conversation is lost when the conversation ends.
+
+## Closing
+
+- `self work done <id>` closes a unit only when a report carries a commit or an
+  artifact, or the done itself states what verifiably happened:
+  `self work done <id> --report "<what verifiably happened>"`. A bare claim is
+  refused, and declared criteria gate it until each is covered.
+- A record's text is immutable once confirmed. Correct it by restating:
+  `--supersedes <id>` on any add verb records the new wording and keeps the
+  lineage. `retract` withdraws a record with nothing replacing it.
+
+## Rules that keep the state trustworthy
+
+- Records — events, decisions, reports, conventions — are written in English
+  so whoever opens them next can read them; answer the person in their own
+  language.
+- A branch reaches main through a pull request: PR review and CI own merge
+  control. Superself owns context and the work graph, not the merge gate.
+- Never hand-edit generated state files or anything under `.superself/`.
+- In a project without a superself block, ask the user once whether to
+  register it with `self project init`. Never register a project on your own.
+
+## Going deeper
+
+`self --help` lists every verb; `self <command> --help` prints one command's
+flags without touching state. Topic guides ship with the CLI:
+
+- `self help agents` — how a session drives this CLI, start to finish
+- `self help context` — what `self context` renders, and why something is missing from it
+- `self help records` — one entity behind every record kind, and how a record is corrected
+- `self help placement` — scope, priority and exposure — how a record earns its place in context
+- `self help work` — the work graph: outcomes, evidence, criteria, and proposals
+- `self help goals` — long-term goals, objectives, milestones, and what reaching one takes
+- `self help workspace` — the store, the projects in it, and moving it between machines


### PR DESCRIPTION
## Summary

- Adds a local plugin `superself` with one skill that teaches a session to drive the Superself `self` CLI (read `self context` at start, attach work to a unit, report with evidence, close only with proof, record confirmed decisions).
- Adds the marketplace entry (category `workflows`), regenerated native-install registries (`make generate-all`), and the catalog rows / counts in README, AGENTS.md and docs, following the pattern of #645.
- Disclosure: I maintain Superself (https://github.com/fxylabs/superself). It is a free, Apache-2.0, local-first CLI (`npm install -g superself`) — no account, no paid tier, no hooks, no MCP; the plugin only issues `self` shell commands. The same disclosure is in `plugins/superself/README.md`.

## Scope

- [x] Plugin authoring (new or modified `plugins/<name>/...`)
- [ ] Adapter framework (`tools/adapters/`)
- [ ] Quality tooling (validators, gardener, plugin-eval)
- [ ] Per-harness setup or docs (docs/harnesses.md)
- [x] AGENTS.md / ARCHITECTURE.md / docs/ (counts + catalog rows only)
- [ ] CI / build / release
- [ ] Other

## Affected harnesses

- [x] Claude Code
- [x] OpenAI Codex CLI
- [x] Cursor
- [x] OpenCode
- [x] Antigravity CLI
- [ ] Pure tooling / framework (no harness behavior change)

## Test plan

- `make generate-all` — superself: 2 files per harness, 0 errors
- `make validate STRICT=1` — OK across 5 harnesses
- `make garden` — 0 errors, 10 pre-existing warnings (none touch this plugin; `STRICT=1` fails on main for the same warnings)
- `make test` — 495 passed, 2 skipped
- `python3 tools/check_agent_name_collisions.py --fail-on-duplicates` — OK
- markdownlint-cli2 with `.markdownlint.json` on the touched markdown — 0 issues
- Every `self` command in the skill checked against the current CLI help

## Related issue(s)

Closes #674
