### PR TITLE
feat(plugin): add HOL Guard external marketplace entry

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1121,7 +1121,8 @@
       "source": {
         "source": "git-subdir",
         "url": "https://github.com/hashgraph-online/hol-guard-plugin.git",
-        "path": "distributions/wshobson-agents"
+        "path": "distributions/wshobson-agents",
+        "sha": "43b2dda59e9f07057c52e69fd7426188faae1488"
       },
       "description": "Local pre-execution security controls and pre-install scanning for AI agent tools, packages, skills, plugins, and MCP servers.",
       "version": "0.1.0",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1117,6 +1117,31 @@
       "category": "memory"
     },
     {
+      "name": "hol-guard",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/hashgraph-online/hol-guard-plugin.git",
+        "path": "distributions/wshobson-agents"
+      },
+      "description": "Local pre-execution security controls and pre-install scanning for AI agent tools, packages, skills, plugins, and MCP servers.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Hashgraph Online",
+        "url": "https://github.com/hashgraph-online"
+      },
+      "homepage": "https://github.com/hashgraph-online/hol-guard",
+      "license": "Apache-2.0",
+      "category": "security",
+      "keywords": [
+        "hol-guard",
+        "ai-security",
+        "agent-security",
+        "plugin-security",
+        "mcp-security",
+        "supply-chain-security"
+      ]
+    },
+    {
       "name": "protect-mcp",
       "source": "./plugins/protect-mcp",
       "description": "Cedar policy enforcement + Ed25519 signed receipts for every Claude Code tool call. First cryptographic governance plugin \u2014 decisions are policy-gated before they run and every decision produces a tamper-evident receipt verifiable offline.",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # claude-agents — multi-harness agentic plugin marketplace
 
-Production-ready agentic-workflow building blocks: **92 plugins** (91 local + 1 external), **202 agents**, **181 skills**, **105 commands**. Native source-of-truth for Claude Code; also consumed by OpenAI Codex CLI, Cursor, OpenCode, and the Google Antigravity CLI (`agy`) from a single Markdown source.
+Production-ready agentic-workflow building blocks: **93 plugins** (91 local + 2 external), **202 agents**, **181 skills**, **105 commands**. Native source-of-truth for Claude Code; also consumed by OpenAI Codex CLI, Cursor, OpenCode, and the Google Antigravity CLI (`agy`) from a single Markdown source.
 
 This file is the canonical context file. Codex / Cursor / OpenCode / Antigravity CLI read it directly. Claude Code reads it via `CLAUDE.md`, a symlink to this file.
 
@@ -10,7 +10,7 @@ This file is the canonical context file. Codex / Cursor / OpenCode / Antigravity
 
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — top-level architectural overview (adapter framework, source-of-truth invariant, capability matrix summary)
 - **[docs/architecture.md](docs/architecture.md)** — detailed design principles
-- **[docs/plugins.md](docs/plugins.md)** — full plugin catalog (92 plugins by category)
+- **[docs/plugins.md](docs/plugins.md)** — full plugin catalog (93 plugins by category)
 - **[docs/agents.md](docs/agents.md)** — agent reference (202 agents, model tiers)
 - **[docs/agent-skills.md](docs/agent-skills.md)** — skill reference (progressive disclosure model)
 - **[docs/usage.md](docs/usage.md)** — commands, workflows, examples

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,7 +25,7 @@ claude-agents/
 ├── CONTRIBUTING.md                 # Contributor entry point
 ├── .claude-plugin/marketplace.json # Plugin registry (source of truth)
 ├── .antigravity/plugins/<p>/       # Generated Antigravity CLI plugins (gitignored)
-├── plugins/                        # SOURCE OF TRUTH (91 local plugins; 1 external in marketplace)
+├── plugins/                        # SOURCE OF TRUTH (91 local plugins; 2 external in marketplace)
 │   └── <name>/
 │       ├── .claude-plugin/plugin.json
 │       ├── agents/*.md

--- a/README.md
+++ b/README.md
@@ -159,12 +159,16 @@ integrations for Codex CLI, Cursor, OpenCode, and Copilot (not yet Antigravity C
 `git-subdir` entry for Claude Code from the reviewed `distributions/wshobson-agents`
 payload in [hashgraph-online/hol-guard-plugin](https://github.com/hashgraph-online/hol-guard-plugin).
 The payload exposes local `hol-guard` and `plugin-scanner` skills. Guard Cloud is neither
-required nor promoted on the default path.
+required nor promoted on the default path. This marketplace entry is a Claude Code
+discovery surface only; it does not add HOL Guard to this repository's generated Codex,
+Cursor, OpenCode, Antigravity, or Copilot registries.
 
-The payload pins its local CLI versions and requires user approval before installation.
-When protection is explicitly requested, the external `hol-guard` runtime can modify
-supported harness hook/settings configuration; those changes are performed by the local
-Guard CLI, not by files in this marketplace repository.
+The reviewed external payload is pinned to commit `43b2dda59e9f07057c52e69fd7426188faae1488`. Its local CLI pins are
+`hol-guard==2.2.119` and `plugin-scanner==2.2.119`, and installation requires user approval.
+For a reviewed payload update, the marketplace `sha` and the matching marketplace/external
+manifest versions must be advanced together. When protection is explicitly requested, the
+external `hol-guard` runtime can modify supported harness hook/settings configuration; those
+changes are performed by the local Guard CLI, not by files in this marketplace repository.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agentic Plugin Marketplace
 
-> Production-ready agentic workflow building blocks: **92 plugins**, **202 agents**,
+> Production-ready agentic workflow building blocks: **93 plugins**, **202 agents**,
 > **181 skills**, **105 commands** — built for Claude Code and consumed natively by
 > OpenAI Codex CLI, Cursor, OpenCode, the Antigravity CLI, and GitHub Copilot from a single Markdown source.
 
@@ -19,7 +19,7 @@ Pick your harness:
 
 ```bash
 /plugin marketplace add wshobson/agents
-/plugin install python-development          # or any of 92 plugins
+/plugin install python-development          # or any of 93 plugins
 ```
 
 [→ Full Claude Code setup, troubleshooting, and plugin catalog](docs/usage.md)
@@ -47,7 +47,7 @@ Setup details and per-harness gotchas: [docs/harnesses.md](docs/harnesses.md).
 
 | | Count | What it is |
 |---|---:|---|
-| **Plugins** | 92 | Granular, single-purpose installable units (91 local + 1 external via git-subdir) |
+| **Plugins** | 93 | Granular, single-purpose installable units (91 local + 2 external via git-subdir) |
 | **Agents** | 202 | Domain experts (architecture, languages, infra, security, data, ML, docs, business, SEO) |
 | **Skills** | 181 | Modular knowledge packages with progressive disclosure (load when activated) |
 | **Commands** | 105 | Slash commands: scaffolding, security scans, test gen, infrastructure setup |
@@ -125,7 +125,7 @@ uv run plugin-eval certify path/to/skill
 
 Detail lives in `docs/`. Read in this order:
 
-- **[docs/plugins.md](docs/plugins.md)** — full catalog of all 92 plugins
+- **[docs/plugins.md](docs/plugins.md)** — full catalog of all 93 plugins
 - **[docs/agents.md](docs/agents.md)** — all 202 agents by category
 - **[docs/agent-skills.md](docs/agent-skills.md)** — 181 skills with progressive disclosure
 - **[docs/usage.md](docs/usage.md)** — commands, workflows, examples
@@ -152,6 +152,19 @@ integrations for Codex CLI, Cursor, OpenCode, and Copilot (not yet Antigravity C
 | Cursor | [integrations/cursor](https://github.com/major7apps/pensyve/tree/main/integrations/cursor) |
 | OpenCode | [integrations/opencode-plugin](https://github.com/major7apps/pensyve/tree/main/integrations/opencode-plugin) |
 | Copilot | `.copilot/` in repo root or `~/.copilot/` via `make install-copilot` |
+
+## External Security Integration
+
+[HOL Guard](https://github.com/hashgraph-online/hol-guard) is included as an external
+`git-subdir` entry for Claude Code from the reviewed `distributions/wshobson-agents`
+payload in [hashgraph-online/hol-guard-plugin](https://github.com/hashgraph-online/hol-guard-plugin).
+The payload exposes local `hol-guard` and `plugin-scanner` skills. Guard Cloud is neither
+required nor promoted on the default path.
+
+The payload pins its local CLI versions and requires user approval before installation.
+When protection is explicitly requested, the external `hol-guard` runtime can modify
+supported harness hook/settings configuration; those changes are performed by the local
+Guard CLI, not by files in this marketplace repository.
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,7 +36,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 
 ### Plugin Distribution
 
-- **92 marketplace plugins** (91 local + 1 external via git-subdir) optimized for specific use cases
+- **93 marketplace plugins** (91 local + 2 external via git-subdir) optimized for specific use cases
 - **26 clear categories** with 1-10 plugins each for easy discovery
 - Organized by domain:
   - **Development**: 6 plugins (debugging, backend, frontend, UI, multi-platform, essentials)
@@ -81,7 +81,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 ```
 claude-agents/
 ├── .claude-plugin/
-│   └── marketplace.json          # Marketplace catalog (92 plugins)
+│   └── marketplace.json          # Marketplace catalog (93 plugins)
 ├── plugins/                       # Isolated plugin directories
 │   ├── python-development/
 │   │   ├── agents/               # Python language agents
@@ -393,5 +393,5 @@ Feature Development Workflow:
 
 - [Agent Skills](./agent-skills.md) - Modular knowledge packages
 - [Agent Reference](./agents.md) - Complete agent catalog
-- [Plugin Reference](./plugins.md) - All 92 marketplace plugins
+- [Plugin Reference](./plugins.md) - All 93 marketplace plugins
 - [Usage Guide](./usage.md) - Commands and workflows

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,7 +40,7 @@ This marketplace follows industry best practices with a focus on granularity, co
 - **26 clear categories** with 1-10 plugins each for easy discovery
 - Organized by domain:
   - **Development**: 6 plugins (debugging, backend, frontend, UI, multi-platform, essentials)
-  - **Security**: 6 plugins (scanning, compliance, API, frontend/mobile, reverse engineering, hook policy)
+  - **Security**: 7 plugins (scanning, compliance, API, frontend/mobile, reverse engineering, hook policy, HOL Guard)
   - **Operations**: 4 plugins (incident, diagnostics, distributed, observability)
   - **Languages**: 10 plugins (Python, JS/TS, systems, JVM, scripting, functional, embedded, and more)
   - **Infrastructure**: 5 plugins (deployment, validation, K8s, cloud, CI/CD)

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -146,8 +146,14 @@ For generated harnesses, use Pensyve's upstream harness-native integration:
 The Claude Code marketplace includes HOL Guard as an external `git-subdir` plugin from
 `https://github.com/hashgraph-online/hol-guard-plugin.git`, path `distributions/wshobson-agents`.
 The reviewed payload exposes the portable `hol-guard` and `plugin-scanner` skills and
-keeps decisioning local by default. Guard Cloud is neither required nor promoted.
-Runtime installation is version-pinned in that external payload and requires user approval.
+keeps decisioning local by default. Guard Cloud is neither required nor promoted. This
+marketplace entry is a Claude Code discovery surface only; it does not add HOL Guard to the
+generated Codex, Cursor, OpenCode, Antigravity, or Copilot registries.
+
+The reviewed payload is pinned to commit `43b2dda59e9f07057c52e69fd7426188faae1488` and installs the exact local CLI versions
+`hol-guard==2.2.119` and `plugin-scanner==2.2.119`, with user approval required before
+installation. For a reviewed payload update, advance the marketplace `sha` and matching
+marketplace/external manifest versions together.
 
 When the user explicitly requests protection, the local HOL Guard runtime can modify
 supported harness hook/settings configuration. Generated harness outputs in this repository

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -141,6 +141,18 @@ For generated harnesses, use Pensyve's upstream harness-native integration:
 | OpenCode | `integrations/opencode-plugin` |
 | Copilot | `.copilot/` (repo-level) or `~/.copilot/` (global install via `make install-copilot`) |
 
+## External HOL Guard integration
+
+The Claude Code marketplace includes HOL Guard as an external `git-subdir` plugin from
+`https://github.com/hashgraph-online/hol-guard-plugin.git`, path `distributions/wshobson-agents`.
+The reviewed payload exposes the portable `hol-guard` and `plugin-scanner` skills and
+keeps decisioning local by default. Guard Cloud is neither required nor promoted.
+Runtime installation is version-pinned in that external payload and requires user approval.
+
+When the user explicitly requests protection, the local HOL Guard runtime can modify
+supported harness hook/settings configuration. Generated harness outputs in this repository
+do not vendor or rewrite the external HOL Guard payload.
+
 ## Global install
 
 OpenCode, Copilot, and Antigravity support installing generated artifacts globally for

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,6 +1,6 @@
 # Complete Plugin Reference
 
-Browse all **92 marketplace plugins** organized by category: 91 local plugins plus 1 externally hosted `git-subdir` entry (`pensyve`).
+Browse all **93 marketplace plugins** organized by category: 91 local plugins plus 2 externally hosted `git-subdir` entries (`pensyve` and `hol-guard`).
 
 ## Quick Start - Essential Plugins
 
@@ -223,7 +223,7 @@ Next.js, React + Vite, and Node.js project setup with pnpm and TypeScript best p
 | **cloud-infrastructure**  | AWS/Azure/GCP cloud architecture            | `/plugin install cloud-infrastructure`  |
 | **cicd-automation**       | CI/CD pipeline configuration                | `/plugin install cicd-automation`       |
 
-### 🔒 Security (6 plugins)
+### 🔒 Security (7 plugins)
 
 | Plugin                       | Description                                                     | Install                                    |
 | ---------------------------- | --------------------------------------------------------------- | ------------------------------------------ |
@@ -233,6 +233,7 @@ Next.js, React + Vite, and Node.js project setup with pnpm and TypeScript best p
 | **frontend-mobile-security** | XSS/CSRF prevention and mobile security                         | `/plugin install frontend-mobile-security` |
 | **reverse-engineering**      | Binary analysis, malware triage, firmware security (authorized) | `/plugin install reverse-engineering`      |
 | **block-no-verify**          | PreToolUse hook blocking `--no-verify` and hook-bypass flags    | `/plugin install block-no-verify`          |
+| **hol-guard**                | Local pre-execution policy and pre-install agent supply-chain scanning | `/plugin install hol-guard`                 |
 
 ### 🛡️ Governance (3 plugins)
 
@@ -363,7 +364,7 @@ plugins/python-development/
 /plugin marketplace add wshobson/agents
 ```
 
-This makes all 92 marketplace plugins available for installation, but **does not load any agents or tools** into your context.
+This makes all 93 marketplace plugins available for installation, but **does not load any agents or tools** into your context.
 
 ### Step 2: Install Specific Plugins
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -409,5 +409,5 @@ See [Agent Skills](./agent-skills.md) for details on the 181 specialized skills.
 
 - [Agent Skills](./agent-skills.md) - Specialized knowledge packages
 - [Agent Reference](./agents.md) - Complete agent catalog
-- [Plugin Reference](./plugins.md) - All 92 marketplace plugins
+- [Plugin Reference](./plugins.md) - All 93 marketplace plugins
 - [Architecture](./architecture.md) - Design principles


### PR DESCRIPTION
## Summary

- Add `hol-guard` as an external `git-subdir` marketplace plugin from `hashgraph-online/hol-guard-plugin/distributions/wshobson-agents`, resolving #654.
- Keep the approved local-only default explicit: Guard Cloud is neither required nor promoted, installation is gated on user approval, and the runtime hook/settings surface is disclosed.
- Update marketplace/catalog counts from 92 to 93 (91 local + 2 external) and document the external HOL Guard integration.

## Scope

- [ ] Plugin authoring (new or modified `plugins/<name>/...`)
- [ ] Adapter framework (`tools/adapters/`)
- [ ] Quality tooling (validators, gardener, plugin-eval)
- [x] Per-harness setup or docs (`docs/harnesses.md`)
- [x] AGENTS.md / ARCHITECTURE.md / docs/
- [ ] CI / build / release
- [x] Other: external marketplace `git-subdir` catalog entry

## Affected harnesses

- [x] Claude Code
- [ ] OpenAI Codex CLI
- [ ] Cursor
- [ ] OpenCode
- [ ] Antigravity CLI
- [ ] Pure tooling / framework (no harness behavior change)

The external source is a Claude marketplace `git-subdir` entry. `make generate-all` derives native registries from local `plugins/`, so no generated registry delta is expected; CI's generation/drift gates can verify that.

**Scope clarification:** this PR intentionally narrows #654's cross-harness discovery objective to Claude Code. It does not claim marketplace discovery or generated-registry inclusion for Codex, Cursor, OpenCode, Antigravity, Gemini CLI, or Copilot. The portable external skills may be usable elsewhere, but those harnesses are outside this contribution's accepted artifact.

## External/vendor disclosure

I maintain HOL Guard and `hashgraph-online/hol-guard-plugin`.

Submission-time payload reviewed by this PR:

- source: `https://github.com/hashgraph-online/hol-guard-plugin.git`
- path: `distributions/wshobson-agents`
- reviewed source commit: `43b2dda59e9f07057c52e69fd7426188faae1488`
- payload: `.claude-plugin/plugin.json`, `skills/hol-guard/SKILL.md`, `skills/plugin-scanner/SKILL.md`, `README.md`, `LICENSE`
- no `hooks/`, `.mcp.json`, install scripts, package lifecycle hooks, daemon, telemetry setup, OAuth flow, or hosted-service endpoint in the marketplace payload
- Guard Cloud is never required or promoted on the default path, and the skills do not route workspace/package/URL/prompt/finding data to a hosted HOL service
- the external runtime can modify supported harness hook/settings configuration only when the user explicitly requests protection; that behavior is disclosed in the payload README
- current exact local CLI pins at submission are `hol-guard==2.2.119` and `plugin-scanner==2.2.119`. The marketplace now pins the reviewed external source commit; for a reviewed update, advance the marketplace `sha` and the matching marketplace/external manifest versions together.

AI-assisted tooling was used to prepare the mechanical catalog/count changes and this PR description; the external ownership and security disclosures are recorded in #654.

## Test plan

Local execution of the repository's full CI suite was not available in this environment. The diff was statically checked before commit for:

- valid marketplace JSON and `git-subdir` schema
- 93 total entries = 91 local + 2 external
- exact HOL Guard source/path/version/license/category metadata
- canonical README/AGENTS count updates and documented external-source constraints

CI should run the repository's standard `make validate STRICT=1`, `make garden`, tests, generation/drift, smoke tests, and code-quality gates.

## Cross-harness portability notes

No local plugin source is vendored in this PR. The external payload carries portable Agent Skills; generated harness artifacts in this repository continue to be derived only from local `plugins/`. This contribution's official discovery surface is Claude Code only.

## Related issue(s)

Closes #654