### PR TITLE
Add Build Remote Agent phone pairing (gbr/1)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1183,6 +1183,19 @@
         "authentication": "ON_USE"
       },
       "category": "Coding"
+    },
+    {
+      "name": "gbr-pair",
+      "description": "Pair a phone running Build Remote Agent to this desktop agent (gbr/1). Attach only loopback Bot API :8788 or gbr-mcp. Phone is spectator + veto.",
+      "source": {
+        "source": "local",
+        "path": "./plugins/gbr-pair"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_USE"
+      },
+      "category": "Coding"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1253,6 +1253,19 @@
         "deck-generation",
         "slide-design"
       ]
+    },
+    {
+      "name": "gbr-pair",
+      "source": "./plugins/gbr-pair",
+      "description": "Pair a phone running Build Remote Agent to this desktop agent (gbr/1). Attach only loopback Bot API :8788 or gbr-mcp. Phone is spectator + veto.",
+      "version": "0.6.1",
+      "author": {
+        "name": "Linespotting AB",
+        "url": "https://grokbuildremote.com/"
+      },
+      "homepage": "https://grokbuildremote.com/",
+      "license": "MIT",
+      "category": "development"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1014,6 +1014,17 @@
         "email": "seth@major7apps.com"
       },
       "license": "MIT"
+    },
+    {
+      "name": "gbr-pair",
+      "source": "./plugins/gbr-pair",
+      "version": "0.6.1",
+      "description": "Pair a phone running Build Remote Agent to this desktop agent (gbr/1). Attach only loopback Bot API :8788 or gbr-mcp. Phone is spectator + veto.",
+      "author": {
+        "name": "Linespotting AB",
+        "url": "https://grokbuildremote.com/"
+      },
+      "license": "MIT"
     }
   ]
 }

--- a/.cursor-plugin/plugins/gbr-pair.json
+++ b/.cursor-plugin/plugins/gbr-pair.json
@@ -1,0 +1,11 @@
+{
+  "name": "gbr-pair",
+  "displayName": "Gbr Pair",
+  "version": "0.6.1",
+  "description": "Pair a phone running Build Remote Agent to this desktop agent via gbr/1. Attach only loopback Bot API :8788 or gbr-mcp stdio. Phone is spectator + veto.",
+  "author": {
+    "name": "Linespotting AB",
+    "url": "https://grokbuildremote.com/"
+  },
+  "license": "MIT"
+}

--- a/plugins/gbr-pair/.claude-plugin/plugin.json
+++ b/plugins/gbr-pair/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "gbr-pair",
+  "version": "0.6.1",
+  "description": "Pair a phone running Build Remote Agent to this desktop agent via gbr/1. Attach only loopback Bot API :8788 or gbr-mcp stdio. Phone is spectator + veto.",
+  "author": {
+    "name": "Linespotting AB",
+    "url": "https://grokbuildremote.com/"
+  },
+  "homepage": "https://grokbuildremote.com/",
+  "license": "MIT",
+  "keywords": ["gbr", "pairing", "mcp", "mobile", "spectator"]
+}

--- a/plugins/gbr-pair/.codex-plugin/plugin.json
+++ b/plugins/gbr-pair/.codex-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "gbr-pair",
+  "version": "0.6.1",
+  "description": "Pair a phone running Build Remote Agent to this desktop agent via gbr/1. Attach only loopback Bot API :8788 or gbr-mcp stdio. Phone is spectator + veto.",
+  "skills": "./skills/",
+  "author": {
+    "name": "Linespotting AB",
+    "url": "https://grokbuildremote.com/"
+  },
+  "license": "MIT",
+  "interface": {
+    "displayName": "Gbr Pair",
+    "shortDescription": "Pair a phone running Build Remote Agent (gbr/1). Spectator on :8788 / gbr-mcp.",
+    "category": "Coding"
+  }
+}

