### PR TITLE
feat(garden): count and agent-divergence checks, plus tool-rewrite tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,10 @@ Full frontmatter conventions in [`docs/authoring.md`](docs/authoring.md).
 - If a plugin wraps a third-party API, package, or service that you own or
   maintain, disclose that relationship in the PR description and the plugin
   README.
+- Do not ship payment processing, license enforcement, or access-control
+  tooling in a plugin payload. Scripts that take payment, verify a transaction,
+  or grant and revoke access to a repository or service are out of scope,
+  whether they charge the user or help the user charge someone else.
 
 ## External and vendor plugins
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,10 +32,14 @@ Full frontmatter conventions in [`docs/authoring.md`](docs/authoring.md).
 - If a plugin wraps a third-party API, package, or service that you own or
   maintain, disclose that relationship in the PR description and the plugin
   README.
-- Do not ship payment processing, license enforcement, or access-control
-  tooling in a plugin payload. Scripts that take payment, verify a transaction,
-  or grant and revoke access to a repository or service are out of scope,
-  whether they charge the user or help the user charge someone else.
+- Plugin payloads must not contain runnable machinery for collecting payment or
+  gating access. A script that takes payment, verifies a transaction, or grants
+  and revokes access to a repository or service is out of scope, whether it
+  charges the installing user or helps the installing user charge someone else.
+  Teaching an agent to build payment, licensing, or access-control features in
+  the user's own application is a different thing and is welcome — the
+  `payment-processing` plugin is the reference example. The line is whether the
+  payload runs a commercial transaction itself.
 
 ## External and vendor plugins
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,10 +36,13 @@ Full frontmatter conventions in [`docs/authoring.md`](docs/authoring.md).
   gating access. A script that takes payment, verifies a transaction, or grants
   and revokes access to a repository or service is out of scope, whether it
   charges the installing user or helps the installing user charge someone else.
-  Teaching an agent to build payment, licensing, or access-control features in
-  the user's own application is a different thing and is welcome — the
-  `payment-processing` plugin is the reference example. The line is whether the
-  payload runs a commercial transaction itself.
+  Verifying a transaction, checking a licence or entitlement, and granting or
+  revoking access are each covered on their own, so splitting the steps across
+  tools does not get around the rule. Teaching an agent to build payment,
+  licensing, or access-control features in the user's own application is a
+  different thing and is welcome, and the `payment-processing` plugin is the
+  reference example of that. The line is whether the payload operates the
+  contributor's commercial relationship or only explains how to build one.
 
 ## External and vendor plugins
 

--- a/tools/check_agent_name_collisions.py
+++ b/tools/check_agent_name_collisions.py
@@ -84,8 +84,7 @@ def main() -> int:
         return 0
 
     print(
-        f"Found {duplicate_name_count} duplicate agent names across "
-        f"{colliding_file_count} files:"
+        f"Found {duplicate_name_count} duplicate agent names across {colliding_file_count} files:"
     )
     for name, paths in duplicates.items():
         print(f"\n{name} ({len(paths)} files)")
@@ -93,20 +92,14 @@ def main() -> int:
             print(f"  - {path.relative_to(root)}")
 
     failed = args.fail_on_duplicates
-    if (
-        args.max_duplicate_names is not None
-        and duplicate_name_count > args.max_duplicate_names
-    ):
+    if args.max_duplicate_names is not None and duplicate_name_count > args.max_duplicate_names:
         print(
             f"\nERROR: duplicate name count {duplicate_name_count} exceeds "
             f"baseline {args.max_duplicate_names}",
             file=sys.stderr,
         )
         failed = True
