### PR TITLE
chore(tooling): close the ruff scope gap and correct two stale docs

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -35,34 +35,33 @@ jobs:
         run: uv sync --all-extras
 
       - name: ruff check (lint)
-        # Scope: adapter framework + plugin-eval. yt-design-extractor.py is legacy
-        # and out of scope for the multi-harness work; not gated.
+        # Scope: all of tools/ plus plugin-eval. Narrower per-file paths let
+        # check_agent_name_collisions.py, the installers and yt-design-extractor.py
+        # drift out of format; `make lint` runs this same scope locally.
         run: |
           uv run ruff check \
-            ../../tools/adapters/ \
-            ../../tools/generate.py \
-            ../../tools/validate_generated.py \
-            ../../tools/doc_gardener.py \
-            ../../tools/tests/ \
+            ../../tools/ \
             src/plugin_eval/
 
       - name: ruff format --check
         run: |
           uv run ruff format --check \
-            ../../tools/adapters/ \
-            ../../tools/generate.py \
-            ../../tools/validate_generated.py \
-            ../../tools/doc_gardener.py \
-            ../../tools/tests/ \
+            ../../tools/ \
             src/plugin_eval/
 
       - name: ty type-check
         run: |
+          # Not ../../tools/ — yt-design-extractor imports optional OCR deps that are
+          # installed only by `make install-ocr`, so ty cannot resolve them here.
           uv run ty check \
             ../../tools/adapters/ \
             ../../tools/generate.py \
             ../../tools/validate_generated.py \
             ../../tools/doc_gardener.py \
+            ../../tools/install_opencode.py \
+            ../../tools/install_copilot.py \
+            ../../tools/install_antigravity.py \
+            ../../tools/check_agent_name_collisions.py \
             ../../tools/tests/ \
             src/plugin_eval/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ make generate HARNESS=antigravity  # .antigravity/plugins/<p>/
 make generate-all                  # all four
 ```
 
-Generated artifacts are **committed** so each harness installs natively from a clone / GitHub URL (native-install commands in [`docs/harnesses.md`](docs/harnesses.md)). Run `make generate-all` before committing source changes — it also prunes artifacts whose source was removed; CI fails on drift. Source-of-truth lives only under `plugins/`; never hand-edit generated files.
+The small per-harness registries are **committed** so each harness installs natively from a clone / GitHub URL (native-install commands in [`docs/harnesses.md`](docs/harnesses.md)). The transformed skill and agent trees under `.codex/`, `.opencode/`, `.copilot/` and `.antigravity/` stay gitignored and are rebuilt locally. Run `make generate-all` before committing source changes — it also prunes artifacts whose source was removed; CI fails on drift. Source-of-truth lives only under `plugins/`; never hand-edit generated files.
 
 ## Skills (cross-harness)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,19 +64,25 @@ Every PR runs these on CI (`.github/workflows/`); run them locally before pushin
 
 ```bash
 make validate STRICT=1     # structural validation across all harness outputs
-make garden STRICT=1       # drift, dead-link, stale-artifact detection
+make garden                # drift, dead-link, stale-artifact detection
 make test                  # full pytest suite (plugin-eval + tools/tests/)
 make smoke-test            # real-CLI subprocess tests (OpenCode, Antigravity, Codex, Claude)
 ```
 
+`make garden STRICT=1` also fails on warnings. Main currently carries ten
+`SKILL_OVER_CODEX_CAP` warnings, so treat it as something to read rather than a
+pass/fail gate until those skills are split. CI gates on errors only.
+
 Code-quality checks (also in CI):
 
 ```bash