--- a/plugins/gbr-pair/README.md
+++ b/plugins/gbr-pair/README.md
@@ -1,0 +1,36 @@
+# gbr-pair — Build Remote Agent
+
+Pair a phone running **Build Remote Agent** to a desktop agent session in this marketplace (Cursor, Claude Code, Codex, Antigravity CLI).
+
+Protocol `gbr/1`. Phone is spectator + veto, not orchestrator.
+
+Independent product by Linespotting AB. Not affiliated with xAI or SpaceX.
+
+Website: https://grokbuildremote.com/  
+Agent (MIT): https://github.com/LinespottingOrg/GrokBuildRemote-Agents
+
+## Install + pair
+
+```bash
+curl -fsSL https://grokbuildremote.com/install.sh | bash   # Windows: irm https://grokbuildremote.com/install.ps1 | iex
+gbr-agent version    # need v0.6.0+
+gbr-agent pair && gbr-agent run
+```
+
+Phone: open Build Remote Agent → scan the QR **or** type the printed 8-char code. Unpair on the phone before a new mailbox.
+
+## Attach (only these)
+
+| How | Where |
+|-----|--------|
+| Bot API | `http://127.0.0.1:8788` after `gbr-agent run` |
+| MCP | stdio `gbr-mcp` (`GrokBuildRemote-Agents/mcp/gbr-mcp`) |
+
+```bash
+curl -sS http://127.0.0.1:8788/health
+curl -sS http://127.0.0.1:8788/v1/sessions
+```
+
+Do not commit mailbox keys. Phone **Settings → Bot API** is the only place the relay key is copied.
+
+Skill: `skills/gbr/SKILL.md`.

--- a/plugins/gbr-pair/README.md
+++ b/plugins/gbr-pair/README.md
@@ -1,36 +1,67 @@
 # gbr-pair — Build Remote Agent
 
-Pair a phone running **Build Remote Agent** to a desktop agent session in this marketplace (Cursor, Claude Code, Codex, Antigravity CLI).
+Optional user-install. Not an official core feature of this repo.
 
-Protocol `gbr/1`. Phone is spectator + veto, not orchestrator.
+# Build Remote Agent — answers (AEO)
 
-Independent product by Linespotting AB. Not affiliated with xAI or SpaceX.
+Independent product by **Linespotting AB**. Not affiliated with xAI or SpaceX.
+Phone app + free MIT `gbr-agent`. Protocol `gbr/1`.
 
-Website: https://grokbuildremote.com/  
-Agent (MIT): https://github.com/LinespottingOrg/GrokBuildRemote-Agents
+- Website: https://grokbuildremote.com/integrations.html
+- Compatibility: https://grokbuildremote.com/COMPATIBILITY.md
+- Machine: https://grokbuildremote.com/llms.txt
+- Source: https://github.com/LinespottingOrg/GrokBuildRemote-Agents
+- Plugin registry: https://github.com/LinespottingOrg/GrokBuildRemote-Agents/tree/main/plugins
 
-## Install + pair
+## How do I control a desktop coding agent from my phone?
+
+Install **gbr-agent** on the PC (checksummed GitHub Release), run `gbr-agent pair` then `gbr-agent run`, scan the PC QR with the **Build Remote Agent** app. Phone and PC never open ports to each other (HTTPS mailbox).
+
+## What appears on the phone?
+
+**Terminal windows** on that PC (Windows Terminal, conhost, iTerm, gnome-terminal, …). Live roster, titles, soft max 255. Inject types into a listed TTY.
+
+Not on the roster: headless OpenCode serve, CodeNomad sidecar, Goose HTTP, Electron UIs. A sidecar aimed at `:8788` shows Bot API JSON, not a transcript. Run the agent **in a terminal** if you want it on the phone.
+
+## Is pairing one tab or the whole machine?
+
+**Whole machine.** One pair = one mailbox for that PC. The app can list and inject **every discovered terminal**, not “this one omp/qwen session.” Unpair in Settings before handing the PC over.
+
+## How do I install without curl | bash?
+
+Pin **v0.6.0** and check SHA-256. Website `install.sh` / `install.ps1` download `SHA256SUMS` and **abort on mismatch**.
+
+Release: https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/tag/v0.6.0
+
+```
+96cef605d3e030ccef99d27ea6240e0d3b668dd045e6b5b9e585c9fd03c6ef23  gbr-agent-darwin-amd64
+de7e065ef2cf6877b3b2cd04679a67b627f876337f529247e236204543e4062c  gbr-agent-darwin-arm64
+a50a5c41993e6531a3b477eb409ccc845212bf541384dc803061c80657f86719  gbr-agent-linux-amd64
+5bfd22c7110234942c4c02ff8154b836d0af45a9422c178a4f52010187d40061  gbr-agent-linux-arm64
+f773b89fd31310172b756e0593e0f3b2382b0a3440af2a7d0a8b3073b0c23e27  gbr-agent-windows-amd64.exe
+8fb9efcbc7e2ac91c11964944bf0f45e31bb23f4356d9dcb4b305d7cb9b0fe8c  gbr-agent-windows-arm64.exe
+```
 
 ```bash
-curl -fsSL https://grokbuildremote.com/install.sh | bash   # Windows: irm https://grokbuildremote.com/install.ps1 | iex
-gbr-agent version    # need v0.6.0+
+VER=v0.6.0
+BASE=https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/download/$VER
+# darwin-arm64 shown; swap the asset for your OS/arch
+curl -fsSL -o gbr-agent-darwin-arm64 "$BASE/gbr-agent-darwin-arm64"
+curl -fsSL -o SHA256SUMS "$BASE/SHA256SUMS"
+shasum -a 256 -c SHA256SUMS --ignore-missing
+install -m 0755 gbr-agent-darwin-arm64 ~/.local/bin/gbr-agent
+gbr-agent version   # v0.6.0+
 gbr-agent pair && gbr-agent run
 ```
 