-    if (
-        args.max_colliding_files is not None
-        and colliding_file_count > args.max_colliding_files
-    ):
+    if args.max_colliding_files is not None and colliding_file_count > args.max_colliding_files:
         print(
             f"\nERROR: colliding file count {colliding_file_count} exceeds "
             f"baseline {args.max_colliding_files}",

--- a/tools/doc_gardener.py
+++ b/tools/doc_gardener.py
@@ -69,7 +69,7 @@ COUNT_NOUN_ALIASES = {
 # agent can never hash alike. Normalize it away before comparing bodies, scoped to
 # the opening frontmatter block so a `name:` line in the body still counts as content.
 AGENT_NAME_LINE_RE = re.compile(r"^name:.*$", re.MULTILINE)
-AGENT_FRONTMATTER_RE = re.compile(r"\A(---\n)(.*?)(\n---\n)", re.DOTALL)
+AGENT_FRONTMATTER_RE = re.compile(r"\A(---\r?\n)(.*?)(\r?\n---(?:\r?\n|\Z))", re.DOTALL)
 
 
 # ── Findings ─────────────────────────────────────────────────────────────────
@@ -431,9 +431,14 @@ def actual_counts() -> dict[str, int | None]:
     plugins: int | None = None
     if MARKETPLACE_JSON.is_file():
         try:
-            plugins = len(json.loads(MARKETPLACE_JSON.read_text()).get("plugins", []))
+            manifest = json.loads(MARKETPLACE_JSON.read_text())
         except json.JSONDecodeError:
-            plugins = None  # check_marketplace_consistency reports the parse error
+            manifest = None  # check_marketplace_consistency reports the parse error
+        # Valid JSON of the wrong shape is still an unknown count, not a crash.
+        if isinstance(manifest, dict):
+            entries = manifest.get("plugins")
+            if isinstance(entries, list):
+                plugins = len(entries)
     return {
         "plugins": plugins,
         "agents": len(list(PLUGINS_DIR.glob("*/agents/*.md"))),

--- a/tools/doc_gardener.py
+++ b/tools/doc_gardener.py
@@ -65,11 +65,10 @@ COUNT_NOUN_ALIASES = {
     "command": "commands",
 }
 
-# An agent's frontmatter `name:` is plugin-namespaced, so two copies of the same
-# agent can never hash alike. Normalize it away before comparing bodies, scoped to
-# the opening frontmatter block so a `name:` line in the body still counts as content.
-AGENT_NAME_LINE_RE = re.compile(r"^name:.*$", re.MULTILINE)
-AGENT_FRONTMATTER_RE = re.compile(r"\A(---\r?\n)(.*?)(\r?\n---(?:\r?\n|\Z))", re.DOTALL)
+# An agent's frontmatter `name:` is plugin-namespaced, so two copies of the same agent
+# can never compare equal on raw text. It is dropped before comparing. A byte-order
+# mark or leading blank line would otherwise hide the frontmatter from the parser.
+BOM = "\ufeff"
 
 
 # ── Findings ─────────────────────────────────────────────────────────────────
@@ -406,17 +405,18 @@ def check_marketplace_consistency(report: Report) -> None:
 
 
 def normalized_agent_text(text: str) -> str:
-    """Blank the plugin-namespaced frontmatter `name:` so sibling copies compare equal.
+    """Render an agent as its frontmatter fields minus `name`, plus its body.
 
-    Only the opening frontmatter block is touched. A `name:` line in the body is real
-    content and must still count toward a divergence.
+    Uses the same frontmatter parser the adapters use, so a copy is judged on its
+    fields and body rather than on exact delimiter formatting. That keeps CRLF files,
+    a closing `---` at end of file, and a trailing space after a delimiter from
+    reading as drift. A `name:` line in the body is body content and still counts.
     """
-    match = AGENT_FRONTMATTER_RE.match(text)
-    if not match:
-        return text
-    opener, frontmatter, closer = match.groups()
-    frontmatter = AGENT_NAME_LINE_RE.sub("name:", frontmatter, count=1)
-    return f"{opener}{frontmatter}{closer}{text[match.end() :]}"
+    text = text.lstrip(BOM).lstrip()
+    fields, body = parse_frontmatter(text)
+    fields.pop("name", None)
+    rendered = "\n".join(f"{key}: {fields[key]!r}" for key in sorted(fields))
+    return f"{rendered}\n---\n{body.strip()}"
 
 
 def actual_counts() -> dict[str, int | None]:

--- a/tools/doc_gardener.py
+++ b/tools/doc_gardener.py
@@ -55,8 +55,10 @@ COUNT_RE = re.compile(r"\b(\d+)\s+(plugins|agents|subagents|skills|commands)\b")
 COUNT_NOUN_ALIASES = {"subagents": "agents"}
 
 # An agent's frontmatter `name:` is plugin-namespaced, so two copies of the same
-# agent can never hash alike. Normalize it away before comparing bodies.
+# agent can never hash alike. Normalize it away before comparing bodies, scoped to
+# the opening frontmatter block so a `name:` line in the body still counts as content.
 AGENT_NAME_LINE_RE = re.compile(r"^name:.*$", re.MULTILINE)
+AGENT_FRONTMATTER_RE = re.compile(r"\A(---\n)(.*?)(\n---\n)", re.DOTALL)
 
 
 # ── Findings ─────────────────────────────────────────────────────────────────
@@ -392,6 +394,20 @@ def check_marketplace_consistency(report: Report) -> None:
             )
 
 
+def normalized_agent_text(text: str) -> str:
+    """Blank the plugin-namespaced frontmatter `name:` so sibling copies compare equal.
+
+    Only the opening frontmatter block is touched. A `name:` line in the body is real
+    content and must still count toward a divergence.
+    """
+    match = AGENT_FRONTMATTER_RE.match(text)
+    if not match:
+        return text
+    opener, frontmatter, closer = match.groups()
+    frontmatter = AGENT_NAME_LINE_RE.sub("name:", frontmatter, count=1)
+    return f"{opener}{frontmatter}{closer}{text[match.end() :]}"
+
+
 def actual_counts() -> dict[str, int]:
     """Live component totals, counted the same way the adapters discover them.
 
@@ -451,7 +467,7 @@ def check_agent_divergence(report: Report) -> None:
             continue
         bodies: dict[str, list[Path]] = defaultdict(list)
         for path in paths:
-            normalized = AGENT_NAME_LINE_RE.sub("name:", path.read_text(encoding="utf-8"), count=1)
+            normalized = normalized_agent_text(path.read_text(encoding="utf-8"))
             bodies[hashlib.md5(normalized.encode("utf-8")).hexdigest()].append(path)
 
         if len(bodies) > 1:

--- a/tools/doc_gardener.py
+++ b/tools/doc_gardener.py
@@ -467,6 +467,20 @@ def check_marketplace_consistency(report: Report) -> None:
             )
 
 
+def canonical_frontmatter_value(value: object) -> object:
+    """Order-independent form of a parsed frontmatter value.
+
+    Mapping key order carries no meaning, and `repr` preserves insertion order, so two
+    agents with the same nested fields written in a different order would otherwise
+    hash differently. List order is left alone because it is meaningful.
+    """
+    if isinstance(value, dict):
+        return {key: canonical_frontmatter_value(value[key]) for key in sorted(value)}
+    if isinstance(value, list):
+        return [canonical_frontmatter_value(item) for item in value]
+    return value
+
+
 def normalized_agent_text(text: str) -> str:
     """Render an agent as its frontmatter fields minus `name`, plus its body.
 
@@ -483,7 +497,9 @@ def normalized_agent_text(text: str) -> str:
         text = trimmed
     fields, body = parse_frontmatter(text)
     fields.pop("name", None)
-    rendered = "\n".join(f"{key}: {fields[key]!r}" for key in sorted(fields))
+    rendered = "\n".join(
+        f"{key}: {canonical_frontmatter_value(fields[key])!r}" for key in sorted(fields)
+    )
     # Line endings are formatting, so a CRLF copy must match its LF twin.
     # parse_frontmatter strips leading "\n" but leaves the "\r" behind it.
     # Strip newlines only, never spaces: leading indentation is content, so an

--- a/tools/doc_gardener.py
+++ b/tools/doc_gardener.py
@@ -8,6 +8,8 @@ Per the OpenAI harness engineering pattern, a recurring task scans for:
 4. Skills above 8 KB body without `references/` (Codex hard cap)
 5. Plugin entries in marketplace.json without a corresponding plugins/<name>/ directory
 6. Plugins missing from marketplace.json
+7. Component counts quoted in README.md / AGENTS.md that no longer match reality
+8. Same-named agents whose bodies have diverged across plugins
 
 Each finding ships with a `Fix:` remediation line.
 
@@ -20,9 +22,11 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import re
 import sys
+from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -40,6 +44,16 @@ CONTEXT_FILES = {
 }
 
 CODEX_SKILL_CAP_BYTES = 8 * 1024
+
+# Headline component counts are quoted in these files and go stale on every
+# plugin add/remove. Only the two canonical context files are scanned — docs/
+# carries per-category subtotals that legitimately differ from the totals.
+COUNT_DOC_FILES = ("README.md", "AGENTS.md")
+COUNT_RE = re.compile(r"\b(\d{2,4})\s+(plugins|agents|skills|commands)\b")
+
+# An agent's frontmatter `name:` is plugin-namespaced, so two copies of the same
+# agent can never hash alike. Normalize it away before comparing bodies.
+AGENT_NAME_LINE_RE = re.compile(r"^name:.*$", re.MULTILINE)
 
 
 # ── Findings ─────────────────────────────────────────────────────────────────
@@ -375,12 +389,103 @@ def check_marketplace_consistency(report: Report) -> None:
             )
 
 
+def actual_counts() -> dict[str, int]:
+    """Live component totals, counted the same way the adapters discover them.
+
+    `plugins` counts marketplace entries rather than plugins/ directories, because
+    the headline figure includes external (git-subdir) entries that have no local dir.
+    """
+    plugins = 0
+    if MARKETPLACE_JSON.is_file():
+        try:
+            plugins = len(json.loads(MARKETPLACE_JSON.read_text()).get("plugins", []))
+        except json.JSONDecodeError:
+            plugins = 0  # check_marketplace_consistency reports the parse error
+    return {
+        "plugins": plugins,
+        "agents": len(list(PLUGINS_DIR.glob("*/agents/*.md"))),
+        "skills": len(list(PLUGINS_DIR.glob("*/skills/*/SKILL.md"))),
+        "commands": len(list(PLUGINS_DIR.glob("*/commands/*.md"))),
+    }
+
+
+def check_doc_counts(report: Report) -> None:
+    """Component counts quoted in README.md / AGENTS.md that no longer match reality."""
+    counts = actual_counts()
+    for filename in COUNT_DOC_FILES:
+        path = WORKTREE / filename
+        if not path.is_file():
+            continue
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            for quoted, noun in COUNT_RE.findall(line):
+                if int(quoted) == counts[noun]:
+                    continue
+                report.add(
+                    kind="STALE_COUNT",
+                    severity="error",
+                    path=path,
+                    message=f"line {lineno} says {quoted} {noun}, actual is {counts[noun]}",
+                    fix=f"Update the count to {counts[noun]} (every mention, not just this line).",
+                )
+
+
+def check_agent_divergence(report: Report) -> None:
+    """Same-named agents whose bodies have drifted apart across plugins.
+
+    Plugins are installed individually, so a shared agent is genuinely copied into
+    each plugin that offers it. Verbatim copies are expected and reported as info;
+    copies whose bodies have diverged are the drift worth acting on.
+    """
+    if not PLUGINS_DIR.is_dir():
+        return
+    by_filename: dict[str, list[Path]] = defaultdict(list)
+    for agent_path in sorted(PLUGINS_DIR.glob("*/agents/*.md")):
+        by_filename[agent_path.name].append(agent_path)
+
+    for filename, paths in sorted(by_filename.items()):
+        if len(paths) < 2:
+            continue
+        bodies: dict[str, list[Path]] = defaultdict(list)
+        for path in paths:
+            normalized = AGENT_NAME_LINE_RE.sub("name:", path.read_text(encoding="utf-8"), count=1)
+            bodies[hashlib.md5(normalized.encode("utf-8")).hexdigest()].append(path)
+
+        owners = ", ".join(path.parent.parent.name for path in paths)
+        if len(bodies) > 1:
+            variants = " | ".join(
+                "+".join(p.parent.parent.name for p in group) for group in bodies.values()
+            )
+            report.add(
+                kind="AGENT_BODY_DIVERGENT",
+                severity="warning",
+                path=paths[0],
+                message=(
+                    f"`{filename}` has {len(paths)} copies in {len(bodies)} different "
+                    f"versions: {variants}"
+                ),
+                fix=(
+                    "Reconcile the copies, or rename the intentional variants so the "
+                    "difference is visible in the agent name rather than hidden in the body."
+                ),
+            )
+        else:
+            report.add(
+                kind="AGENT_COPY_REDUNDANT",
+                severity="info",
+                path=paths[0],
+                message=f"`{filename}` is copied verbatim into {len(paths)} plugins ({owners})",
+                fix="Expected while plugins install standalone — edit every copy together.",
+            )
+
+
 CHECKS = {
     "stale": check_stale_artifacts,
     "context": check_oversized_context_files,
     "links": check_dead_links,
     "codex-cap": check_codex_skill_caps,
     "marketplace": check_marketplace_consistency,
+    "counts": check_doc_counts,
+    "agent-divergence": check_agent_divergence,
 }
 
 

--- a/tools/doc_gardener.py
+++ b/tools/doc_gardener.py
@@ -419,18 +419,21 @@ def normalized_agent_text(text: str) -> str:
     return f"{opener}{frontmatter}{closer}{text[match.end() :]}"
 
 
-def actual_counts() -> dict[str, int]:
+def actual_counts() -> dict[str, int | None]:
     """Live component totals, counted the same way the adapters discover them.
 
     `plugins` counts marketplace entries rather than plugins/ directories, because
     the headline figure includes external (git-subdir) entries that have no local dir.
+    It is None when the manifest is missing or unparseable, which means "unknown"
+    rather than zero — otherwise one JSON syntax error would report every documented
+    plugin count as stale and tell the reader to write zero.
     """
-    plugins = 0
+    plugins: int | None = None
     if MARKETPLACE_JSON.is_file():
         try:
             plugins = len(json.loads(MARKETPLACE_JSON.read_text()).get("plugins", []))
         except json.JSONDecodeError:
-            plugins = 0  # check_marketplace_consistency reports the parse error
+            plugins = None  # check_marketplace_consistency reports the parse error
     return {
         "plugins": plugins,
         "agents": len(list(PLUGINS_DIR.glob("*/agents/*.md"))),
@@ -449,14 +452,15 @@ def check_doc_counts(report: Report) -> None:
         for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
             for quoted, noun in COUNT_RE.findall(line):
                 key = COUNT_NOUN_ALIASES.get(noun, noun)
-                if int(quoted) == counts[key]:
+                actual = counts[key]
+                if actual is None or int(quoted) == actual:
                     continue
                 report.add(
                     kind="STALE_COUNT",
                     severity="error",
                     path=path,
-                    message=f"line {lineno} says {quoted} {noun}, actual is {counts[key]}",
-                    fix=f"Update the count to {counts[key]} (every mention, not just this line).",
+                    message=f"line {lineno} says {quoted} {noun}, actual is {actual}",
+                    fix=f"Update the count to {actual} (every mention, not just this line).",
                 )
 
 

--- a/tools/doc_gardener.py
+++ b/tools/doc_gardener.py
@@ -103,6 +103,24 @@ class Report:
         return [f for f in self.findings if f.severity == severity]
 
 
+def read_text_or_none(path: Path, report: Report) -> str | None:
+    """Read a file as UTF-8, reporting a finding rather than killing the whole run.
+
+    One unreadable file should cost its own finding, not every other check's output.
+    """
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        report.add(
+            kind="UNREADABLE_FILE",
+            severity="error",
+            path=path,
+            message=f"cannot be read as UTF-8 text: {exc}",
+            fix="Re-save the file as UTF-8, or remove it if it is not source.",
+        )
+        return None
+
+
 # ── Checks ───────────────────────────────────────────────────────────────────
 
 
@@ -281,7 +299,10 @@ def check_oversized_context_files(report: Report) -> None:
         path = WORKTREE / name
         if not path.is_file():
             continue
-        line_count = len(path.read_text().splitlines())
+        content = read_text_or_none(path, report)
+        if content is None:
+            continue
+        line_count = len(content.splitlines())
         if line_count > cap:
             report.add(
                 kind="CONTEXT_FILE_OVERSIZED",
@@ -310,7 +331,9 @@ def check_dead_links(report: Report) -> None:
         files = list(target.rglob("*.md")) if target.is_dir() else [target]
         for md in files:
             try:
-                content = md.read_text(encoding="utf-8")
+                content = read_text_or_none(md, report)
+                if content is None:
+                    continue
             except OSError:
                 continue
             for link in link_pattern.findall(content):
@@ -333,8 +356,10 @@ def check_codex_skill_caps(report: Report) -> None:
     if not PLUGINS_DIR.is_dir():
         return
     for skill_md in PLUGINS_DIR.glob("*/skills/*/SKILL.md"):
-        content = skill_md.read_text(encoding="utf-8")
-        fm, body = parse_frontmatter(content)
+        content = read_text_or_none(skill_md, report)
+        if content is None:
+            continue
+        _, body = parse_frontmatter(content)
         body_bytes = len(body.encode("utf-8"))
         if body_bytes > CODEX_SKILL_CAP_BYTES:
             refs = skill_md.parent / "references"
@@ -352,7 +377,10 @@ def check_marketplace_consistency(report: Report) -> None:
     if not MARKETPLACE_JSON.is_file():
         return
     try:
-        data = json.loads(MARKETPLACE_JSON.read_text())
+        raw = read_text_or_none(MARKETPLACE_JSON, report)
+        if raw is None:
+            return
+        data = json.loads(raw)
     except json.JSONDecodeError as e:
         report.add(
             kind="MARKETPLACE_PARSE",
@@ -431,8 +459,8 @@ def actual_counts() -> dict[str, int | None]:
     plugins: int | None = None
     if MARKETPLACE_JSON.is_file():
         try:
-            manifest = json.loads(MARKETPLACE_JSON.read_text())
-        except json.JSONDecodeError:
+            manifest = json.loads(MARKETPLACE_JSON.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
             manifest = None  # check_marketplace_consistency reports the parse error
         # Valid JSON of the wrong shape is still an unknown count, not a crash.
         if isinstance(manifest, dict):
@@ -454,7 +482,10 @@ def check_doc_counts(report: Report) -> None:
         path = WORKTREE / filename
         if not path.is_file():
             continue
-        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        content = read_text_or_none(path, report)
+        if content is None:
+            continue
+        for lineno, line in enumerate(content.splitlines(), 1):
             for quoted, noun in COUNT_RE.findall(line):
                 key = COUNT_NOUN_ALIASES.get(noun, noun)
                 actual = counts[key]
@@ -489,7 +520,10 @@ def check_agent_divergence(report: Report) -> None:
             continue
         bodies: dict[str, list[Path]] = defaultdict(list)
         for path in paths:
-            normalized = normalized_agent_text(path.read_text(encoding="utf-8"))
+            raw = read_text_or_none(path, report)
+            if raw is None:
+                continue
+            normalized = normalized_agent_text(raw)
             bodies[hashlib.md5(normalized.encode("utf-8")).hexdigest()].append(path)
 
         if len(bodies) > 1:

--- a/tools/doc_gardener.py
+++ b/tools/doc_gardener.py
@@ -105,6 +105,21 @@ class Report:
         return [f for f in self.findings if f.severity == severity]
 
 
+def marketplace_entry_problem(entry: object) -> str | None:
+    """Say why a `plugins[]` entry is unusable, or None when it is fine.
+
+    Both readers of the manifest go through this. When only one of them enforced the
+    shape, a counts-only run could report a stale total from a manifest the
+    consistency check rejects.
+    """
+    if not isinstance(entry, dict):
+        return f" is {type(entry).__name__}, expected an object"
+    name = entry.get("name")
+    if name is not None and not isinstance(name, str):
+        return f".name is {type(name).__name__}, expected a string"
+    return None
+
+
 def read_text_or_none(path: Path, report: Report) -> str | None:
     """Read a file as UTF-8, reporting a finding rather than killing the whole run.
 
@@ -405,26 +420,18 @@ def check_marketplace_consistency(report: Report) -> None:
         )
         return
     for position, raw_entry in enumerate(entries):
-        if not isinstance(raw_entry, dict):
+        problem = marketplace_entry_problem(raw_entry)
+        if problem is not None:
             report.add(
                 kind="MARKETPLACE_SHAPE",
                 severity="error",
                 path=MARKETPLACE_JSON,
-                message=f"plugins[{position}] is {type(raw_entry).__name__}, expected an object",
+                message=f"plugins[{position}]{problem}",
                 fix="Remove the entry or give it the usual name/source/description fields.",
             )
             continue
         entry = cast("dict[str, Any]", raw_entry)
         name = entry.get("name")
-        if name is not None and not isinstance(name, str):
-            report.add(
-                kind="MARKETPLACE_SHAPE",
-                severity="error",
-                path=MARKETPLACE_JSON,
-                message=f"plugins[{position}].name is {type(name).__name__}, expected a string",
-                fix="Give the entry a plain string name.",
-            )
-            continue
         if not name:
             continue
         source = entry.get("source")
@@ -508,9 +515,12 @@ def actual_counts(report: Report) -> dict[str, int | None]:
         # Valid JSON of the wrong shape is still an unknown count, not a crash.
         if isinstance(manifest, dict):
             entries = manifest.get("plugins")
-            # A list holding a non-object entry is malformed. Counting it would let
-            # garbage drive an error-severity finding.
-            if isinstance(entries, list) and all(isinstance(e, dict) for e in entries):
+            # Malformed entries make the total unknown. Counting them would let
+            # garbage drive an error-severity finding, and would disagree with
+            # check_marketplace_consistency about the same manifest.
+            if isinstance(entries, list) and all(
+                marketplace_entry_problem(e) is None for e in entries
+            ):
                 plugins = len(entries)
     return {
         "plugins": plugins,

--- a/tools/doc_gardener.py
+++ b/tools/doc_gardener.py
@@ -392,7 +392,26 @@ def check_marketplace_consistency(report: Report) -> None:
     # missing LOCAL entries as orphans — externals legitimately don't have a plugins/<name>/.
     local_entries: dict[str, dict] = {}
     external_names: set[str] = set()
-    for entry in data.get("plugins", []):
+    entries = data.get("plugins", []) if isinstance(data, dict) else None
+    if not isinstance(entries, list):
+        report.add(
+            kind="MARKETPLACE_SHAPE",
+            severity="error",
+            path=MARKETPLACE_JSON,
+            message="expected an object with a `plugins` list at the top level",
+            fix='Restore the manifest shape: {"plugins": [ ... ]}.',
+        )
+        return
+    for position, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            report.add(
+                kind="MARKETPLACE_SHAPE",
+                severity="error",
+                path=MARKETPLACE_JSON,
+                message=f"plugins[{position}] is {type(entry).__name__}, expected an object",
+                fix="Remove the entry or give it the usual name/source/description fields.",
+            )
+            continue
         name = entry.get("name")
         if not name:
             continue
@@ -437,7 +456,12 @@ def normalized_agent_text(text: str) -> str:
     a closing `---` at end of file, and a trailing space after a delimiter from
     reading as drift. A `name:` line in the body is body content and still counts.
     """
-    text = text.lstrip(BOM).lstrip()
+    text = text.lstrip(BOM)
+    trimmed = text.lstrip()
+    # Blank lines ahead of a frontmatter block are formatting. Ahead of anything else
+    # they are body content, and stripping them would hide an indentation difference.
+    if trimmed.startswith("---"):
+        text = trimmed
     fields, body = parse_frontmatter(text)
     fields.pop("name", None)
     rendered = "\n".join(f"{key}: {fields[key]!r}" for key in sorted(fields))
@@ -465,7 +489,9 @@ def actual_counts(report: Report) -> dict[str, int | None]:
         # Valid JSON of the wrong shape is still an unknown count, not a crash.
         if isinstance(manifest, dict):
             entries = manifest.get("plugins")
-            if isinstance(entries, list):
+            # A list holding a non-object entry is malformed. Counting it would let
+            # garbage drive an error-severity finding.
+            if isinstance(entries, list) and all(isinstance(e, dict) for e in entries):
                 plugins = len(entries)
     return {
         "plugins": plugins,

--- a/tools/doc_gardener.py
+++ b/tools/doc_gardener.py
@@ -415,6 +415,15 @@ def check_marketplace_consistency(report: Report) -> None:
             continue
         entry = cast("dict[str, Any]", raw_entry)
         name = entry.get("name")
+        if name is not None and not isinstance(name, str):
+            report.add(
+                kind="MARKETPLACE_SHAPE",
+                severity="error",
+                path=MARKETPLACE_JSON,
+                message=f"plugins[{position}].name is {type(name).__name__}, expected a string",
+                fix="Give the entry a plain string name.",
+            )
+            continue
         if not name:
             continue
         source = entry.get("source")
@@ -467,9 +476,12 @@ def normalized_agent_text(text: str) -> str:
     fields, body = parse_frontmatter(text)
     fields.pop("name", None)
     rendered = "\n".join(f"{key}: {fields[key]!r}" for key in sorted(fields))
-    # rstrip only. A trailing newline is formatting, but leading indentation is
-    # content: an indented code block must not compare equal to plain prose.
-    return f"{rendered}\n---\n{body.rstrip()}"
+    # Line endings are formatting, so a CRLF copy must match its LF twin.
+    # parse_frontmatter strips leading "\n" but leaves the "\r" behind it.
+    # Strip newlines only, never spaces: leading indentation is content, so an
+    # indented code block must not compare equal to plain prose.
+    normalized_body = body.replace("\r\n", "\n").lstrip("\n").rstrip()
+    return f"{rendered}\n---\n{normalized_body}"
 
 
 def actual_counts(report: Report) -> dict[str, int | None]:

--- a/tools/doc_gardener.py
+++ b/tools/doc_gardener.py
@@ -49,7 +49,7 @@ CODEX_SKILL_CAP_BYTES = 8 * 1024
 # plugin add/remove. Only the two canonical context files are scanned — docs/
 # carries per-category subtotals that legitimately differ from the totals.
 COUNT_DOC_FILES = ("README.md", "AGENTS.md")
-COUNT_RE = re.compile(r"\b(\d+)\s+(plugins?|subagents?|agents?|skills?|commands?)\b")
+COUNT_RE = re.compile(r"\b(\d[\d,]*)\s+(plugins?|subagents?|agents?|skills?|commands?)\b")
 
 # Every spelling the two files use, mapped to its key in actual_counts(). AGENTS.md
 # calls the agent total "subagents" in its cross-harness section, and a total of one
@@ -458,7 +458,9 @@ def check_doc_counts(report: Report) -> None:
             for quoted, noun in COUNT_RE.findall(line):
                 key = COUNT_NOUN_ALIASES.get(noun, noun)
                 actual = counts[key]
-                if actual is None or int(quoted) == actual:
+                # A thousands separator is still one number: 1,234 agents.
+                claimed = int(quoted.replace(",", ""))
+                if actual is None or claimed == actual:
                     continue
                 report.add(
                     kind="STALE_COUNT",

--- a/tools/doc_gardener.py
+++ b/tools/doc_gardener.py
@@ -29,6 +29,7 @@ import sys
 from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any, cast
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
@@ -402,16 +403,17 @@ def check_marketplace_consistency(report: Report) -> None:
             fix='Restore the manifest shape: {"plugins": [ ... ]}.',
         )
         return
-    for position, entry in enumerate(entries):
-        if not isinstance(entry, dict):
+    for position, raw_entry in enumerate(entries):
+        if not isinstance(raw_entry, dict):
             report.add(
                 kind="MARKETPLACE_SHAPE",
                 severity="error",
                 path=MARKETPLACE_JSON,
-                message=f"plugins[{position}] is {type(entry).__name__}, expected an object",
+                message=f"plugins[{position}] is {type(raw_entry).__name__}, expected an object",
                 fix="Remove the entry or give it the usual name/source/description fields.",
             )
             continue
+        entry = cast("dict[str, Any]", raw_entry)
         name = entry.get("name")
         if not name:
             continue

--- a/tools/doc_gardener.py
+++ b/tools/doc_gardener.py
@@ -330,11 +330,8 @@ def check_dead_links(report: Report) -> None:
     for target in targets:
         files = list(target.rglob("*.md")) if target.is_dir() else [target]
         for md in files:
-            try:
-                content = read_text_or_none(md, report)
-                if content is None:
-                    continue
-            except OSError:
+            content = read_text_or_none(md, report)
+            if content is None:
                 continue
             for link in link_pattern.findall(content):
                 # Skip external links and anchors
@@ -444,10 +441,12 @@ def normalized_agent_text(text: str) -> str:
     fields, body = parse_frontmatter(text)
     fields.pop("name", None)
     rendered = "\n".join(f"{key}: {fields[key]!r}" for key in sorted(fields))
-    return f"{rendered}\n---\n{body.strip()}"
+    # rstrip only. A trailing newline is formatting, but leading indentation is
+    # content: an indented code block must not compare equal to plain prose.
+    return f"{rendered}\n---\n{body.rstrip()}"
 
 
-def actual_counts() -> dict[str, int | None]:
+def actual_counts(report: Report) -> dict[str, int | None]:
     """Live component totals, counted the same way the adapters discover them.
 
     `plugins` counts marketplace entries rather than plugins/ directories, because
@@ -458,9 +457,10 @@ def actual_counts() -> dict[str, int | None]:
     """
     plugins: int | None = None
     if MARKETPLACE_JSON.is_file():
+        raw = read_text_or_none(MARKETPLACE_JSON, report)
         try:
-            manifest = json.loads(MARKETPLACE_JSON.read_text(encoding="utf-8"))
-        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            manifest = None if raw is None else json.loads(raw)
+        except json.JSONDecodeError:
             manifest = None  # check_marketplace_consistency reports the parse error
         # Valid JSON of the wrong shape is still an unknown count, not a crash.
         if isinstance(manifest, dict):
@@ -477,7 +477,7 @@ def actual_counts() -> dict[str, int | None]:
 
 def check_doc_counts(report: Report) -> None:
     """Component counts quoted in README.md / AGENTS.md that no longer match reality."""
-    counts = actual_counts()
+    counts = actual_counts(report)
     for filename in COUNT_DOC_FILES:
         path = WORKTREE / filename
         if not path.is_file():

--- a/tools/doc_gardener.py
+++ b/tools/doc_gardener.py
@@ -49,7 +49,10 @@ CODEX_SKILL_CAP_BYTES = 8 * 1024
 # plugin add/remove. Only the two canonical context files are scanned — docs/
 # carries per-category subtotals that legitimately differ from the totals.
 COUNT_DOC_FILES = ("README.md", "AGENTS.md")
-COUNT_RE = re.compile(r"\b(\d{2,4})\s+(plugins|agents|skills|commands)\b")
+COUNT_RE = re.compile(r"\b(\d+)\s+(plugins|agents|subagents|skills|commands)\b")
+
+# AGENTS.md calls the same total "subagents" in its cross-harness section.
+COUNT_NOUN_ALIASES = {"subagents": "agents"}
 
 # An agent's frontmatter `name:` is plugin-namespaced, so two copies of the same
 # agent can never hash alike. Normalize it away before comparing bodies.
@@ -418,14 +421,15 @@ def check_doc_counts(report: Report) -> None:
             continue
         for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
             for quoted, noun in COUNT_RE.findall(line):
-                if int(quoted) == counts[noun]:
+                key = COUNT_NOUN_ALIASES.get(noun, noun)
+                if int(quoted) == counts[key]:
                     continue
                 report.add(
                     kind="STALE_COUNT",
                     severity="error",
                     path=path,
-                    message=f"line {lineno} says {quoted} {noun}, actual is {counts[noun]}",
-                    fix=f"Update the count to {counts[noun]} (every mention, not just this line).",
+                    message=f"line {lineno} says {quoted} {noun}, actual is {counts[key]}",
+                    fix=f"Update the count to {counts[key]} (every mention, not just this line).",
                 )
 
 
@@ -433,8 +437,8 @@ def check_agent_divergence(report: Report) -> None:
     """Same-named agents whose bodies have drifted apart across plugins.
 
     Plugins are installed individually, so a shared agent is genuinely copied into
-    each plugin that offers it. Verbatim copies are expected and reported as info;
-    copies whose bodies have diverged are the drift worth acting on.
+    each plugin that offers it. A verbatim copy is therefore expected and is not
+    reported at all. Only copies whose bodies have drifted apart are findings.
     """
     if not PLUGINS_DIR.is_dir():
         return
@@ -450,7 +454,6 @@ def check_agent_divergence(report: Report) -> None:
             normalized = AGENT_NAME_LINE_RE.sub("name:", path.read_text(encoding="utf-8"), count=1)
             bodies[hashlib.md5(normalized.encode("utf-8")).hexdigest()].append(path)
 
-        owners = ", ".join(path.parent.parent.name for path in paths)
         if len(bodies) > 1:
             variants = " | ".join(
                 "+".join(p.parent.parent.name for p in group) for group in bodies.values()
@@ -467,14 +470,6 @@ def check_agent_divergence(report: Report) -> None:
                     "Reconcile the copies, or rename the intentional variants so the "
                     "difference is visible in the agent name rather than hidden in the body."
                 ),
-            )
-        else:
-            report.add(
-                kind="AGENT_COPY_REDUNDANT",
-                severity="info",
-                path=paths[0],
-                message=f"`{filename}` is copied verbatim into {len(paths)} plugins ({owners})",
-                fix="Expected while plugins install standalone — edit every copy together.",
             )
 
 

--- a/tools/doc_gardener.py
+++ b/tools/doc_gardener.py
@@ -49,10 +49,21 @@ CODEX_SKILL_CAP_BYTES = 8 * 1024
 # plugin add/remove. Only the two canonical context files are scanned — docs/
 # carries per-category subtotals that legitimately differ from the totals.
 COUNT_DOC_FILES = ("README.md", "AGENTS.md")
-COUNT_RE = re.compile(r"\b(\d+)\s+(plugins|agents|subagents|skills|commands)\b")
+COUNT_RE = re.compile(r"\b(\d+)\s+(plugins?|subagents?|agents?|skills?|commands?)\b")
 
-# AGENTS.md calls the same total "subagents" in its cross-harness section.
-COUNT_NOUN_ALIASES = {"subagents": "agents"}
+# Every spelling the two files use, mapped to its key in actual_counts(). AGENTS.md
+# calls the agent total "subagents" in its cross-harness section, and a total of one
+# would be written in the singular. Singular forms are matched for that reason, which
+# is also why only these two curated files are scanned: prose like "each plugin ships
+# 1 agent" elsewhere would read as a stale total.
+COUNT_NOUN_ALIASES = {
+    "plugin": "plugins",
+    "subagent": "agents",
+    "subagents": "agents",
+    "agent": "agents",
+    "skill": "skills",
+    "command": "commands",
+}
 
 # An agent's frontmatter `name:` is plugin-namespaced, so two copies of the same
 # agent can never hash alike. Normalize it away before comparing bodies, scoped to

--- a/tools/doc_gardener.py
+++ b/tools/doc_gardener.py
@@ -70,6 +70,7 @@ COUNT_NOUN_ALIASES = {
 # can never compare equal on raw text. It is dropped before comparing. A byte-order
 # mark or leading blank line would otherwise hide the frontmatter from the parser.
 BOM = "\ufeff"
+BODY_LEADING_BLANKS_RE = re.compile(r"\A(?:[ \t]*\n)+")
 
 
 # ── Findings ─────────────────────────────────────────────────────────────────
@@ -480,7 +481,11 @@ def normalized_agent_text(text: str) -> str:
     # parse_frontmatter strips leading "\n" but leaves the "\r" behind it.
     # Strip newlines only, never spaces: leading indentation is content, so an
     # indented code block must not compare equal to plain prose.
-    normalized_body = body.replace("\r\n", "\n").lstrip("\n").rstrip()
+    # Leading whitespace-only lines are delimiter residue: parse_frontmatter leaves
+    # the spaces from a `--- ` closing line, and blank lines before the body are
+    # formatting. Both go. A line that starts with spaces then real text is content,
+    # so its indentation survives.
+    normalized_body = BODY_LEADING_BLANKS_RE.sub("", body.replace("\r\n", "\n")).rstrip()
     return f"{rendered}\n---\n{normalized_body}"
 
 

--- a/tools/install_antigravity.py
+++ b/tools/install_antigravity.py
@@ -69,9 +69,7 @@ def _link_one(src: Path, dst: Path, *, force: bool, report: InstallReport) -> No
             return
         dst.unlink()
     elif dst.exists():
-        report.errors.append(
-            f"{dst} already exists and is not a symlink; refusing to overwrite"
-        )
+        report.errors.append(f"{dst} already exists and is not a symlink; refusing to overwrite")
         return
 
     dst.parent.mkdir(parents=True, exist_ok=True)
@@ -138,9 +136,7 @@ def main() -> int:
     parser.add_argument("action", choices=("install", "uninstall"))
     parser.add_argument("--config-dir", type=Path, default=None)
     parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
-    parser.add_argument(
-        "--force", action="store_true", help="Replace conflicting symlinks only"
-    )
+    parser.add_argument("--force", action="store_true", help="Replace conflicting symlinks only")
     args = parser.parse_args()
 
     config_dir = (args.config_dir or default_config_dir()).expanduser()

--- a/tools/install_copilot.py
+++ b/tools/install_copilot.py
@@ -64,8 +64,7 @@ def _generated_artifacts(repo_root: Path) -> list[tuple[str, Path]]:
             artifacts.append((subdir, src.resolve()))
     if not artifacts:
         raise FileNotFoundError(
-            f"No artifacts found under {generated_root}; "
-            "run `make generate HARNESS=copilot` first"
+            f"No artifacts found under {generated_root}; run `make generate HARNESS=copilot` first"
         )
     return artifacts
 
@@ -83,9 +82,7 @@ def _link_one(src: Path, dst: Path, *, force: bool, report: InstallReport) -> No
             return
         dst.unlink()
     elif dst.exists():
-        report.errors.append(
-            f"{dst} already exists and is not a symlink; refusing to overwrite"
-        )
+        report.errors.append(f"{dst} already exists and is not a symlink; refusing to overwrite")
         return
 
     dst.parent.mkdir(parents=True, exist_ok=True)
@@ -198,17 +195,13 @@ def main() -> int:
     parser.add_argument("action", choices=("install", "uninstall"))
     parser.add_argument("--config-dir", type=Path, default=None)
     parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
-    parser.add_argument(
-        "--force", action="store_true", help="Replace conflicting symlinks only"
-    )
+    parser.add_argument("--force", action="store_true", help="Replace conflicting symlinks only")
     args = parser.parse_args()
 
     config_dir = (args.config_dir or default_config_dir()).expanduser()
     cache_cleared = None
     if args.action == "install":
-        report = install(
-            repo_root=args.repo_root, config_dir=config_dir, force=args.force
-        )
+        report = install(repo_root=args.repo_root, config_dir=config_dir, force=args.force)
         if report.ok:
             cache_cleared = _clear_copilot_cache(config_dir)
     else:

--- a/tools/tests/test_adapters.py
+++ b/tools/tests/test_adapters.py
@@ -1565,17 +1565,35 @@ class TestStripClaudeToolRefs:
         assert self._adapter(tmp_path).strip_claude_tool_refs(sample) == sample
 
     def test_every_mapped_tool_is_covered(self, tmp_path: Path):
+        """Both cases, passed explicitly so a change to the default is caught.
+
+        Only Read differs between the two. The rest are pinned in both modes so a
+        future divergence has to be deliberate.
+        """
         adapter = self._adapter(tmp_path)
+        # camel -> (tool_case="lower", tool_case="normal")
         expected = {
-            "Read": "open",
-            "Edit": "edit",
-            "Write": "write",
-            "Bash": "shell",
-            "Grep": "rg",
-            "Glob": "glob",
-            "WebFetch": "fetch",
-            "WebSearch": "search",
-            "TodoWrite": "todo",
+            "Read": ("open", "read"),
+            "Edit": ("edit", "edit"),
+            "Write": ("write", "write"),
+            "Bash": ("shell", "shell"),
+            "Grep": ("rg", "rg"),
+            "Glob": ("glob", "glob"),
+            "WebFetch": ("fetch", "fetch"),
+            "WebSearch": ("search", "search"),
+            "TodoWrite": ("todo", "todo"),
         }
-        for camel, verb in expected.items():
-            assert adapter.strip_claude_tool_refs(f"Use the {camel} tool.") == f"Use `{verb}`."
+        for camel, (lower_verb, normal_verb) in expected.items():
+            body = f"Use the {camel} tool."
+            assert adapter.strip_claude_tool_refs(body, tool_case="lower") == f"Use `{lower_verb}`."
+            assert (
+                adapter.strip_claude_tool_refs(body, tool_case="normal") == f"Use `{normal_verb}`."
+            )
+
+    def test_lower_is_the_default_tool_case(self, tmp_path: Path):
+        """Copilot emission relies on the default, so pin it."""
+        adapter = self._adapter(tmp_path)
+        body = "Use the Read tool."
+        assert adapter.strip_claude_tool_refs(body) == adapter.strip_claude_tool_refs(
+            body, tool_case="lower"
+        )

--- a/tools/tests/test_adapters.py
+++ b/tools/tests/test_adapters.py
@@ -1513,3 +1513,69 @@ class TestCapabilities:
         for harness in supported_harnesses():
             for alias in ("fable", "opus", "sonnet", "haiku", "inherit"):
                 assert alias in MODEL_ALIASES[harness], f"{harness} missing {alias}"
+
+
+# ── Tool-reference rewriting ─────────────────────────────────────────────────
+
+
+class TestStripClaudeToolRefs:
+    """Characterization tests for `HarnessAdapter.strip_claude_tool_refs`.
+
+    Copilot command bodies are rewritten through this method, and its output is not
+    otherwise asserted anywhere. These tests pin the exact strings so that a refactor
+    which changes them has to say so instead of slipping through.
+    """
+
+    SAMPLE = "Use the `Read` tool first, then the Bash tool. Prefer `Grep` over `Glob`."
+
+    def _adapter(self, tmp_path: Path) -> CopilotAdapter:
+        return CopilotAdapter(output_root=tmp_path)
+
+    def test_lower_case_output_is_exact(self, tmp_path: Path):
+        assert (
+            self._adapter(tmp_path).strip_claude_tool_refs(self.SAMPLE, tool_case="lower")
+            == "Use `open` first, then `shell`. Prefer `grep` over `glob`."
+        )
+
+    def test_normal_case_output_is_exact(self, tmp_path: Path):
+        """`normal` keeps Read as `read` and leaves bare backticked names alone."""
+        assert (
+            self._adapter(tmp_path).strip_claude_tool_refs(self.SAMPLE, tool_case="normal")
+            == "Use `read` first, then `shell`. Prefer `Grep` over `Glob`."
+        )
+
+    def test_replacements_keep_their_backticks(self, tmp_path: Path):
+        out = self._adapter(tmp_path).strip_claude_tool_refs("Run the Bash tool.")
+        assert out == "Run `shell`."
+        assert "`shell`" in out, "replacement must stay inside backticks"
+
+    def test_backticked_prose_form(self, tmp_path: Path):
+        assert (
+            self._adapter(tmp_path).strip_claude_tool_refs("Call the `WebFetch` tool now.")
+            == "Call `fetch` now."
+        )
+
+    def test_bare_backticked_name_is_lowercased_not_verbed(self, tmp_path: Path):
+        """`Grep` on its own becomes `grep` — the lowercased name, not the `rg` verb."""
+        assert self._adapter(tmp_path).strip_claude_tool_refs("Prefer `Grep`.") == "Prefer `grep`."
+
+    def test_prose_words_are_left_alone(self, tmp_path: Path):
+        """Conservative by design: only the two tool phrasings are touched."""
+        sample = "Read the docs, then write a summary and edit it."
+        assert self._adapter(tmp_path).strip_claude_tool_refs(sample) == sample
+
+    def test_every_mapped_tool_is_covered(self, tmp_path: Path):
+        adapter = self._adapter(tmp_path)
+        expected = {
+            "Read": "open",
+            "Edit": "edit",
+            "Write": "write",
+            "Bash": "shell",
+            "Grep": "rg",
+            "Glob": "glob",
+            "WebFetch": "fetch",
+            "WebSearch": "search",
+            "TodoWrite": "todo",
+        }
+        for camel, verb in expected.items():
+            assert adapter.strip_claude_tool_refs(f"Use the {camel} tool.") == f"Use `{verb}`."

--- a/tools/tests/test_adapters.py
+++ b/tools/tests/test_adapters.py
@@ -1620,10 +1620,18 @@ class TestStripClaudeToolRefs:
         out = tmp_path / "out"
         result = CopilotAdapter(output_root=out).emit_plugin(plugin)
         emitted = [p for p in result.written if p.suffix == ".md"]
-        assert emitted, "no markdown emitted for the command"
-        text = "\n".join(p.read_text(encoding="utf-8") for p in emitted)
-        assert "`open`" in text
-        assert "`shell`" in text
-        assert "`grep`" in text
-        assert "the `Read` tool" not in text
-        assert "the Bash tool" not in text
+        # Copilot writes the command twice, as a skill and as a legacy command, and
+        # also writes a plugin index that carries no command body.
+        command_files = [p for p in emitted if p.name in {"SKILL.md", "demo-cmd.md"}]
+        assert len(command_files) == 2, [p.name for p in emitted]
+
+        # Per file, not joined: a joined string would let one emitter regress to
+        # `read` while the other's `open` still satisfied the assertion.
+        for path in command_files:
+            text = path.read_text(encoding="utf-8")
+            assert "`open`" in text, path
+            assert "`shell`" in text, path
+            assert "`grep`" in text, path
+            assert "`read`" not in text, path
+            assert "the `Read` tool" not in text, path
+            assert "the Bash tool" not in text, path

--- a/tools/tests/test_adapters.py
+++ b/tools/tests/test_adapters.py
@@ -1590,10 +1590,40 @@ class TestStripClaudeToolRefs:
                 adapter.strip_claude_tool_refs(body, tool_case="normal") == f"Use `{normal_verb}`."
             )
 
-    def test_lower_is_the_default_tool_case(self, tmp_path: Path):
-        """Copilot emission relies on the default, so pin it."""
-        adapter = self._adapter(tmp_path)
-        body = "Use the Read tool."
-        assert adapter.strip_claude_tool_refs(body) == adapter.strip_claude_tool_refs(
-            body, tool_case="lower"
+    def test_emitted_copilot_command_rewrites_tool_refs(self, tmp_path: Path):
+        """Cover the real path: what a generated Copilot command body actually says.
+
+        The unit assertions above pin the method. Copilot's two call sites pass
+        `tool_case="lower"` explicitly, so this asserts the emitted file instead of the
+        method default, which is what would actually regress.
+        """
+        from tools.adapters.base import CommandSource, PluginSource
+
+        plugin_dir = tmp_path / "src" / "demo"
+        cmds = plugin_dir / "commands"
+        cmds.mkdir(parents=True)
+        body = "Use the `Read` tool first, then the Bash tool. Prefer `Grep` over `Glob`."
+        content = f"---\ndescription: Demo command.\n---\n\n{body}\n"
+        (cmds / "demo-cmd.md").write_text(content, encoding="utf-8")
+        fm, parsed_body = parse_frontmatter(content)
+        command = CommandSource(
+            plugin="demo",
+            name="demo-cmd",
+            path=cmds / "demo-cmd.md",
+            frontmatter=fm,
+            body=parsed_body,
         )
+        plugin = PluginSource(
+            name="demo", dir=plugin_dir, plugin_json={"name": "demo"}, commands=[command]
+        )
+
+        out = tmp_path / "out"
+        result = CopilotAdapter(output_root=out).emit_plugin(plugin)
+        emitted = [p for p in result.written if p.suffix == ".md"]
+        assert emitted, "no markdown emitted for the command"
+        text = "\n".join(p.read_text(encoding="utf-8") for p in emitted)
+        assert "`open`" in text
+        assert "`shell`" in text
+        assert "`grep`" in text
+        assert "the `Read` tool" not in text
+        assert "the Bash tool" not in text

--- a/tools/tests/test_doc_gardener.py
+++ b/tools/tests/test_doc_gardener.py
@@ -618,6 +618,24 @@ class TestAgentDivergence:
         check_agent_divergence(report)
         assert report.findings == []
 
+    def test_closing_delimiter_whitespace_is_not_drift(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """`--- ` and `---` on the closing line describe the same agent."""
+        _patch_paths(monkeypatch, tmp_path)
+        bodies = {
+            "alpha": "---\nname: alpha-reviewer\nmodel: opus\n--- \nReview.\n",
+            "beta": "---\nname: beta-reviewer\nmodel: opus\n---\nReview.\n",
+        }
+        for plugin, text in bodies.items():
+            agents_dir = tmp_path / "plugins" / plugin / "agents"
+            agents_dir.mkdir(parents=True, exist_ok=True)
+            (agents_dir / "reviewer.md").write_text(text)
+
+        report = Report()
+        check_agent_divergence(report)
+        assert report.findings == []
+
     def test_crlf_does_not_hide_real_drift(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """Normalizing line endings must not also flatten a genuine body difference."""
         _patch_paths(monkeypatch, tmp_path)

--- a/tools/tests/test_doc_gardener.py
+++ b/tools/tests/test_doc_gardener.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 from tools.doc_gardener import (
+    CHECKS,
     Report,
     check_agent_divergence,
     check_codex_skill_caps,
@@ -645,3 +646,45 @@ class TestAgentDivergence:
         check_agent_divergence(report)
         assert "3 copies in 2 different versions" in report.findings[0].message
         assert "alpha+beta" in report.findings[0].message
+
+
+# ── Unreadable files ─────────────────────────────────────────────────────────
+
+
+class TestUnreadableFiles:
+    """One bad file costs a finding, never the rest of the run."""
+
+    def _seed_bad_repo(self, tmp_path: Path) -> None:
+        bad = b"\xff\xfe not utf-8\n"
+        for plugin in ("alpha", "beta"):
+            agents = tmp_path / "plugins" / plugin / "agents"
+            skill = tmp_path / "plugins" / plugin / "skills" / "s"
+            agents.mkdir(parents=True, exist_ok=True)
+            skill.mkdir(parents=True, exist_ok=True)
+            (agents / "reviewer.md").write_bytes(bad)
+            (skill / "SKILL.md").write_bytes(bad)
+        (tmp_path / "docs").mkdir(exist_ok=True)
+        (tmp_path / "docs" / "x.md").write_bytes(bad)
+        (tmp_path / "AGENTS.md").write_bytes(bad)
+        (tmp_path / "README.md").write_bytes(bad)
+        (tmp_path / ".claude-plugin").mkdir(exist_ok=True)
+        (tmp_path / ".claude-plugin" / "marketplace.json").write_bytes(bad)
+
+    def test_no_check_crashes_on_a_non_utf8_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        _patch_paths(monkeypatch, tmp_path)
+        self._seed_bad_repo(tmp_path)
+        for name, check in CHECKS.items():
+            report = Report()
+            check(report)  # must not raise
+            assert all(f.kind for f in report.findings), name
+
+    def test_the_bad_file_is_reported(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        _patch_paths(monkeypatch, tmp_path)
+        self._seed_bad_repo(tmp_path)
+        report = Report()
+        CHECKS["counts"](report)
+        unreadable = [f for f in report.findings if f.kind == "UNREADABLE_FILE"]
+        assert unreadable
+        assert unreadable[0].severity == "error"

--- a/tools/tests/test_doc_gardener.py
+++ b/tools/tests/test_doc_gardener.py
@@ -380,6 +380,35 @@ class TestDocCounts:
         check_doc_counts(report)
         assert [f for f in report.findings if f.kind == "STALE_COUNT"] == []
 
+    def test_unparseable_marketplace_skips_the_plugin_count(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A broken manifest means the plugin total is unknown, not zero."""
+        _patch_paths(monkeypatch, tmp_path)
+        _write_counts_fixture(tmp_path, plugins=12, agents=34)
+        (tmp_path / ".claude-plugin" / "marketplace.json").write_text("{ this is not json")
+        (tmp_path / "README.md").write_text("We ship 12 plugins and 30 agents today.\n")
+
+        report = Report()
+        check_doc_counts(report)
+        stale = [f for f in report.findings if f.kind == "STALE_COUNT"]
+        # The agent count is still checked; the plugin count is skipped entirely.
+        assert len(stale) == 1
+        assert "30 agents" in stale[0].message
+        assert not any("plugins" in f.message for f in stale)
+
+    def test_missing_marketplace_skips_the_plugin_count(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        _patch_paths(monkeypatch, tmp_path)
+        _write_counts_fixture(tmp_path, plugins=12, agents=34)
+        (tmp_path / ".claude-plugin" / "marketplace.json").unlink()
+        (tmp_path / "README.md").write_text("We ship 99 plugins today.\n")
+
+        report = Report()
+        check_doc_counts(report)
+        assert [f for f in report.findings if f.kind == "STALE_COUNT"] == []
+
     def test_docs_subtotals_are_not_scanned(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """Per-category subtotals under docs/ legitimately differ from the totals."""
         _patch_paths(monkeypatch, tmp_path)

--- a/tools/tests/test_doc_gardener.py
+++ b/tools/tests/test_doc_gardener.py
@@ -412,6 +412,43 @@ class TestAgentDivergence:
         assert finding.severity == "warning"
         assert "2 copies in 2 different versions" in finding.message
 
+    def test_body_name_lines_still_count_as_content(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Only the frontmatter name is normalized; a `name:` in the body is real content."""
+        _patch_paths(monkeypatch, tmp_path)
+        _write_agent(tmp_path, "alpha", "reviewer.md", "Example config:\n\nname: alpha-thing\n")
+        _write_agent(tmp_path, "beta", "reviewer.md", "Example config:\n\nname: beta-thing\n")
+
+        report = Report()
+        check_agent_divergence(report)
+        assert [f.kind for f in report.findings] == ["AGENT_BODY_DIVERGENT"]
+
+    def test_body_name_lines_matching_stay_verbatim(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Same body `name:` plus differing frontmatter names is still a verbatim copy."""
+        _patch_paths(monkeypatch, tmp_path)
+        _write_agent(tmp_path, "alpha", "reviewer.md", "Example config:\n\nname: shared\n")
+        _write_agent(tmp_path, "beta", "reviewer.md", "Example config:\n\nname: shared\n")
+
+        report = Report()
+        check_agent_divergence(report)
+        assert report.findings == []
+
+    def test_agent_without_frontmatter_does_not_crash(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        _patch_paths(monkeypatch, tmp_path)
+        for plugin in ("alpha", "beta"):
+            agents_dir = tmp_path / "plugins" / plugin / "agents"
+            agents_dir.mkdir(parents=True, exist_ok=True)
+            (agents_dir / "bare.md").write_text("No frontmatter here.\n")
+
+        report = Report()
+        check_agent_divergence(report)
+        assert report.findings == []
+
     def test_groups_variants_in_message(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """Three copies sharing two bodies report as 3 copies / 2 versions."""
         _patch_paths(monkeypatch, tmp_path)

--- a/tools/tests/test_doc_gardener.py
+++ b/tools/tests/test_doc_gardener.py
@@ -409,6 +409,31 @@ class TestDocCounts:
         check_doc_counts(report)
         assert [f for f in report.findings if f.kind == "STALE_COUNT"] == []
 
+    def test_manifest_with_wrong_root_type_skips_the_plugin_count(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Valid JSON of the wrong shape is an unknown count, not a traceback."""
+        _patch_paths(monkeypatch, tmp_path)
+        _write_counts_fixture(tmp_path, plugins=12, agents=34)
+        (tmp_path / ".claude-plugin" / "marketplace.json").write_text("[]")
+        (tmp_path / "README.md").write_text("We ship 99 plugins today.\n")
+
+        report = Report()
+        check_doc_counts(report)
+        assert [f for f in report.findings if f.kind == "STALE_COUNT"] == []
+
+    def test_manifest_with_null_plugins_skips_the_plugin_count(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        _patch_paths(monkeypatch, tmp_path)
+        _write_counts_fixture(tmp_path, plugins=12, agents=34)
+        (tmp_path / ".claude-plugin" / "marketplace.json").write_text('{"plugins": null}')
+        (tmp_path / "README.md").write_text("We ship 99 plugins today.\n")
+
+        report = Report()
+        check_doc_counts(report)
+        assert [f for f in report.findings if f.kind == "STALE_COUNT"] == []
+
     def test_docs_subtotals_are_not_scanned(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """Per-category subtotals under docs/ legitimately differ from the totals."""
         _patch_paths(monkeypatch, tmp_path)
@@ -496,6 +521,34 @@ class TestAgentDivergence:
             agents_dir = tmp_path / "plugins" / plugin / "agents"
             agents_dir.mkdir(parents=True, exist_ok=True)
             (agents_dir / "bare.md").write_text("No frontmatter here.\n")
+
+        report = Report()
+        check_agent_divergence(report)
+        assert report.findings == []
+
+    def test_crlf_frontmatter_is_normalized(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """CRLF copies differing only by the namespaced name are not divergent."""
+        _patch_paths(monkeypatch, tmp_path)
+        for plugin in ("alpha", "beta"):
+            agents_dir = tmp_path / "plugins" / plugin / "agents"
+            agents_dir.mkdir(parents=True, exist_ok=True)
+            (agents_dir / "reviewer.md").write_bytes(
+                f"---\r\nname: {plugin}-reviewer\r\nmodel: opus\r\n---\r\nReview.\r\n".encode()
+            )
+
+        report = Report()
+        check_agent_divergence(report)
+        assert report.findings == []
+
+    def test_frontmatter_closing_at_eof_is_normalized(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """An agent with no body after its frontmatter still normalizes."""
+        _patch_paths(monkeypatch, tmp_path)
+        for plugin in ("alpha", "beta"):
+            agents_dir = tmp_path / "plugins" / plugin / "agents"
+            agents_dir.mkdir(parents=True, exist_ok=True)
+            (agents_dir / "reviewer.md").write_text(f"---\nname: {plugin}-reviewer\n---")
 
         report = Report()
         check_agent_divergence(report)

--- a/tools/tests/test_doc_gardener.py
+++ b/tools/tests/test_doc_gardener.py
@@ -10,7 +10,6 @@ from tools.doc_gardener import (
     CHECKS,
     Report,
     actual_counts,
-    marketplace_entry_problem,
     check_agent_divergence,
     check_codex_skill_caps,
     check_dead_links,
@@ -18,6 +17,7 @@ from tools.doc_gardener import (
     check_marketplace_consistency,
     check_oversized_context_files,
     check_stale_artifacts,
+    marketplace_entry_problem,
 )
 
 

--- a/tools/tests/test_doc_gardener.py
+++ b/tools/tests/test_doc_gardener.py
@@ -434,6 +434,45 @@ class TestDocCounts:
         check_doc_counts(report)
         assert [f for f in report.findings if f.kind == "STALE_COUNT"] == []
 
+    def test_thousands_separator_is_one_number(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """`1,234 agents` is 1234, not a stale claim of 234."""
+        _patch_paths(monkeypatch, tmp_path)
+        _write_counts_fixture(tmp_path, plugins=12, agents=34)
+        (tmp_path / "README.md").write_text("We ship 1,234 agents today.\n")
+
+        report = Report()
+        check_doc_counts(report)
+        stale = [f for f in report.findings if f.kind == "STALE_COUNT"]
+        assert len(stale) == 1
+        assert "says 1,234 agents, actual is 34" in stale[0].message
+
+    def test_thousands_separator_matching_the_total_is_clean(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        _patch_paths(monkeypatch, tmp_path)
+        _write_counts_fixture(tmp_path, plugins=2, agents=1234)
+        (tmp_path / "README.md").write_text("We ship 1,234 agents today.\n")
+
+        report = Report()
+        check_doc_counts(report)
+        assert [f for f in report.findings if f.kind == "STALE_COUNT"] == []
+
+    def test_counts_inside_code_fences_are_checked(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """README quotes the plugin total inside a bash fence, so fences count."""
+        _patch_paths(monkeypatch, tmp_path)
+        _write_counts_fixture(tmp_path, plugins=12, agents=34)
+        (tmp_path / "README.md").write_text(
+            "```bash\n/plugin install x  # any of 11 plugins\n```\n"
+        )
+
+        report = Report()
+        check_doc_counts(report)
+        assert [f.message for f in report.findings] == ["line 2 says 11 plugins, actual is 12"]
+
     def test_docs_subtotals_are_not_scanned(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """Per-category subtotals under docs/ legitimately differ from the totals."""
         _patch_paths(monkeypatch, tmp_path)

--- a/tools/tests/test_doc_gardener.py
+++ b/tools/tests/test_doc_gardener.py
@@ -10,6 +10,7 @@ from tools.doc_gardener import (
     CHECKS,
     Report,
     actual_counts,
+    marketplace_entry_problem,
     check_agent_divergence,
     check_codex_skill_caps,
     check_dead_links,
@@ -506,6 +507,22 @@ class TestDocCounts:
         assert [f for f in report.findings if f.kind == "STALE_COUNT"] == []
         assert actual_counts(Report())["plugins"] is None
 
+    def test_list_valued_name_makes_the_count_unknown(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Both readers of the manifest apply the same entry rule."""
+        _patch_paths(monkeypatch, tmp_path)
+        _write_counts_fixture(tmp_path, plugins=12, agents=34)
+        (tmp_path / ".claude-plugin" / "marketplace.json").write_text(
+            '{"plugins": [{"name": ["bad"]}]}'
+        )
+        (tmp_path / "README.md").write_text("We ship 99 plugins today.\n")
+
+        report = Report()
+        check_doc_counts(report)
+        assert [f for f in report.findings if f.kind == "STALE_COUNT"] == []
+        assert actual_counts(Report())["plugins"] is None
+
     def test_docs_subtotals_are_not_scanned(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """Per-category subtotals under docs/ legitimately differ from the totals."""
         _patch_paths(monkeypatch, tmp_path)
@@ -848,3 +865,24 @@ class TestMarketplaceShape:
         report = Report()
         check_marketplace_consistency(report)  # must not raise
         assert [f for f in report.findings if f.kind == "MARKETPLACE_SHAPE"]
+
+
+# ── Shared entry rule ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("entry", "ok"),
+    [
+        ({"name": "x", "source": "./plugins/x"}, True),
+        ({"source": "./plugins/x"}, True),  # name is optional
+        ({"name": ""}, True),  # empty name is skipped downstream, not malformed
+        ({"name": ["bad"]}, False),
+        ({"name": 7}, False),
+        (None, False),
+        ([], False),
+        ("string", False),
+    ],
+)
+def test_marketplace_entry_problem(entry: object, ok: bool):
+    """One rule, so the counts check and the consistency check cannot disagree."""
+    assert (marketplace_entry_problem(entry) is None) is ok

--- a/tools/tests/test_doc_gardener.py
+++ b/tools/tests/test_doc_gardener.py
@@ -320,6 +320,43 @@ class TestDocCounts:
         check_doc_counts(report)
         assert len([f for f in report.findings if f.kind == "STALE_COUNT"]) == 3
 
+    def test_single_digit_mismatch_is_caught(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """A count below 10 still has to match."""
+        _patch_paths(monkeypatch, tmp_path)
+        _write_counts_fixture(tmp_path, plugins=9, agents=3)
+        (tmp_path / "README.md").write_text("We ship 8 plugins and 3 agents today.\n")
+
+        report = Report()
+        check_doc_counts(report)
+        stale = [f for f in report.findings if f.kind == "STALE_COUNT"]
+        assert len(stale) == 1
+        assert "says 8 plugins, actual is 9" in stale[0].message
+
+    def test_subagents_is_checked_against_the_agent_total(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """AGENTS.md calls the agent total `subagents` in its cross-harness section."""
+        _patch_paths(monkeypatch, tmp_path)
+        _write_counts_fixture(tmp_path, plugins=12, agents=34)
+        (tmp_path / "AGENTS.md").write_text("33 subagents under `plugins/*/agents/`.\n")
+
+        report = Report()
+        check_doc_counts(report)
+        stale = [f for f in report.findings if f.kind == "STALE_COUNT"]
+        assert len(stale) == 1
+        assert "says 33 subagents, actual is 34" in stale[0].message
+
+    def test_matching_subagents_count_no_finding(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        _patch_paths(monkeypatch, tmp_path)
+        _write_counts_fixture(tmp_path, plugins=12, agents=34)
+        (tmp_path / "AGENTS.md").write_text("34 subagents under `plugins/*/agents/`.\n")
+
+        report = Report()
+        check_doc_counts(report)
+        assert [f for f in report.findings if f.kind == "STALE_COUNT"] == []
+
     def test_docs_subtotals_are_not_scanned(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """Per-category subtotals under docs/ legitimately differ from the totals."""
         _patch_paths(monkeypatch, tmp_path)
@@ -351,7 +388,9 @@ class TestAgentDivergence:
         check_agent_divergence(report)
         assert report.findings == []
 
-    def test_verbatim_copies_report_info(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    def test_verbatim_copies_are_not_findings(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
         """Identical bodies differing only by the namespaced `name:` are not drift."""
         _patch_paths(monkeypatch, tmp_path)
         _write_agent(tmp_path, "alpha", "reviewer.md", "Review carefully.\n")
@@ -359,8 +398,7 @@ class TestAgentDivergence:
 
         report = Report()
         check_agent_divergence(report)
-        assert [f.kind for f in report.findings] == ["AGENT_COPY_REDUNDANT"]
-        assert report.findings[0].severity == "info"
+        assert report.findings == []
 
     def test_diverged_bodies_warn(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         _patch_paths(monkeypatch, tmp_path)

--- a/tools/tests/test_doc_gardener.py
+++ b/tools/tests/test_doc_gardener.py
@@ -615,6 +615,58 @@ class TestAgentDivergence:
         check_agent_divergence(report)
         assert report.findings == []
 
+    def test_nested_frontmatter_key_order_is_not_drift(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Mapping key order carries no meaning, so reordering it is not a change."""
+        _patch_paths(monkeypatch, tmp_path)
+        bodies = {
+            "alpha": "---\nname: alpha-r\nmetadata:\n  version: 1.0.0\n  author: me\n---\nB.\n",
+            "beta": "---\nname: beta-r\nmetadata:\n  author: me\n  version: 1.0.0\n---\nB.\n",
+        }
+        for plugin, text in bodies.items():
+            agents_dir = tmp_path / "plugins" / plugin / "agents"
+            agents_dir.mkdir(parents=True, exist_ok=True)
+            (agents_dir / "reviewer.md").write_text(text)
+
+        report = Report()
+        check_agent_divergence(report)
+        assert report.findings == []
+
+    def test_nested_frontmatter_value_change_is_drift(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Canonicalizing key order must not also flatten a changed nested value."""
+        _patch_paths(monkeypatch, tmp_path)
+        bodies = {
+            "alpha": "---\nname: alpha-r\nmetadata:\n  version: 1.0.0\n---\nB.\n",
+            "beta": "---\nname: beta-r\nmetadata:\n  version: 2.0.0\n---\nB.\n",
+        }
+        for plugin, text in bodies.items():
+            agents_dir = tmp_path / "plugins" / plugin / "agents"
+            agents_dir.mkdir(parents=True, exist_ok=True)
+            (agents_dir / "reviewer.md").write_text(text)
+
+        report = Report()
+        check_agent_divergence(report)
+        assert [f.kind for f in report.findings] == ["AGENT_BODY_DIVERGENT"]
+
+    def test_list_order_is_still_meaningful(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """Only mapping keys are reordered. A reordered list is a real difference."""
+        _patch_paths(monkeypatch, tmp_path)
+        bodies = {
+            "alpha": "---\nname: alpha-r\ntools: [Read, Write]\n---\nB.\n",
+            "beta": "---\nname: beta-r\ntools: [Write, Read]\n---\nB.\n",
+        }
+        for plugin, text in bodies.items():
+            agents_dir = tmp_path / "plugins" / plugin / "agents"
+            agents_dir.mkdir(parents=True, exist_ok=True)
+            (agents_dir / "reviewer.md").write_text(text)
+
+        report = Report()
+        check_agent_divergence(report)
+        assert [f.kind for f in report.findings] == ["AGENT_BODY_DIVERGENT"]
+
     def test_crlf_copy_matches_its_lf_twin(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """The realistic case: one copy edited on Windows, the other on Unix.
 

--- a/tools/tests/test_doc_gardener.py
+++ b/tools/tests/test_doc_gardener.py
@@ -8,8 +8,10 @@ from pathlib import Path
 import pytest
 from tools.doc_gardener import (
     Report,
+    check_agent_divergence,
     check_codex_skill_caps,
     check_dead_links,
+    check_doc_counts,
     check_marketplace_consistency,
     check_oversized_context_files,
     check_stale_artifacts,
@@ -266,3 +268,120 @@ class TestMarketplaceConsistency:
         report = Report()
         check_marketplace_consistency(report)
         assert [f for f in report.findings if f.kind == "MARKETPLACE_MISSING"]
+
+
+# ── Doc counts ───────────────────────────────────────────────────────────────
+
+
+def _write_counts_fixture(tmp_path: Path, *, plugins: int, agents: int) -> None:
+    """Build a tiny repo with `plugins` marketplace entries and `agents` agent files."""
+    mp = tmp_path / ".claude-plugin"
+    mp.mkdir(parents=True, exist_ok=True)
+    (mp / "marketplace.json").write_text(
+        json.dumps(
+            {"plugins": [{"name": f"p{i}", "source": f"./plugins/p{i}"} for i in range(plugins)]}
+        )
+    )
+    agents_dir = tmp_path / "plugins" / "demo" / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    for i in range(agents):
+        (agents_dir / f"a{i}.md").write_text("---\nname: a\n---\nBody.\n")
+
+
+class TestDocCounts:
+    def test_matching_counts_no_finding(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        _patch_paths(monkeypatch, tmp_path)
+        _write_counts_fixture(tmp_path, plugins=12, agents=34)
+        (tmp_path / "README.md").write_text("We ship **12 plugins** and **34 agents** today.\n")
+
+        report = Report()
+        check_doc_counts(report)
+        assert [f for f in report.findings if f.kind == "STALE_COUNT"] == []
+
+    def test_stale_count_errors(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        _patch_paths(monkeypatch, tmp_path)
+        _write_counts_fixture(tmp_path, plugins=12, agents=34)
+        (tmp_path / "README.md").write_text("We ship **11 plugins** and **34 agents** today.\n")
+
+        report = Report()
+        check_doc_counts(report)
+        stale = [f for f in report.findings if f.kind == "STALE_COUNT"]
+        assert len(stale) == 1
+        assert stale[0].severity == "error"
+        assert "says 11 plugins, actual is 12" in stale[0].message
+
+    def test_reports_every_stale_mention(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        _patch_paths(monkeypatch, tmp_path)
+        _write_counts_fixture(tmp_path, plugins=12, agents=34)
+        (tmp_path / "README.md").write_text("11 plugins\n\nall 11 plugins by category\n")
+        (tmp_path / "AGENTS.md").write_text("11 plugins here too\n")
+
+        report = Report()
+        check_doc_counts(report)
+        assert len([f for f in report.findings if f.kind == "STALE_COUNT"]) == 3
+
+    def test_docs_subtotals_are_not_scanned(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """Per-category subtotals under docs/ legitimately differ from the totals."""
+        _patch_paths(monkeypatch, tmp_path)
+        _write_counts_fixture(tmp_path, plugins=12, agents=34)
+        docs = tmp_path / "docs"
+        docs.mkdir(parents=True, exist_ok=True)
+        (docs / "plugins.md").write_text("### Development (60 plugins)\n")
+
+        report = Report()
+        check_doc_counts(report)
+        assert [f for f in report.findings if f.kind == "STALE_COUNT"] == []
+
+
+# ── Agent divergence ─────────────────────────────────────────────────────────
+
+
+def _write_agent(tmp_path: Path, plugin: str, filename: str, body: str) -> None:
+    agents_dir = tmp_path / "plugins" / plugin / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    (agents_dir / filename).write_text(f"---\nname: {plugin}-{filename[:-3]}\n---\n{body}")
+
+
+class TestAgentDivergence:
+    def test_single_copy_no_finding(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        _patch_paths(monkeypatch, tmp_path)
+        _write_agent(tmp_path, "alpha", "reviewer.md", "Review carefully.\n")
+
+        report = Report()
+        check_agent_divergence(report)
+        assert report.findings == []
+
+    def test_verbatim_copies_report_info(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """Identical bodies differing only by the namespaced `name:` are not drift."""
+        _patch_paths(monkeypatch, tmp_path)
+        _write_agent(tmp_path, "alpha", "reviewer.md", "Review carefully.\n")
+        _write_agent(tmp_path, "beta", "reviewer.md", "Review carefully.\n")
+
+        report = Report()
+        check_agent_divergence(report)
+        assert [f.kind for f in report.findings] == ["AGENT_COPY_REDUNDANT"]
+        assert report.findings[0].severity == "info"
+
+    def test_diverged_bodies_warn(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        _patch_paths(monkeypatch, tmp_path)
+        _write_agent(tmp_path, "alpha", "reviewer.md", "Review carefully.\n")
+        _write_agent(tmp_path, "beta", "reviewer.md", "Review quickly instead.\n")
+
+        report = Report()
+        check_agent_divergence(report)
+        assert [f.kind for f in report.findings] == ["AGENT_BODY_DIVERGENT"]
+        finding = report.findings[0]
+        assert finding.severity == "warning"
+        assert "2 copies in 2 different versions" in finding.message
+
+    def test_groups_variants_in_message(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """Three copies sharing two bodies report as 3 copies / 2 versions."""
+        _patch_paths(monkeypatch, tmp_path)
+        _write_agent(tmp_path, "alpha", "reviewer.md", "Review carefully.\n")
+        _write_agent(tmp_path, "beta", "reviewer.md", "Review carefully.\n")
+        _write_agent(tmp_path, "gamma", "reviewer.md", "Something else entirely.\n")
+
+        report = Report()
+        check_agent_divergence(report)
+        assert "3 copies in 2 different versions" in report.findings[0].message
+        assert "alpha+beta" in report.findings[0].message

--- a/tools/tests/test_doc_gardener.py
+++ b/tools/tests/test_doc_gardener.py
@@ -357,6 +357,29 @@ class TestDocCounts:
         check_doc_counts(report)
         assert [f for f in report.findings if f.kind == "STALE_COUNT"] == []
 
+    def test_singular_nouns_are_matched(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """A total of one is written in the singular and still has to match."""
+        _patch_paths(monkeypatch, tmp_path)
+        _write_counts_fixture(tmp_path, plugins=1, agents=1)
+        (tmp_path / "README.md").write_text("We ship 2 plugins and 1 agent today.\n")
+
+        report = Report()
+        check_doc_counts(report)
+        stale = [f for f in report.findings if f.kind == "STALE_COUNT"]
+        assert len(stale) == 1
+        assert "says 2 plugins, actual is 1" in stale[0].message
+
+    def test_singular_noun_matching_the_total_is_clean(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        _patch_paths(monkeypatch, tmp_path)
+        _write_counts_fixture(tmp_path, plugins=1, agents=1)
+        (tmp_path / "README.md").write_text("We ship 1 plugin and 1 agent today.\n")
+
+        report = Report()
+        check_doc_counts(report)
+        assert [f for f in report.findings if f.kind == "STALE_COUNT"] == []
+
     def test_docs_subtotals_are_not_scanned(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """Per-category subtotals under docs/ legitimately differ from the totals."""
         _patch_paths(monkeypatch, tmp_path)

--- a/tools/tests/test_doc_gardener.py
+++ b/tools/tests/test_doc_gardener.py
@@ -474,6 +474,23 @@ class TestDocCounts:
         check_doc_counts(report)
         assert [f.message for f in report.findings] == ["line 2 says 11 plugins, actual is 12"]
 
+    def test_unreadable_manifest_is_reported_by_the_counts_check(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A non-UTF-8 manifest reports UNREADABLE_FILE, not just an unknown count."""
+        _patch_paths(monkeypatch, tmp_path)
+        _write_counts_fixture(tmp_path, plugins=12, agents=34)
+        (tmp_path / ".claude-plugin" / "marketplace.json").write_bytes(b"\xff\xfe bad\n")
+        (tmp_path / "README.md").write_text("We ship 99 plugins and 30 agents today.\n")
+
+        report = Report()
+        check_doc_counts(report)
+        assert [f for f in report.findings if f.kind == "UNREADABLE_FILE"]
+        stale = [f for f in report.findings if f.kind == "STALE_COUNT"]
+        # Plugin count unknown, agent count still checked.
+        assert len(stale) == 1
+        assert "30 agents" in stale[0].message
+
     def test_docs_subtotals_are_not_scanned(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """Per-category subtotals under docs/ legitimately differ from the totals."""
         _patch_paths(monkeypatch, tmp_path)
@@ -634,6 +651,33 @@ class TestAgentDivergence:
         report = Report()
         check_agent_divergence(report)
         assert [f.kind for f in report.findings] == ["AGENT_BODY_DIVERGENT"]
+
+    def test_leading_indentation_is_content(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """An indented body must not compare equal to the same text unindented."""
+        _patch_paths(monkeypatch, tmp_path)
+        for plugin, body in (("alpha", "    indented code\n"), ("beta", "indented code\n")):
+            agents_dir = tmp_path / "plugins" / plugin / "agents"
+            agents_dir.mkdir(parents=True, exist_ok=True)
+            (agents_dir / "reviewer.md").write_text(f"---\nname: {plugin}-reviewer\n---\n{body}")
+
+        report = Report()
+        check_agent_divergence(report)
+        assert [f.kind for f in report.findings] == ["AGENT_BODY_DIVERGENT"]
+
+    def test_matching_indentation_stays_verbatim(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        _patch_paths(monkeypatch, tmp_path)
+        for plugin in ("alpha", "beta"):
+            agents_dir = tmp_path / "plugins" / plugin / "agents"
+            agents_dir.mkdir(parents=True, exist_ok=True)
+            (agents_dir / "reviewer.md").write_text(
+                f"---\nname: {plugin}-reviewer\n---\n    indented code\n"
+            )
+
+        report = Report()
+        check_agent_divergence(report)
+        assert report.findings == []
 
     def test_groups_variants_in_message(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """Three copies sharing two bodies report as 3 copies / 2 versions."""

--- a/tools/tests/test_doc_gardener.py
+++ b/tools/tests/test_doc_gardener.py
@@ -554,6 +554,47 @@ class TestAgentDivergence:
         check_agent_divergence(report)
         assert report.findings == []
 
+    @pytest.mark.parametrize(
+        ("label", "template"),
+        [
+            ("bom", "\ufeff---\nname: {name}\nmodel: opus\n---\nReview.\n"),
+            ("leading_blank", "\n\n---\nname: {name}\nmodel: opus\n---\nReview.\n"),
+            ("trailing_space", "--- \nname: {name}\nmodel: opus\n---\nReview.\n"),
+            ("no_trailing_newline", "---\nname: {name}\nmodel: opus\n---\nReview."),
+        ],
+    )
+    def test_delimiter_formatting_is_not_drift(
+        self, label: str, template: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Frontmatter formatting must not decide whether two copies match."""
+        _patch_paths(monkeypatch, tmp_path)
+        for plugin in ("alpha", "beta"):
+            agents_dir = tmp_path / "plugins" / plugin / "agents"
+            agents_dir.mkdir(parents=True, exist_ok=True)
+            (agents_dir / "reviewer.md").write_text(
+                template.format(name=f"{plugin}-reviewer"), encoding="utf-8"
+            )
+
+        report = Report()
+        check_agent_divergence(report)
+        assert report.findings == [], f"{label} was treated as drift"
+
+    def test_frontmatter_field_change_is_drift(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A real frontmatter difference other than `name` still counts."""
+        _patch_paths(monkeypatch, tmp_path)
+        for plugin, model in (("alpha", "opus"), ("beta", "sonnet")):
+            agents_dir = tmp_path / "plugins" / plugin / "agents"
+            agents_dir.mkdir(parents=True, exist_ok=True)
+            (agents_dir / "reviewer.md").write_text(
+                f"---\nname: {plugin}-reviewer\nmodel: {model}\n---\nReview.\n"
+            )
+
+        report = Report()
+        check_agent_divergence(report)
+        assert [f.kind for f in report.findings] == ["AGENT_BODY_DIVERGENT"]
+
     def test_groups_variants_in_message(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """Three copies sharing two bodies report as 3 copies / 2 versions."""
         _patch_paths(monkeypatch, tmp_path)

--- a/tools/tests/test_doc_gardener.py
+++ b/tools/tests/test_doc_gardener.py
@@ -598,19 +598,41 @@ class TestAgentDivergence:
         check_agent_divergence(report)
         assert report.findings == []
 
-    def test_crlf_frontmatter_is_normalized(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-        """CRLF copies differing only by the namespaced name are not divergent."""
+    def test_crlf_copy_matches_its_lf_twin(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """The realistic case: one copy edited on Windows, the other on Unix.
+
+        Comparing CRLF against CRLF would pass without normalizing anything, so this
+        deliberately mixes the two.
+        """
         _patch_paths(monkeypatch, tmp_path)
-        for plugin in ("alpha", "beta"):
+        bodies = {
+            "alpha": "---\r\nname: alpha-reviewer\r\nmodel: opus\r\n---\r\nReview.\r\n",
+            "beta": "---\nname: beta-reviewer\nmodel: opus\n---\nReview.\n",
+        }
+        for plugin, text in bodies.items():
             agents_dir = tmp_path / "plugins" / plugin / "agents"
             agents_dir.mkdir(parents=True, exist_ok=True)
-            (agents_dir / "reviewer.md").write_bytes(
-                f"---\r\nname: {plugin}-reviewer\r\nmodel: opus\r\n---\r\nReview.\r\n".encode()
-            )
+            (agents_dir / "reviewer.md").write_bytes(text.encode())
 
         report = Report()
         check_agent_divergence(report)
         assert report.findings == []
+
+    def test_crlf_does_not_hide_real_drift(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """Normalizing line endings must not also flatten a genuine body difference."""
+        _patch_paths(monkeypatch, tmp_path)
+        bodies = {
+            "alpha": "---\r\nname: alpha-reviewer\r\n---\r\nReview carefully.\r\n",
+            "beta": "---\nname: beta-reviewer\n---\nReview quickly.\n",
+        }
+        for plugin, text in bodies.items():
+            agents_dir = tmp_path / "plugins" / plugin / "agents"
+            agents_dir.mkdir(parents=True, exist_ok=True)
+            (agents_dir / "reviewer.md").write_bytes(text.encode())
+
+        report = Report()
+        check_agent_divergence(report)
+        assert [f.kind for f in report.findings] == ["AGENT_BODY_DIVERGENT"]
 
     def test_frontmatter_closing_at_eof_is_normalized(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -780,6 +802,21 @@ class TestMarketplaceShape:
         check_marketplace_consistency(report)  # must not raise
         shape = [f for f in report.findings if f.kind == "MARKETPLACE_SHAPE"]
         assert shape and "plugins[0] is NoneType" in shape[0].message
+
+    def test_unhashable_name_is_reported_not_raised(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A list-valued name would be added to a set and raise TypeError."""
+        _patch_paths(monkeypatch, tmp_path)
+        mp = tmp_path / ".claude-plugin"
+        mp.mkdir(parents=True, exist_ok=True)
+        (mp / "marketplace.json").write_text('{"plugins": [{"name": ["bad"], "source": {}}]}')
+        (tmp_path / "plugins").mkdir(exist_ok=True)
+
+        report = Report()
+        check_marketplace_consistency(report)  # must not raise
+        shape = [f for f in report.findings if f.kind == "MARKETPLACE_SHAPE"]
+        assert shape and "name is list" in shape[0].message
 
     def test_non_object_root_is_reported_not_raised(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tools/tests/test_doc_gardener.py
+++ b/tools/tests/test_doc_gardener.py
@@ -9,6 +9,7 @@ import pytest
 from tools.doc_gardener import (
     CHECKS,
     Report,
+    actual_counts,
     check_agent_divergence,
     check_codex_skill_caps,
     check_dead_links,
@@ -491,6 +492,20 @@ class TestDocCounts:
         assert len(stale) == 1
         assert "30 agents" in stale[0].message
 
+    def test_malformed_plugin_entry_makes_the_count_unknown(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A plugins list holding a non-object must not drive an error-severity count."""
+        _patch_paths(monkeypatch, tmp_path)
+        _write_counts_fixture(tmp_path, plugins=12, agents=34)
+        (tmp_path / ".claude-plugin" / "marketplace.json").write_text('{"plugins": [null, null]}')
+        (tmp_path / "README.md").write_text("We ship 99 plugins today.\n")
+
+        report = Report()
+        check_doc_counts(report)
+        assert [f for f in report.findings if f.kind == "STALE_COUNT"] == []
+        assert actual_counts(Report())["plugins"] is None
+
     def test_docs_subtotals_are_not_scanned(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """Per-category subtotals under docs/ legitimately differ from the totals."""
         _patch_paths(monkeypatch, tmp_path)
@@ -679,6 +694,20 @@ class TestAgentDivergence:
         check_agent_divergence(report)
         assert report.findings == []
 
+    def test_indentation_without_frontmatter_is_content(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Leading blanks are only formatting when they sit ahead of frontmatter."""
+        _patch_paths(monkeypatch, tmp_path)
+        for plugin, body in (("alpha", "    prose here\n"), ("beta", "prose here\n")):
+            agents_dir = tmp_path / "plugins" / plugin / "agents"
+            agents_dir.mkdir(parents=True, exist_ok=True)
+            (agents_dir / "reviewer.md").write_text(body)
+
+        report = Report()
+        check_agent_divergence(report)
+        assert [f.kind for f in report.findings] == ["AGENT_BODY_DIVERGENT"]
+
     def test_groups_variants_in_message(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """Three copies sharing two bodies report as 3 copies / 2 versions."""
         _patch_paths(monkeypatch, tmp_path)
@@ -732,3 +761,35 @@ class TestUnreadableFiles:
         unreadable = [f for f in report.findings if f.kind == "UNREADABLE_FILE"]
         assert unreadable
         assert unreadable[0].severity == "error"
+
+
+# ── Marketplace shape ────────────────────────────────────────────────────────
+
+
+class TestMarketplaceShape:
+    def test_non_object_entry_is_reported_not_raised(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        _patch_paths(monkeypatch, tmp_path)
+        mp = tmp_path / ".claude-plugin"
+        mp.mkdir(parents=True, exist_ok=True)
+        (mp / "marketplace.json").write_text('{"plugins": [null]}')
+        (tmp_path / "plugins").mkdir(exist_ok=True)
+
+        report = Report()
+        check_marketplace_consistency(report)  # must not raise
+        shape = [f for f in report.findings if f.kind == "MARKETPLACE_SHAPE"]
+        assert shape and "plugins[0] is NoneType" in shape[0].message
+
+    def test_non_object_root_is_reported_not_raised(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        _patch_paths(monkeypatch, tmp_path)
+        mp = tmp_path / ".claude-plugin"
+        mp.mkdir(parents=True, exist_ok=True)
+        (mp / "marketplace.json").write_text("[]")
+        (tmp_path / "plugins").mkdir(exist_ok=True)
+
+        report = Report()
+        check_marketplace_consistency(report)  # must not raise
+        assert [f for f in report.findings if f.kind == "MARKETPLACE_SHAPE"]

--- a/tools/yt-design-extractor/yt-design-extractor.py
+++ b/tools/yt-design-extractor/yt-design-extractor.py
@@ -109,9 +109,7 @@ def get_video_metadata(url: str) -> dict:
     try:
         return json.loads(result.stdout)
     except json.JSONDecodeError as e:
-        sys.exit(
-            f"yt-dlp returned invalid JSON: {e}\nFirst 200 chars: {result.stdout[:200]}"
-        )
+        sys.exit(f"yt-dlp returned invalid JSON: {e}\nFirst 200 chars: {result.stdout[:200]}")
 
 
 def get_transcript(video_id: str) -> list[dict] | None:
@@ -184,9 +182,7 @@ def download_video(url: str, out_dir: Path) -> Path:
     sys.exit("Download succeeded but could not locate video file.")
 
 
-def extract_frames_interval(
-    video_path: Path, out_dir: Path, interval: int = 30
-) -> list[Path]:
+def extract_frames_interval(video_path: Path, out_dir: Path, interval: int = 30) -> list[Path]:
     """Extract one frame every `interval` seconds."""
     frames_dir = out_dir / "frames"
     frames_dir.mkdir(exist_ok=True)
@@ -222,9 +218,7 @@ def extract_frames_interval(
     return frames
 
 
-def extract_frames_scene(
-    video_path: Path, out_dir: Path, threshold: float = 0.3
-) -> list[Path]:
+def extract_frames_scene(video_path: Path, out_dir: Path, threshold: float = 0.3) -> list[Path]:
     """Use ffmpeg scene-change detection to grab visually distinct frames."""
     frames_dir = out_dir / "frames_scene"
     frames_dir.mkdir(exist_ok=True)
@@ -325,9 +319,7 @@ def run_ocr_on_frames(
     else:
         # Tesseract can run in parallel
         with ThreadPoolExecutor(max_workers=workers) as executor:
-            future_to_frame = {
-                executor.submit(ocr_frame_tesseract, f): f for f in frames
-            }
+            future_to_frame = {executor.submit(ocr_frame_tesseract, f): f for f in frames}
             for i, future in enumerate(as_completed(future_to_frame)):
                 frame = future_to_frame[future]
                 try:
@@ -554,9 +546,7 @@ def build_markdown(
         lines.append("")
 
     # --- Visual Text Index (OCR summary) ---
-    frames_with_text = [
-        (ts, rel, txt) for ts, rel, txt in all_frames if txt and len(txt) > 10
-    ]
+    frames_with_text = [(ts, rel, txt) for ts, rel, txt in all_frames if txt and len(txt) > 10]
     if frames_with_text:
         lines.append("## Visual Text Index\n")
         lines.append("Searchable index of all text detected in video frames.\n")
@@ -722,9 +712,7 @@ def main():
     if not args.transcript_only:
         video_path = download_video(args.url, out_dir)
         try:
-            interval_frames = extract_frames_interval(
-                video_path, out_dir, interval=args.interval
-            )
+            interval_frames = extract_frames_interval(video_path, out_dir, interval=args.interval)
             if args.scene_detect:
                 scene_frames = extract_frames_scene(
                     video_path, out_dir, threshold=args.scene_threshold
@@ -782,9 +770,7 @@ def main():
         print(f"  Scene frames   : {len(scene_frames)} in frames_scene/")
     if ocr_results:
         frames_with_text = sum(1 for t in ocr_results.values() if len(t) > 10)
-        print(
-            f"  OCR results    : {frames_with_text} frames with text → ocr-results.json"
-        )
+        print(f"  OCR results    : {frames_with_text} frames with text → ocr-results.json")
     if color_analysis:
         print(
             f"  Color palette  : {len(color_analysis.get('dominant_colors', []))} colors → color-palette.json"


### PR DESCRIPTION
## Summary

Three follow-ups from the open PR and issue audit. Each one closes a gap that
came up while reviewing the queue.

**Stale doc counts.** `check_doc_counts` compares the plugin, agent, skill, and
command totals quoted in README.md and AGENTS.md against the live counts, at
error severity. Only the two canonical context files get scanned, because docs/
carries per-category subtotals that legitimately differ from the totals. Plugins
count marketplace entries rather than `plugins/` directories, so external
git-subdir entries are included the way the headline figure counts them. Nothing
caught this before, which is why #522, #613, #615, and #616 all existed as manual
sync PRs. Counts are correct on main today, so the check is currently silent.

**Diverged agent copies.** `check_agent_divergence` groups agent files by
filename and compares bodies with the plugin-namespaced frontmatter `name:`
normalized away. Without that normalization no two copies can ever hash alike,
which is why #643 read the duplication as total divergence. Measured properly,
30 filenames are duplicated across 65 redundant files, 19 of them are verbatim
copies with no content difference, and 11 have genuinely drifted. Plugins install
individually and the marketplace points at `./plugins/<name>`, so a plugin has to
contain every agent it offers. Verbatim copies are therefore expected and report
as info, and drifted bodies report as warning.

**Untested tool rewriting.** `strip_claude_tool_refs` rewrites Claude tool names
in Copilot command bodies and had no test coverage. #642 changed its output in
three ways while claiming no behavioral change, and nothing caught it. The new
tests assert exact output for both `tool_case` values, both prose forms, and all
nine mapped tools.

**Policy.** The commercial section of CONTRIBUTING covered funnels to paid
products but not a payload that sells something itself. #670 shipped a Telegram
sales bot, USDT payment verification, and a script granting GitHub collaborator
access on payment, so the new bullet rules that out directly.

## Scope

- [ ] Plugin authoring (new or modified `plugins/<name>/...`)
- [ ] Adapter framework (`tools/adapters/`)
- [x] Quality tooling (validators, gardener, plugin-eval)
- [ ] Per-harness setup or docs (docs/harnesses.md)
- [ ] AGENTS.md / ARCHITECTURE.md / docs/
- [ ] CI / build / release
- [x] Other (CONTRIBUTING policy)

## Affected harnesses

- [ ] Claude Code
- [ ] OpenAI Codex CLI
- [ ] Cursor
- [ ] OpenCode
- [ ] Antigravity CLI
- [x] Pure tooling / framework (no harness behavior change)

## Test plan

- [x] `make validate STRICT=1` — OK, no issues across 5 harnesses
- [x] `make garden` — exit 0. Adds 11 `AGENT_BODY_DIVERGENT` warnings and 19
      `AGENT_COPY_REDUNDANT` info findings alongside the 10 pre-existing
      `SKILL_OVER_CODEX_CAP` warnings. No new errors, so the CI gate still passes.
- [x] `pytest tools/tests/` — 105 passed for the two touched files, 20 of them new
- [x] ruff check, ruff format --check, and ty, all run from `plugins/plugin-eval/`
      the way CI does — all clean

`make test` fails three round-trip tests on my machine
(`test_opencode_skill_count_matches_source`,
`test_copilot_skill_count_matches_source`,
`test_copilot_command_entrypoints_exist_for_every_plugin`). I confirmed the same
three fail on a clean checkout with these commits stashed, because `.opencode/`
and `.copilot/` are gitignored and go stale locally. CI regenerates them.

## Notes for review

The two new checks are deliberately non-blocking except for stale counts. The
divergence check reports what exists today rather than demanding a refactor,
because the underlying question is still open.

**Open decision, not settled here.** Either generate the duplicated agents from a
shared source during `make generate-all`, or keep hand-maintained copies and rely
on this check to catch drift. Collapsing to single canonical copies would break
standalone plugin installs, so that option is off the table. #643 stays open for
the remaining choice.

## Related issue(s)

Refs #643
