### PR TITLE
docs: use HOL Guard canonical product URL

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1130,7 +1130,7 @@
         "name": "Hashgraph Online",
         "url": "https://github.com/hashgraph-online"
       },
-      "homepage": "https://github.com/hashgraph-online/hol-guard",
+      "homepage": "https://hol.org/guard",
       "license": "Apache-2.0",
       "category": "security",
       "keywords": [

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ integrations for Codex CLI, Cursor, OpenCode, and Copilot (not yet Antigravity C
 
 ## External Security Integration
 
-[HOL Guard](https://github.com/hashgraph-online/hol-guard) is included as an external
+[HOL Guard](https://hol.org/guard) is included as an external
 `git-subdir` entry for Claude Code from the reviewed `distributions/wshobson-agents`
 payload in [hashgraph-online/hol-guard-plugin](https://github.com/hashgraph-online/hol-guard-plugin).
 The payload exposes local `hol-guard` and `plugin-scanner` skills. Guard Cloud is neither


### PR DESCRIPTION
## Summary

- Point the merged `hol-guard` marketplace entry's `homepage` at the canonical product page, `https://hol.org/guard`.
- Point the rendered README's HOL Guard product link at the same canonical page.
- Keep the external git-subdir source, reviewed SHA, version pins, and behavior unchanged.

This is a follow-up metadata/documentation correction to #678 and the accepted scope in #654.

## Validation

- `.claude-plugin/marketplace.json` parses as valid JSON after the change.
- No plugin payload, source URL, pin, install behavior, or generated harness registry is changed.

## Disclosure

I am President of HOL / Hashgraph Online and am materially affiliated with HOL Guard.