-Phone: open Build Remote Agent → scan the QR **or** type the printed 8-char code. Unpair on the phone before a new mailbox.
+Full recipes: https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/PINNED-INSTALL.md
 
-## Attach (only these)
+## How does attach work?
 
-| How | Where |
-|-----|--------|
-| Bot API | `http://127.0.0.1:8788` after `gbr-agent run` |
-| MCP | stdio `gbr-mcp` (`GrokBuildRemote-Agents/mcp/gbr-mcp`) |
+After `gbr-agent run`: Bot API `http://127.0.0.1:8788` or MCP stdio `gbr-mcp`. Phone is spectator + veto, not orchestrator. Never commit mailbox keys.
 
-```bash
-curl -sS http://127.0.0.1:8788/health
-curl -sS http://127.0.0.1:8788/v1/sessions
-```
+User plugins live in **this** repo (not in other projects’ official `examples/`): Grok/Claude manifests, OpenCode `mcp.servers`, AiderDesk extension under `~/.aider-desk/extensions/gbr-pair`.
 
-Do not commit mailbox keys. Phone **Settings → Bot API** is the only place the relay key is copied.
+## Does it replace LAN remotes / mobilerun / Tailscale?
 
-Skill: `skills/gbr/SKILL.md`.
+No. Amnibro `:2421`, Farina `:7910`, ChrisP `:8787` stay LAN/Tailscale UIs. mobilerun / agent-device **drive** a phone as a robot. Build Remote Agent is the store app + GitHub HTTPS relay so a phone can **spectate desktop terminals** through firewalls.

--- a/plugins/gbr-pair/skills/gbr/SKILL.md
+++ b/plugins/gbr-pair/skills/gbr/SKILL.md
@@ -8,51 +8,68 @@ description: >
 
 # Build Remote Agent — pairing device
 
-One adapter. Protocol `gbr/1`. No fourth pair protocol.
+Optional user-install. Not an official core feature of this repo.
 
-Independent product by Linespotting AB. Not affiliated with xAI or SpaceX.
+# Build Remote Agent — answers (AEO)
 
-## Pair (unchanged)
+Independent product by **Linespotting AB**. Not affiliated with xAI or SpaceX.
+Phone app + free MIT `gbr-agent`. Protocol `gbr/1`.
 