-cd plugins/plugin-eval
-uv run ruff check ../../tools/ src/plugin_eval/
-uv run ruff format --check ../../tools/ src/plugin_eval/
-uv run ty check ../../tools/ src/plugin_eval/
+make lint      # ruff check, ruff format --check, and ty
+make format    # apply ruff format and safe fixes
 ```
+
+Both run from `plugins/plugin-eval/`, which is where the ruff and ty config lives.
+Invoking ruff from the repo root instead silently falls back to line-length 88 and
+disagrees with CI.
 
 ## Cross-harness portability checklist
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,13 @@ YTX_SCRIPT := yt-design-extractor.py
 # `uv run` against the plugin-eval venv — has pyyaml + extra-paths to tools/adapters/
 UV_TOOLS := uv run $(EVAL_PROJECT) python
 
-.PHONY: help install install-ocr install-easyocr deps check run run-full run-ocr run-transcript clean generate generate-all clean-generated install-opencode uninstall-opencode install-copilot uninstall-copilot install-antigravity uninstall-antigravity validate garden test smoke-test
+# Paths for `make lint` / `make format`, relative to plugins/plugin-eval/ where the
+# ruff and ty config lives. ty skips tools/yt-design-extractor/ because that tool
+# imports optional OCR dependencies installed only by `make install-ocr`.
+RUFF_PATHS := ../../tools/ src/plugin_eval/
+TY_PATHS := ../../tools/adapters/ ../../tools/generate.py ../../tools/validate_generated.py ../../tools/doc_gardener.py ../../tools/install_opencode.py ../../tools/install_copilot.py ../../tools/install_antigravity.py ../../tools/check_agent_name_collisions.py ../../tools/tests/ src/plugin_eval/
+
+.PHONY: help install install-ocr install-easyocr deps check run run-full run-ocr run-transcript clean generate generate-all clean-generated install-opencode uninstall-opencode install-copilot uninstall-copilot install-antigravity uninstall-antigravity validate garden lint format test smoke-test
 
 help:
 	@echo "claude-agents — multi-harness plugin marketplace"
@@ -34,6 +40,8 @@ help:
 	@echo "  make uninstall-antigravity                       Remove repo-owned Antigravity symlinks"
 	@echo "  make validate [HARNESS=<h>] [STRICT=1]           Structural validation of generated artifacts"
 	@echo "  make garden [STRICT=1]                           Run doc-gardener (drift detection)"
+	@echo "  make lint                                        ruff + ty, exactly as CI runs them"
+	@echo "  make format                                      Apply ruff format and safe fixes"
 	@echo "  make test                                        Full pytest suite (plugin-eval + tools)"
 	@echo "  make smoke-test                                  Real-CLI smoke test (skips CLIs not on PATH)"
 	@echo ""
@@ -189,6 +197,19 @@ endif
 
 garden:
 	$(UV_TOOLS) tools/doc_gardener.py $(if $(STRICT),--strict)
+
+# Code-quality gates. These MUST run from plugins/plugin-eval/, which is where the
+# [tool.ruff] and [tool.ty] config lives and where CI runs them. Running ruff from the
+# repo root silently falls back to line-length 88 and disagrees with CI, so use these
+# targets rather than invoking ruff directly.
+lint:
+	cd plugins/plugin-eval && uv run ruff check $(RUFF_PATHS)
+	cd plugins/plugin-eval && uv run ruff format --check $(RUFF_PATHS)
+	cd plugins/plugin-eval && uv run ty check $(TY_PATHS)
+
+format:
+	cd plugins/plugin-eval && uv run ruff format $(RUFF_PATHS)
+	cd plugins/plugin-eval && uv run ruff check --fix $(RUFF_PATHS)
 
 # Full pytest suite — plugin-eval framework + tools/ adapters/validators/gardener.
 test:

--- a/Makefile
+++ b/Makefile
@@ -202,14 +202,18 @@ garden:
 # [tool.ruff] and [tool.ty] config lives and where CI runs them. Running ruff from the
 # repo root silently falls back to line-length 88 and disagrees with CI, so use these
 # targets rather than invoking ruff directly.
+#
+# --extra dev matters: ruff and ty live in that extra. Without it `uv run ruff`
+# provisions an unpinned ruff on the fly, which can differ from the locked version CI
+# uses and disagree about formatting.
 lint:
-	cd plugins/plugin-eval && uv run ruff check $(RUFF_PATHS)
-	cd plugins/plugin-eval && uv run ruff format --check $(RUFF_PATHS)
-	cd plugins/plugin-eval && uv run ty check $(TY_PATHS)
+	cd plugins/plugin-eval && uv run --extra dev ruff check $(RUFF_PATHS)
+	cd plugins/plugin-eval && uv run --extra dev ruff format --check $(RUFF_PATHS)
+	cd plugins/plugin-eval && uv run --extra dev ty check $(TY_PATHS)
 
 format:
-	cd plugins/plugin-eval && uv run ruff format $(RUFF_PATHS)
-	cd plugins/plugin-eval && uv run ruff check --fix $(RUFF_PATHS)
+	cd plugins/plugin-eval && uv run --extra dev ruff format $(RUFF_PATHS)
+	cd plugins/plugin-eval && uv run --extra dev ruff check --fix $(RUFF_PATHS)
 
 # Full pytest suite — plugin-eval framework + tools/ adapters/validators/gardener.
 test:

--- a/tools/check_agent_name_collisions.py
+++ b/tools/check_agent_name_collisions.py
@@ -84,8 +84,7 @@ def main() -> int:
         return 0
 
     print(
-        f"Found {duplicate_name_count} duplicate agent names across "
-        f"{colliding_file_count} files:"
+        f"Found {duplicate_name_count} duplicate agent names across {colliding_file_count} files:"
     )
     for name, paths in duplicates.items():
         print(f"\n{name} ({len(paths)} files)")
@@ -93,20 +92,14 @@ def main() -> int:
             print(f"  - {path.relative_to(root)}")
 
     failed = args.fail_on_duplicates
-    if (
-        args.max_duplicate_names is not None
-        and duplicate_name_count > args.max_duplicate_names
-    ):
+    if args.max_duplicate_names is not None and duplicate_name_count > args.max_duplicate_names:
         print(
             f"\nERROR: duplicate name count {duplicate_name_count} exceeds "
             f"baseline {args.max_duplicate_names}",
             file=sys.stderr,
         )
         failed = True
-    if (
-        args.max_colliding_files is not None
-        and colliding_file_count > args.max_colliding_files
-    ):
+    if args.max_colliding_files is not None and colliding_file_count > args.max_colliding_files:
         print(
             f"\nERROR: colliding file count {colliding_file_count} exceeds "
             f"baseline {args.max_colliding_files}",

--- a/tools/install_antigravity.py
+++ b/tools/install_antigravity.py
@@ -69,9 +69,7 @@ def _link_one(src: Path, dst: Path, *, force: bool, report: InstallReport) -> No
             return
         dst.unlink()
     elif dst.exists():
-        report.errors.append(
-            f"{dst} already exists and is not a symlink; refusing to overwrite"
-        )
+        report.errors.append(f"{dst} already exists and is not a symlink; refusing to overwrite")
         return
 
     dst.parent.mkdir(parents=True, exist_ok=True)
@@ -138,9 +136,7 @@ def main() -> int:
     parser.add_argument("action", choices=("install", "uninstall"))
     parser.add_argument("--config-dir", type=Path, default=None)
     parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
-    parser.add_argument(
-        "--force", action="store_true", help="Replace conflicting symlinks only"
-    )
+    parser.add_argument("--force", action="store_true", help="Replace conflicting symlinks only")
     args = parser.parse_args()
 
     config_dir = (args.config_dir or default_config_dir()).expanduser()

--- a/tools/install_copilot.py
+++ b/tools/install_copilot.py
@@ -64,8 +64,7 @@ def _generated_artifacts(repo_root: Path) -> list[tuple[str, Path]]:
             artifacts.append((subdir, src.resolve()))
     if not artifacts:
         raise FileNotFoundError(
-            f"No artifacts found under {generated_root}; "
-            "run `make generate HARNESS=copilot` first"
+            f"No artifacts found under {generated_root}; run `make generate HARNESS=copilot` first"
         )
     return artifacts
 
@@ -83,9 +82,7 @@ def _link_one(src: Path, dst: Path, *, force: bool, report: InstallReport) -> No
             return
         dst.unlink()
     elif dst.exists():
-        report.errors.append(
-            f"{dst} already exists and is not a symlink; refusing to overwrite"
-        )
+        report.errors.append(f"{dst} already exists and is not a symlink; refusing to overwrite")
         return
 
     dst.parent.mkdir(parents=True, exist_ok=True)
@@ -198,17 +195,13 @@ def main() -> int:
     parser.add_argument("action", choices=("install", "uninstall"))
     parser.add_argument("--config-dir", type=Path, default=None)
     parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
-    parser.add_argument(
-        "--force", action="store_true", help="Replace conflicting symlinks only"
-    )
+    parser.add_argument("--force", action="store_true", help="Replace conflicting symlinks only")
     args = parser.parse_args()
 
     config_dir = (args.config_dir or default_config_dir()).expanduser()
     cache_cleared = None
     if args.action == "install":
-        report = install(
-            repo_root=args.repo_root, config_dir=config_dir, force=args.force
-        )
+        report = install(repo_root=args.repo_root, config_dir=config_dir, force=args.force)
         if report.ok:
             cache_cleared = _clear_copilot_cache(config_dir)
     else:

--- a/tools/install_opencode.py
+++ b/tools/install_opencode.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -30,12 +31,14 @@ class InstallReport:
         return not self.errors
 
 
-def default_config_dir(env: dict[str, str] | None = None) -> Path:
-    env = env or os.environ
-    if env.get("OPENCODE_CONFIG_DIR"):
-        return Path(env["OPENCODE_CONFIG_DIR"]).expanduser()
-    if env.get("XDG_CONFIG_HOME"):
-        return Path(env["XDG_CONFIG_HOME"]).expanduser() / "opencode"
+def default_config_dir(env: Mapping[str, str] | None = None) -> Path:
+    # os.environ is a Mapping, not a dict, so it needs its own binding rather than
+    # being assigned back over an argument annotated dict[str, str] | None.
+    source: Mapping[str, str] = os.environ if env is None else env
+    if source.get("OPENCODE_CONFIG_DIR"):
+        return Path(source["OPENCODE_CONFIG_DIR"]).expanduser()
+    if source.get("XDG_CONFIG_HOME"):
+        return Path(source["XDG_CONFIG_HOME"]).expanduser() / "opencode"
     return Path.home() / ".config" / "opencode"
 
 

--- a/tools/install_opencode.py
+++ b/tools/install_opencode.py
@@ -32,8 +32,9 @@ class InstallReport:
 
 
 def default_config_dir(env: Mapping[str, str] | None = None) -> Path:
-    # os.environ is a Mapping, not a dict, so it needs its own binding rather than
-    # being assigned back over an argument annotated dict[str, str] | None.
+    # An explicit None check, so a caller passing an empty mapping gets exactly that
+    # rather than falling back to os.environ. Matches install_copilot.default_config_dir.
+    # os.environ is a Mapping rather than a dict, hence the separate binding.
     source: Mapping[str, str] = os.environ if env is None else env
     if source.get("OPENCODE_CONFIG_DIR"):
         return Path(source["OPENCODE_CONFIG_DIR"]).expanduser()

--- a/tools/tests/test_install_opencode.py
+++ b/tools/tests/test_install_opencode.py
@@ -103,3 +103,14 @@ def test_uninstall_removes_only_repo_owned_symlinks(tmp_path: Path):
     assert not (config_dir / "agents" / "demo__agent.md").exists()
     assert unrelated.is_symlink()
     assert real_file.read_text() == "user\n"
+
+
+def test_default_config_dir_respects_an_empty_env(tmp_path: Path, monkeypatch):
+    """An explicitly empty mapping means "no env vars", not "fall back to os.environ"."""
+    monkeypatch.setenv("OPENCODE_CONFIG_DIR", str(tmp_path / "from-environ"))
+    assert default_config_dir({}) == Path.home() / ".config" / "opencode"
+
+
+def test_default_config_dir_reads_os_environ_when_omitted(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENCODE_CONFIG_DIR", str(tmp_path / "from-environ"))
+    assert default_config_dir() == tmp_path / "from-environ"

--- a/tools/yt-design-extractor/yt-design-extractor.py
+++ b/tools/yt-design-extractor/yt-design-extractor.py
@@ -109,9 +109,7 @@ def get_video_metadata(url: str) -> dict:
     try:
         return json.loads(result.stdout)
     except json.JSONDecodeError as e:
-        sys.exit(
-            f"yt-dlp returned invalid JSON: {e}\nFirst 200 chars: {result.stdout[:200]}"
-        )
+        sys.exit(f"yt-dlp returned invalid JSON: {e}\nFirst 200 chars: {result.stdout[:200]}")
 
 
 def get_transcript(video_id: str) -> list[dict] | None:
@@ -184,9 +182,7 @@ def download_video(url: str, out_dir: Path) -> Path:
     sys.exit("Download succeeded but could not locate video file.")
 
 
-def extract_frames_interval(
-    video_path: Path, out_dir: Path, interval: int = 30
-) -> list[Path]:
+def extract_frames_interval(video_path: Path, out_dir: Path, interval: int = 30) -> list[Path]:
     """Extract one frame every `interval` seconds."""
     frames_dir = out_dir / "frames"
     frames_dir.mkdir(exist_ok=True)
@@ -222,9 +218,7 @@ def extract_frames_interval(
     return frames
 
 
-def extract_frames_scene(
-    video_path: Path, out_dir: Path, threshold: float = 0.3
-) -> list[Path]:
+def extract_frames_scene(video_path: Path, out_dir: Path, threshold: float = 0.3) -> list[Path]:
     """Use ffmpeg scene-change detection to grab visually distinct frames."""
     frames_dir = out_dir / "frames_scene"
     frames_dir.mkdir(exist_ok=True)
@@ -325,9 +319,7 @@ def run_ocr_on_frames(
     else:
         # Tesseract can run in parallel
         with ThreadPoolExecutor(max_workers=workers) as executor:
-            future_to_frame = {
-                executor.submit(ocr_frame_tesseract, f): f for f in frames
-            }
+            future_to_frame = {executor.submit(ocr_frame_tesseract, f): f for f in frames}
             for i, future in enumerate(as_completed(future_to_frame)):
                 frame = future_to_frame[future]
                 try:
@@ -554,15 +546,13 @@ def build_markdown(
         lines.append("")
 
     # --- Visual Text Index (OCR summary) ---
-    frames_with_text = [
-        (ts, rel, txt) for ts, rel, txt in all_frames if txt and len(txt) > 10
-    ]
+    frames_with_text = [(ts, rel, txt) for ts, rel, txt in all_frames if txt and len(txt) > 10]
     if frames_with_text:
         lines.append("## Visual Text Index\n")
         lines.append("Searchable index of all text detected in video frames.\n")
         lines.append("| Timestamp | Key Text (preview) |")
         lines.append("|-----------|-------------------|")
-        for ts, rel, txt in frames_with_text:
+        for ts, _rel, txt in frames_with_text:
             # First line or first 80 chars as preview
             preview = txt.split("\n")[0][:80].replace("|", "\\|")
             if len(txt) > 80:
@@ -573,7 +563,7 @@ def build_markdown(
         # Full text dump for searchability
         lines.append("### All Detected Text (Full)\n")
         lines.append("<details><summary>Click to expand full OCR text</summary>\n")
-        for ts, rel, txt in frames_with_text:
+        for ts, _rel, txt in frames_with_text:
             lines.append(f"**[{ts}]**")
             lines.append(f"```\n{txt}\n```\n")
         lines.append("</details>\n")
@@ -722,9 +712,7 @@ def main():
     if not args.transcript_only:
         video_path = download_video(args.url, out_dir)
         try:
-            interval_frames = extract_frames_interval(
-                video_path, out_dir, interval=args.interval
-            )
+            interval_frames = extract_frames_interval(video_path, out_dir, interval=args.interval)
             if args.scene_detect:
                 scene_frames = extract_frames_scene(
                     video_path, out_dir, threshold=args.scene_threshold
@@ -782,9 +770,7 @@ def main():
         print(f"  Scene frames   : {len(scene_frames)} in frames_scene/")
     if ocr_results:
         frames_with_text = sum(1 for t in ocr_results.values() if len(t) > 10)
-        print(
-            f"  OCR results    : {frames_with_text} frames with text → ocr-results.json"
-        )
+        print(f"  OCR results    : {frames_with_text} frames with text → ocr-results.json")
     if color_analysis:
         print(
             f"  Color palette  : {len(color_analysis.get('dominant_colors', []))} colors → color-palette.json"


### PR DESCRIPTION
## Summary

Pre-existing issues found while working on #676. Kept separate so that PR stays reviewable.

**The ruff scope gap.** CI checked ruff against five explicit paths under `tools/`, so anything outside that list was never checked and drifted. Four files were unformatted: `check_agent_name_collisions.py`, both installers, and `yt-design-extractor.py`. Ruff now runs over all of `tools/`, those four are formatted, and two real `B007` findings in `yt-design-extractor.py` are fixed, where a loop unpacked a variable it never read.

`ty` keeps explicit paths rather than widening, because `yt-design-extractor.py` imports optional OCR dependencies that only `make install-ocr` provides, so `ty` cannot resolve them in CI. The paths now name every module it does cover, and there's a comment saying why the tool is excluded.

**A real type bug in `install_opencode.py`.** `default_config_dir` assigned `os.environ`, a `Mapping`, back over a parameter annotated `dict[str, str] | None`. That produced five `ty` errors and left the value reading as possibly-None for the next four lines. It now binds a separate `Mapping`-typed local. The other two installers were already fine.

**New `make lint` and `make format`.** Both run from `plugins/plugin-eval/`, which is where the ruff and ty config lives and where CI runs them. Running ruff from the repo root silently falls back to line-length 88 and disagrees with CI, which is easy to hit and produces reformatting CI does not want. The targets remove the choice.

I tried a root `ruff.toml` first and reverted it. It changes isort's first-party resolution for `tools/`, and CI's own command then fails with `I001` on two test files. Verified both ways before backing it out.

**Two stale docs.** AGENTS.md said generated artifacts are committed. Only the small registries are; the transformed trees under `.codex/`, `.opencode/`, `.copilot/` and `.antigravity/` are gitignored, which `.gitignore` states correctly. CONTRIBUTING listed `make garden STRICT=1` as a gate to run before pushing, but main carries ten `SKILL_OVER_CODEX_CAP` warnings and `STRICT=1` fails on warnings, so it has been red for a while. Two recent PRs noted this in their test plans. The gate list now shows plain `make garden`, with a note explaining what `STRICT=1` adds.

## Scope

- [ ] Plugin authoring (new or modified `plugins/<name>/...`)
- [ ] Adapter framework (`tools/adapters/`)
- [x] Quality tooling (validators, gardener, plugin-eval)
- [ ] Per-harness setup or docs (docs/harnesses.md)
- [x] AGENTS.md / ARCHITECTURE.md / docs/
- [x] CI / build / release
- [ ] Other

## Affected harnesses

- [ ] Claude Code
- [ ] OpenAI Codex CLI
- [ ] Cursor
- [ ] OpenCode
- [ ] Antigravity CLI
- [x] Pure tooling / framework (no harness behavior change)

## Test plan

- [x] `make lint` — ruff check, ruff format --check and ty all clean over the new scope
- [x] `make validate STRICT=1` — OK across 5 harnesses
- [x] `make garden` — exits 0, unchanged output
- [x] `pytest tools/tests/` — 371 passed
- [x] markdownlint clean on CONTRIBUTING.md and AGENTS.md
- [x] `code-quality.yml` parses as YAML
- [x] AGENTS.md still 74 lines, under the 150 budget

The 3 `test_round_trip` failures are pre-existing and unrelated: `.opencode/` and `.copilot/` are gitignored and go stale locally. Identical on a clean checkout of main. CI regenerates them.

## Not addressed here

The ten oversize skills behind the `garden STRICT=1` warnings need their bodies split into `references/`. That is content work across ten plugins and belongs in its own PR. This change documents the situation accurately rather than hiding it.

## Related

Follow-up to #676. No overlap in files except `CONTRIBUTING.md`, which touches a different section.
