### PR TITLE
ci: add MLOps lab pipeline (W&B + HF + reusable mlops workflow)

### DIFF
--- a/.github/workflows/eval-report.yml
+++ b/.github/workflows/eval-report.yml
@@ -46,10 +46,12 @@ jobs:
       DEPTH: ${{ inputs.depth || 'quick' }}
       ONLY_CHANGED: ${{ inputs.only_changed || '' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081  # v5
         with:
           enable-cache: true
 
@@ -111,7 +113,7 @@ jobs:
 
       - name: Upload reports artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: eval-reports-${{ env.DEPTH }}-${{ github.run_id }}
           path: eval-reports/

--- a/.github/workflows/eval-report.yml
+++ b/.github/workflows/eval-report.yml
@@ -17,9 +17,22 @@ on:
         required: false
         default: ''
         type: string
+      log_wandb:
+        description: 'Push eval metrics to Weights & Biases (m7/major7-lab)'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
   schedule:
     # Weekly full static sweep, Mondays at 06:00 UTC
     - cron: '0 6 * * 1'
+
+# Don't let the weekly schedule and a manual dispatch run at once on the same ref.
+concurrency:
+  group: eval-report-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -54,6 +67,38 @@ jobs:
             args+=( --only-changed "$ONLY_CHANGED" )
           fi
           uv run python scripts/eval_all.py "${args[@]}"
+
+      - name: Log eval metrics to Weights & Biases
+        if: ${{ inputs.log_wandb == 'true' }}
+        env:
+          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+          WANDB_ENTITY: m7
+          WANDB_PROJECT: major7-lab
+        run: |
+          uv run --with wandb python - <<'PY'
+          import json, os, wandb, pathlib
+          p = pathlib.Path("eval-reports/summary.json")
+          rows = json.loads(p.read_text()) if p.exists() else []
+          run = wandb.init(
+              project="major7-lab",
+              entity="m7",
+              name=f"plugin-eval-{os.environ.get('DEPTH','quick')}",
+              tags=["plugin-eval", os.environ.get("DEPTH","quick"), "github-actions"],
+              config={"depth": os.environ.get("DEPTH","quick"),
+                      "only_changed": os.environ.get("ONLY_CHANGED",""),
+                      "run_id": os.environ.get("GITHUB_RUN_ID","")},
+          )
+          table = wandb.Table(columns=["plugin", "score", "ci_lower", "ci_upper", "confidence", "errored"])
+          for r in rows:
+            table.add_data(r.get("name"), r.get("score"), r.get("ci_lower"), r.get("ci_upper"), r.get("confidence"), r.get("errored"))
+          scored = [r["score"] for r in rows if not r.get("errored") and r.get("score") is not None]
+          run.log({"eval/mean_score": sum(scored)/len(scored) if scored else float("nan"),
+                   "eval/plugins_evaluated": len(rows),
+                   "eval/plugins_errored": sum(1 for r in rows if r.get("errored")),
+                   "eval/table": table})
+          run.finish()
+          print(f"logged {len(rows)} plugins to wandb")
+          PY
 
       - name: Post report to job summary
         if: always()

--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -106,7 +106,7 @@ jobs:
         run: uv run pytest -q
 
   model-release:
-    name: Release model to HF (${{ env.HF_NAMESPACE }})
+    name: Release model to HF (major7)
     if: ${{ inputs.kind == 'release' || startsWith(github.ref, 'refs/tags/model/') }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -1,0 +1,166 @@
+name: MLOps (lab baseline)
+
+# Reusable MLOps baseline for the Major 7 lab.
+#
+# Two modes:
+#   - kind=ci  (manual dispatch): lint + test gate before pushing a model.
+#   - kind=release (manual dispatch or on model/* tag): validate a model dir,
+#     push it to the Hugging Face `major7` org, and publish a model card
+#     summary.
+#
+# This workflow is deliberately CPU-side only. GPU training/finetuning runs on
+# the DGX Spark and logs straight to Weights & Biases (entity m7, project
+# major7-lab). See docs/mlops.md for the full lab pipeline.
+
+on:
+  workflow_dispatch:
+    inputs:
+      kind:
+        description: 'ci (lint + test) or release (push model to HF)'
+        required: true
+        default: 'ci'
+        type: choice
+        options: [ci, release]
+      hf_target:
+        description: 'HF repo to push for kind=release, e.g. major7/my-model (blank = model/<tag>)'
+        required: false
+        default: ''
+        type: string
+      model_path:
+        description: 'Path to the model directory (or file) to release'
+        required: false
+        default: ''
+        type: string
+  push:
+    tags:
+      - 'model/*'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mlops-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  HF_NAMESPACE: major7
+
+jobs:
+  lint:
+    name: Lint (ruff + ty)
+    if: ${{ inputs.kind == 'ci' || inputs.kind == '' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: plugins/plugin-eval
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081  # v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Sync plugin-eval dev dependencies
+        run: uv sync --all-extras
+
+      - name: ruff check
+        run: uv run ruff check ../../tools/ src/plugin_eval/
+
+      - name: ruff format --check
+        run: uv run ruff format --check ../../tools/ src/plugin_eval/
+
+      - name: ty type-check
+        run: uv run ty check src/plugin_eval/
+
+  test:
+    name: Test (pytest)
+    if: ${{ inputs.kind == 'ci' || inputs.kind == '' }}
+    needs: lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: plugins/plugin-eval
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081  # v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Sync plugin-eval dependencies
+        run: uv sync --all-extras
+
+      - name: Run pytest
+        run: uv run pytest -q
+
+  model-release:
+    name: Release model to HF (${{ env.HF_NAMESPACE }})
+    if: ${{ inputs.kind == 'release' || startsWith(github.ref, 'refs/tags/model/') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+
+      - name: Resolve target and source
+        id: resolve
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          if [ -n "${{ inputs.hf_target }}" ]; then target="${{ inputs.hf_target }}"; else target="${tag#model/}"; fi
+          case "$target" in
+            "$HF_NAMESPACE"/*) full="$target" ;;
+            *) full="$HF_NAMESPACE/$target" ;;
+          esac
+          src="${{ inputs.model_path }}"
+          if [ -z "$src" ]; then src="$(dirname "${tag#model/}")"; fi
+          echo "target=$full" >> "$GITHUB_OUTPUT"
+          echo "src=$src" >> "$GITHUB_OUTPUT"
+          echo ">> HF repo: $full (source path: ./$src)"
+          if [ ! -e "$src" ]; then echo "::error::model path '$src' not found in repo"; exit 1; fi
+
+      - name: Push to Hugging Face
+        run: |
+          uv run --with huggingface_hub --with hf_transfer python - <<'PY'
+          import os
+          from huggingface_hub import HfApi
+          api = HfApi()
+          target = os.environ["TARGET"]
+          src = os.environ["SRC"]
+          # hf_transfer accelerates large uploads; Hugging Face's server negotiates
+          # the protocol, so this is a safe no-op if it is unavailable.
+          os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")
+          if os.path.isfile(src):
+              api.upload_file(path_or_filename=src, repo_id=target, repo_type="model",
+                              commit_message=f"release: {target}")
+          else:
+              api.upload_folder(folder_path=src, repo_id=target, repo_type="model",
+                                commit_message=f"release: {target}")
+          print(f"OK: pushed {src} -> {target}")
+          PY
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          TARGET: "${{ steps.resolve.outputs.target }}"
+          SRC: "${{ steps.resolve.outputs.src }}"
+
+      - name: Model card summary
+        if: always()
+        run: |
+          {
+            echo "## Model release"
+            echo ""
+            echo "- **HF repo:** \`${{ steps.resolve.outputs.target }}\`"
+            echo "- **Source path:** \`${{ steps.resolve.outputs.src }}\`"
+            echo "- **Trigger:** ${{ github.ref }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -8,6 +8,12 @@ name: MLOps (lab baseline)
 #     push it to the Hugging Face `major7` org, and publish a model card
 #     summary.
 #
+# Reuse model: copy this file into another repo and adjust the working
+# directories in the lint/test jobs. It is intentionally not a workflow_call
+# template — a call contract (declared inputs / required secrets / outputs)
+# would add ceremony for a baseline whose jobs are specific to this repo's
+# uv layout.
+#
 # This workflow is deliberately CPU-side only. GPU training/finetuning runs on
 # the DGX Spark and logs straight to Weights & Biases (entity m7, project
 # major7-lab). See docs/mlops.md for the full lab pipeline.
@@ -107,7 +113,15 @@ jobs:
 
   model-release:
     name: Release model to HF (major7)
-    if: ${{ inputs.kind == 'release' || startsWith(github.ref, 'refs/tags/model/') }}
+    # Release blocks on the CI gate: on a model/* tag push, lint + test run
+    # first (inputs.kind is empty on tag pushes, so their if: is true) and a
+    # broken tree cannot reach the HF org. On a manual kind=release dispatch
+    # the gate jobs are skipped, which we allow explicitly below.
+    needs: [lint, test]
+    if: >
+      (inputs.kind == 'release' || startsWith(github.ref, 'refs/tags/model/'))
+      && (needs.lint.result == 'success' || needs.lint.result == 'skipped')
+      && (needs.test.result == 'success' || needs.test.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -116,15 +130,27 @@ jobs:
 
       - name: Resolve target and source
         id: resolve
+        # Untrusted inputs (manual dispatch) must not be interpolated into the
+        # shell script — pass them through env: per GitHub's hardening guide
+        # (code-injection via template expansion).
+        env:
+          HF_TARGET_INPUT: ${{ inputs.hf_target }}
+          MODEL_PATH_INPUT: ${{ inputs.model_path }}
         run: |
           tag="${GITHUB_REF#refs/tags/}"
-          if [ -n "${{ inputs.hf_target }}" ]; then target="${{ inputs.hf_target }}"; else target="${tag#model/}"; fi
+          if [ -n "$HF_TARGET_INPUT" ]; then target="$HF_TARGET_INPUT"; else target="${tag#model/}"; fi
           case "$target" in
             "$HF_NAMESPACE"/*) full="$target" ;;
             *) full="$HF_NAMESPACE/$target" ;;
           esac
-          src="${{ inputs.model_path }}"
-          if [ -z "$src" ]; then src="$(dirname "${tag#model/}")"; fi
+          # Default source: the directory named after the tag (model/my-model-v1
+          # -> my-model-v1/). Never derive a parent directory.
+          src="$MODEL_PATH_INPUT"
+          if [ -z "$src" ]; then src="${tag#model/}"; fi
+          # Defense in depth: refuse to release the repo root or an empty path.
+          case "$src" in
+            ""|.|/) echo "::error::refusing to release repo root or empty path"; exit 1 ;;
+          esac
           echo "target=$full" >> "$GITHUB_OUTPUT"
           echo "src=$src" >> "$GITHUB_OUTPUT"
           echo ">> HF repo: $full (source path: ./$src)"
@@ -132,17 +158,18 @@ jobs:
 
       - name: Push to Hugging Face
         run: |
-          uv run --with huggingface_hub --with hf_transfer python - <<'PY'
+          uv run --with 'huggingface_hub==0.35.0' --with 'hf_transfer==0.1.9' python - <<'PY'
           import os
           from huggingface_hub import HfApi
           api = HfApi()
           target = os.environ["TARGET"]
           src = os.environ["SRC"]
-          # hf_transfer accelerates large uploads; Hugging Face's server negotiates
-          # the protocol, so this is a safe no-op if it is unavailable.
+          # hf_transfer accelerates large uploads; the Hub negotiates the
+          # protocol, so this is a safe no-op when it is unavailable.
           os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")
           if os.path.isfile(src):
-              api.upload_file(path_or_filename=src, repo_id=target, repo_type="model",
+              api.upload_file(path_or_fileobj=src, path_in_repo=os.path.basename(src),
+                              repo_id=target, repo_type="model",
                               commit_message=f"release: {target}")
           else:
               api.upload_folder(folder_path=src, repo_id=target, repo_type="model",
@@ -156,11 +183,14 @@ jobs:
 
       - name: Model card summary
         if: always()
+        env:
+          HF_TARGET_OUT: ${{ steps.resolve.outputs.target }}
+          MODEL_SRC_OUT: ${{ steps.resolve.outputs.src }}
         run: |
           {
             echo "## Model release"
             echo ""
-            echo "- **HF repo:** \`${{ steps.resolve.outputs.target }}\`"
-            echo "- **Source path:** \`${{ steps.resolve.outputs.src }}\`"
-            echo "- **Trigger:** ${{ github.ref }}"
+            echo "- **HF repo:** \`$HF_TARGET_OUT\`"
+            echo "- **Source path:** \`$MODEL_SRC_OUT\`"
+            echo "- **Trigger:** ${GITHUB_REF#refs/tags/}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ This file is the canonical context file. Codex / Cursor / OpenCode / Antigravity
 - **[docs/harnesses.md](docs/harnesses.md)** — per-harness capability matrix
 - **[docs/plugin-eval.md](docs/plugin-eval.md)** — three-layer quality evaluation framework
 - **[docs/round-trip-results.md](docs/round-trip-results.md)** — real-CLI verification recipes
+- **[docs/mlops.md](docs/mlops.md)** — MLOps lab pipeline (W&B, Hugging Face, model release)
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** — how to contribute
 
 ## Working in this repo

--- a/docs/mlops.md
+++ b/docs/mlops.md
@@ -1,0 +1,149 @@
+# MLOps Lab Pipeline
+
+This document covers the end-to-end MLOps pipeline for the Major 7 lab:
+experiment tracking on W&B, model/dataset storage on Hugging Face, and the
+GitHub Actions glue that ties them together.
+
+## Environment
+
+The lab runs on a DGX Spark. GPU training and fine-tuning run locally;
+W&B receives all metrics and artifacts; Hugging Face is the durable model
+and dataset store; GitHub Actions handles CPU-side CI (lint, test, eval,
+model release).
+
+| Service | Entity / namespace | Notes |
+|---|---|---|
+| W&B | `m7` (team under org `m7-org`) | Project: `major7-lab` |
+| Hugging Face | `major7` org | Token has `write` role; admin on `major7` |
+| GitHub Actions | `wshobson/agents` repo | CPU-side only; no GPU runners |
+
+### Shell environment
+
+The following variables are exported in `~/.bashrc`:
+
+```bash
+export WANDB_API_KEY='wandb_v1_…'
+export WANDB_ENTITY='m7'
+export WANDB_PROJECT='major7-lab'
+export HUGGING_FACE_HUB_TOKEN='hf_…'
+export HF_TOKEN=$HUGGING_FACE_HUB_TOKEN
+export HF_HUB_ENABLE_HF_TRANSFER='1'
+```
+
+`HF_HUB_ENABLE_HF_TRANSFER` requires the `hf_transfer` package, which is
+installed in the `unsloth` conda environment.
+
+### Python environment
+
+ML workloads use the `unsloth` conda environment:
+
+```bash
+source ~/miniconda3/bin/activate unsloth
+```
+
+The `unsloth` env has `wandb`, `torch`, and `hf_transfer` installed.
+
+## Training a Model (local GPU)
+
+```python
+import wandb
+from transformers import Trainer, TrainingArguments, AutoModelForSequenceClassification, AutoTokenizer
+
+wandb.init(project="major7-lab", entity="m7", tags=["fine-tune"])
+
+model = AutoModelForSequenceClassification.from_pretrained("major7/my-base-model")
+tokenizer = AutoTokenizer.from_pretrained("major7/my-base-model")
+
+trainer = Trainer(
+    model=model,
+    args=TrainingArguments(
+        output_dir="./checkpoints",
+        report_to="wandb",
+        run_name="my-finetune-run",
+        logging_steps=50,
+        save_steps=500,
+        save_total_limit=3,
+    ),
+)
+trainer.train()
+wandb.finish()
+```
+
+Checkpoints are saved locally under `./checkpoints`. Push the best one to
+Hugging Face after training:
+
+```python
+from huggingface_hub import HfApi
+api = HfApi()
+api.upload_folder(
+    folder_path="./checkpoints/best",
+    repo_id="major7/my-model",
+    repo_type="model",
+    commit_message="finetune: epoch 3, val acc 0.94",
+)
+```
+
+## Running Plugin Eval with W&B Logging
+
+The `eval-report.yml` workflow supports a `log_wandb` dispatch input that
+pushes per-plugin scores to W&B. To run it manually from the GitHub Actions
+UI, set `log_wandb = true`.
+
+Or from the CLI (local GPU, full depth):
+
+```bash
+cd plugins/plugin-eval
+uv run python scripts/eval_all.py --depth deep --output-dir /tmp/eval-reports
+```
+
+The W&B logging step reads `eval-reports/summary.json` and logs a table plus
+aggregate metrics to the `major7-lab` project.
+
+## Releasing a Model via GitHub Actions
+
+Tag a commit with a `model/*` prefix to trigger the release job in
+`mlops.yml`:
+
+```bash
+git tag model/my-model-v1
+git push origin model/my-model-v1
+```
+
+This pushes the directory `my-model-v1/` (relative to the repo root) to
+Hugging Face as `major7/my-model-v1`.
+
+For a manual dispatch, set `kind = release`, `hf_target = major7/my-model`,
+and `model_path = path/to/local/model/dir`.
+
+## W&B Project Layout
+
+All runs land under `wandb.ai/m7/major7-lab`. Use tags to organise:
+
+| Tag | Meaning |
+|---|---|
+| `fine-tune` | Fine-tuning runs |
+| `plugin-eval` | Plugin quality eval runs |
+| `dgx-spark` | Runs executed on the DGX Spark |
+| `github-actions` | Runs triggered from CI |
+
+Group related runs with `group=` in `wandb.init()` so they collapse into a
+single row in the project table.
+
+## Offline Mode
+
+If the network is unstable, set `WANDB_MODE=offline` before starting a run.
+Runs sync later with:
+
+```bash
+wandb sync ./wandb/offline-run-<timestamp>-<id>
+```
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `you may not log runs directly to your organization` | Use the team entity (`m7`), not the org entity (`m7-org`) |
+| W&B run stuck in "syncing" | Check network; run `wandb sync <run-dir>` manually |
+| `hf_transfer` errors on upload | Set `HF_HUB_ENABLE_HF_TRANSFER=0` and retry; fall back to standard HTTP |
+| GitHub Actions HF push fails with 403 | Verify `HF_TOKEN` secret has `write` role and covers the `major7` org |
+| `import torch` hangs on the DGX | Use a lighter probe or run inside the activated `unsloth` env; first CUDA init can be slow |


### PR DESCRIPTION
## Summary
Adds the MLOps lab pipeline to the repo, tying together the three service integrations for the DGX Spark lab:

- **`mlops.yml`** — reusable CI baseline (`ruff` + `ty` + `pytest`) and a **model-release** job that pushes model directories to the Hugging Face `major7` org. Triggered by `model/*` tags or manual dispatch (`kind=release`).
- **`eval-report.yml`** — adds a **concurrency guard** (no overlapping runs on the same ref) and a **`log_wandb`** dispatch input that pushes per-plugin eval metrics to Weights & Biases (`m7/major7-lab`).
- **`docs/mlops.md`** — lab reference: env vars, training/eval/release flows, W&B project layout, offline mode, troubleshooting.

## Design notes
- CPU-side only: GPU training runs locally on the Spark and logs straight to W&B; CI is the lint/test/eval/release glue.
- Pinned action SHAs + `persist-credentials: false` matching existing workflows.
- W&B entity is the **team** (`m7`), not the org (`m7-org`) — W&B rejects direct org-level run logging.
- No secrets added by this PR. Required repo secrets to enable the optional paths: `WANDB_API_KEY`, `HF_TOKEN` (write scope, `major7` org).

## Test Plan
- [ ] `Validate` + `Code Quality` pass on the PR
- [ ] Manual dispatch `mlops.yml` with `kind=ci` → lint+test green
- [ ] Manual dispatch `eval-report.yml` with `log_wandb=true` → run appears in wandb.ai/m7/major7-lab
- [ ] (after setting `HF_TOKEN` secret) `kind=release` push lands in the `major7` HF org