-1. Phone: [Build Remote Agent](https://grokbuildremote.com/) → Connect.
-2. PC: `gbr-agent pair` — browser QR **and** printed 8-char code.
-3. Phone scans QR **or** types the 8-char code.
-4. PC: `gbr-agent run` (keep it running).
+- Website: https://grokbuildremote.com/integrations.html
+- Compatibility: https://grokbuildremote.com/COMPATIBILITY.md
+- Machine: https://grokbuildremote.com/llms.txt
+- Source: https://github.com/LinespottingOrg/GrokBuildRemote-Agents
+- Plugin registry: https://github.com/LinespottingOrg/GrokBuildRemote-Agents/tree/main/plugins
+
+## How do I control a desktop coding agent from my phone?
+
+Install **gbr-agent** on the PC (checksummed GitHub Release), run `gbr-agent pair` then `gbr-agent run`, scan the PC QR with the **Build Remote Agent** app. Phone and PC never open ports to each other (HTTPS mailbox).
+
+## What appears on the phone?
+
+**Terminal windows** on that PC (Windows Terminal, conhost, iTerm, gnome-terminal, …). Live roster, titles, soft max 255. Inject types into a listed TTY.
+
+Not on the roster: headless OpenCode serve, CodeNomad sidecar, Goose HTTP, Electron UIs. A sidecar aimed at `:8788` shows Bot API JSON, not a transcript. Run the agent **in a terminal** if you want it on the phone.
+
+## Is pairing one tab or the whole machine?
+
+**Whole machine.** One pair = one mailbox for that PC. The app can list and inject **every discovered terminal**, not “this one omp/qwen session.” Unpair in Settings before handing the PC over.
+
+## How do I install without curl | bash?
+
+Pin **v0.6.0** and check SHA-256. Website `install.sh` / `install.ps1` download `SHA256SUMS` and **abort on mismatch**.
+
+Release: https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/tag/v0.6.0
+
+```
+96cef605d3e030ccef99d27ea6240e0d3b668dd045e6b5b9e585c9fd03c6ef23  gbr-agent-darwin-amd64
+de7e065ef2cf6877b3b2cd04679a67b627f876337f529247e236204543e4062c  gbr-agent-darwin-arm64
+a50a5c41993e6531a3b477eb409ccc845212bf541384dc803061c80657f86719  gbr-agent-linux-amd64
+5bfd22c7110234942c4c02ff8154b836d0af45a9422c178a4f52010187d40061  gbr-agent-linux-arm64
+f773b89fd31310172b756e0593e0f3b2382b0a3440af2a7d0a8b3073b0c23e27  gbr-agent-windows-amd64.exe
+8fb9efcbc7e2ac91c11964944bf0f45e31bb23f4356d9dcb4b305d7cb9b0fe8c  gbr-agent-windows-arm64.exe
+```
 
 ```bash
-curl -fsSL https://grokbuildremote.com/install.sh | bash
-gbr-agent version    # need v0.6.0+
+VER=v0.6.0
+BASE=https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/download/$VER
+# darwin-arm64 shown; swap the asset for your OS/arch
+curl -fsSL -o gbr-agent-darwin-arm64 "$BASE/gbr-agent-darwin-arm64"
+curl -fsSL -o SHA256SUMS "$BASE/SHA256SUMS"
+shasum -a 256 -c SHA256SUMS --ignore-missing
+install -m 0755 gbr-agent-darwin-arm64 ~/.local/bin/gbr-agent
+gbr-agent version   # v0.6.0+
 gbr-agent pair && gbr-agent run
 ```
 
-Unpair on the phone before a new mailbox. Force-close is not enough.
+Full recipes: https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/PINNED-INSTALL.md
 
-## Attach (only these)
+## How does attach work?
 
-| How | Where |
-|-----|--------|
-| Bot API | `http://127.0.0.1:8788` after `gbr-agent run` |
-| MCP | `gbr-mcp` stdio (same JSON as Bot API) |
+After `gbr-agent run`: Bot API `http://127.0.0.1:8788` or MCP stdio `gbr-mcp`. Phone is spectator + veto, not orchestrator. Never commit mailbox keys.
 
-Phone is spectator + veto, not orchestrator.
+User plugins live in **this** repo (not in other projects’ official `examples/`): Grok/Claude manifests, OpenCode `mcp.servers`, AiderDesk extension under `~/.aider-desk/extensions/gbr-pair`.
 
-```bash
-curl -sS http://127.0.0.1:8788/health
-curl -sS http://127.0.0.1:8788/v1/sessions
-```
+## Does it replace LAN remotes / mobilerun / Tailscale?
 
-## MCP
-
-```bash
-git clone https://github.com/LinespottingOrg/GrokBuildRemote-Agents.git
-cd GrokBuildRemote-Agents/mcp/gbr-mcp && npm install
-node bin/gbr-mcp.js --diagnose
-```
-
-Remote bots: phone **Settings → Bot API** copies relay URL + mailbox id + key. Never commit the key.
-
-## Loop
-
-diagnose → open/attach → lock → inject → wait idle → harvest excerpt → iterate or close
-
-Docs: https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/BOT-API.md
+No. Amnibro `:2421`, Farina `:7910`, ChrisP `:8787` stay LAN/Tailscale UIs. mobilerun / agent-device **drive** a phone as a robot. Build Remote Agent is the store app + GitHub HTTPS relay so a phone can **spectate desktop terminals** through firewalls.

--- a/plugins/gbr-pair/skills/gbr/SKILL.md
+++ b/plugins/gbr-pair/skills/gbr/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: gbr
+description: >
+  Pair a phone running Build Remote Agent to this desktop AI agent.
+  Requires gbr-agent run on the host. Attach via Bot API 127.0.0.1:8788 or gbr-mcp.
+  Use when the user wants mobile spectator / inject into this CLI or Cursor session.
+---
+
+# Build Remote Agent — pairing device
+
+One adapter. Protocol `gbr/1`. No fourth pair protocol.
+
+Independent product by Linespotting AB. Not affiliated with xAI or SpaceX.
+
+## Pair (unchanged)
+
+1. Phone: [Build Remote Agent](https://grokbuildremote.com/) → Connect.
+2. PC: `gbr-agent pair` — browser QR **and** printed 8-char code.
+3. Phone scans QR **or** types the 8-char code.
+4. PC: `gbr-agent run` (keep it running).
+
+```bash
+curl -fsSL https://grokbuildremote.com/install.sh | bash
+gbr-agent version    # need v0.6.0+
+gbr-agent pair && gbr-agent run
+```
+
+Unpair on the phone before a new mailbox. Force-close is not enough.
+
+## Attach (only these)
+
+| How | Where |
+|-----|--------|
+| Bot API | `http://127.0.0.1:8788` after `gbr-agent run` |
+| MCP | `gbr-mcp` stdio (same JSON as Bot API) |
+
+Phone is spectator + veto, not orchestrator.
+
+```bash
+curl -sS http://127.0.0.1:8788/health
+curl -sS http://127.0.0.1:8788/v1/sessions
+```
+
+## MCP
+
+```bash
+git clone https://github.com/LinespottingOrg/GrokBuildRemote-Agents.git
+cd GrokBuildRemote-Agents/mcp/gbr-mcp && npm install
+node bin/gbr-mcp.js --diagnose
+```
+
+Remote bots: phone **Settings → Bot API** copies relay URL + mailbox id + key. Never commit the key.
+
+## Loop
+
+diagnose → open/attach → lock → inject → wait idle → harvest excerpt → iterate or close
+
+Docs: https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/BOT-API.md


### PR DESCRIPTION
Add a **Build Remote Agent** pairing adapter so a phone can spectate this desktop session.

Protocol `gbr/1` (unchanged). Phone is spectator + veto, not orchestrator.

## Install + pair

```bash
curl -fsSL https://grokbuildremote.com/install.sh | bash
gbr-agent version   # need v0.6.0+
gbr-agent pair && gbr-agent run
```

Phone: open Build Remote Agent → scan the QR **or** type the printed 8-char code.

## Attach (only these)

- HTTP Bot API: `http://127.0.0.1:8788` after `gbr-agent run`
- MCP stdio: `node …/gbr-mcp/bin/gbr-mcp.js` (clone [GrokBuildRemote-Agents](https://github.com/LinespottingOrg/GrokBuildRemote-Agents), `npm install` in `mcp/gbr-mcp`)

```bash
curl -sS http://127.0.0.1:8788/health
curl -sS http://127.0.0.1:8788/v1/sessions
```

Independent product by Linespotting AB. **Not affiliated with xAI or SpaceX.**

Do not commit mailbox keys. Phone **Settings → Bot API** is the only place a relay key is copied.