### PR TITLE
fix(adapters): quote YAML scalars in OpenCode and Copilot frontmatter

### DIFF
--- a/tools/adapters/antigravity.py
+++ b/tools/adapters/antigravity.py
@@ -37,6 +37,7 @@ from tools.adapters.base import (
     HarnessAdapter,
     PluginSource,
     SkillSource,
+    yaml_scalar,
 )
 from tools.adapters.capabilities import TOOL_NAME_MAPS, resolve_model
 
@@ -56,85 +57,18 @@ def _generate_command_toml(description: str, prompt: str) -> str:
     )
 
 
-_YAML_SPECIAL_LEADS = (
-    "[",
-    "{",
-    "*",
-    "&",
-    "!",
-    "|",
-    ">",
-    "'",
-    '"',
-    "@",
-    "`",
-    "#",
-    "%",
-    ",",
-    "?",
-    ":",
-    "-",
-)
-
-# YAML 1.1 implicit booleans/null — must be quoted to avoid being interpreted as bool/None.
-_YAML_RESERVED_WORDS = frozenset(
-    {
-        "true",
-        "false",
-        "yes",
-        "no",
-        "on",
-        "off",
-        "null",
-        "~",
-        "True",
-        "False",
-        "Yes",
-        "No",
-        "On",
-        "Off",
-        "Null",
-        "TRUE",
-        "FALSE",
-        "YES",
-        "NO",
-        "ON",
-        "OFF",
-        "NULL",
-    }
-)
-
-
-def _yaml_scalar(value: object) -> str:
-    """Render a value as a YAML scalar, quoting when needed to avoid ambiguity."""
-    s = str(value).replace("\n", " ")
-    needs_quote = (
-        s == ""
-        or s != s.strip()
-        or s.startswith(_YAML_SPECIAL_LEADS)
-        or ": " in s
-        or " #" in s
-        or s[:1].isdigit()
-        or s in _YAML_RESERVED_WORDS
-    )
-    if needs_quote:
-        escaped = s.replace("\\", "\\\\").replace('"', '\\"')
-        return f'"{escaped}"'
-    return s
-
-
 def _yaml_flow_scalar(value: object) -> str:
     """Render a value as one item of a YAML flow sequence (`[a, b]`).
 
     Flow sequences use `,` and `]` as structural delimiters, so an item
-    containing either must be quoted even when `_yaml_scalar` wouldn't quote
+    containing either must be quoted even when `yaml_scalar` wouldn't quote
     it as a bare top-level scalar.
     """
     s = str(value).replace("\n", " ")
     if "," in s or "]" in s:
         escaped = s.replace("\\", "\\\\").replace('"', '\\"')
         return f'"{escaped}"'
-    return _yaml_scalar(s)
+    return yaml_scalar(s)
 
 
 def _antigravity_frontmatter(fm: dict) -> str:
@@ -148,13 +82,13 @@ def _antigravity_frontmatter(fm: dict) -> str:
             # mapping instead of stringifying the Python dict repr.
             lines.append(f"{k}:")
             for subk, subv in v.items():
-                lines.append(f"  {subk}: {_yaml_scalar(subv)}")
+                lines.append(f"  {subk}: {yaml_scalar(subv)}")
         elif isinstance(v, bool):
             lines.append(f"{k}: {'true' if v else 'false'}")
         elif v is None:
             continue
         else:
-            lines.append(f"{k}: {_yaml_scalar(v)}")
+            lines.append(f"{k}: {yaml_scalar(v)}")
     lines.append("---")
     return "\n".join(lines)
 

--- a/tools/adapters/antigravity.py
+++ b/tools/adapters/antigravity.py
@@ -57,15 +57,22 @@ def _generate_command_toml(description: str, prompt: str) -> str:
     )
 
 
+# Every character YAML treats as structural inside a flow collection. A plain scalar in
+# flow context may not contain any of them, at any position.
+_YAML_FLOW_DELIMITERS = ("[", "]", "{", "}", ",")
+
+
 def _yaml_flow_scalar(value: object) -> str:
     """Render a value as one item of a YAML flow sequence (`[a, b]`).
 
-    Flow sequences use `,` and `]` as structural delimiters, so an item
-    containing either must be quoted even when `yaml_scalar` wouldn't quote
-    it as a bare top-level scalar.
+    Flow sequences use `[`, `]`, `{`, `}` and `,` as structural delimiters, so an item
+    containing any of them must be quoted even when `yaml_scalar` wouldn't quote it as a
+    bare top-level scalar. `yaml_scalar` only rejects those characters in the leading
+    position, which is enough in block context but not here: `a {b` would emit as
+    `[a {b]`, and a YAML parser reads the `{` as the start of a flow mapping and fails.
     """
     s = str(value).replace("\n", " ")
-    if "," in s or "]" in s:
+    if any(delimiter in s for delimiter in _YAML_FLOW_DELIMITERS):
         escaped = s.replace("\\", "\\\\").replace('"', '\\"')
         return f'"{escaped}"'
     return yaml_scalar(s)

--- a/tools/adapters/base.py
+++ b/tools/adapters/base.py
@@ -235,6 +235,93 @@ def split_tools_list(raw) -> list[str]:
     return []
 
 
+# ── YAML frontmatter emission ─────────────────────────────────────────────────
+
+_YAML_SPECIAL_LEADS = (
+    "[",
+    "{",
+    "*",
+    "&",
+    "!",
+    "|",
+    ">",
+    "'",
+    '"',
+    "@",
+    "`",
+    "#",
+    "%",
+    ",",
+    "?",
+    ":",
+    "-",
+)
+
+# YAML 1.1 implicit booleans/null — must be quoted to avoid being interpreted as bool/None.
+# YAML 1.2 narrowed this list, but PyYAML's default is still 1.1 (and many consumers are
+# affected); quote conservatively.
+_YAML_RESERVED_WORDS = frozenset(
+    {
+        "true",
+        "false",
+        "yes",
+        "no",
+        "on",
+        "off",
+        "null",
+        "~",
+        "True",
+        "False",
+        "Yes",
+        "No",
+        "On",
+        "Off",
+        "Null",
+        "TRUE",
+        "FALSE",
+        "YES",
+        "NO",
+        "ON",
+        "OFF",
+        "NULL",
+    }
+)
+
+
+def yaml_scalar(value: object) -> str:
+    """Render a value as a YAML scalar, quoting when needed to avoid ambiguity.
+
+    Every adapter that writes frontmatter must route scalars through here. Emitting a
+    bare value that YAML cannot parse produces a file the target harness rejects at
+    load, and the repo's own validators use `parse_frontmatter` (a tolerant hand-rolled
+    reader) rather than a YAML parser, so they will not catch it.
+
+    Quotes when the value:
+    - is empty / pure whitespace
+    - starts with a YAML special character
+    - contains `:` followed by whitespace (would be interpreted as a key)
+    - contains ` #` (would be interpreted as a comment)
+    - has leading or trailing whitespace
+    - starts with a digit (number-like)
+    - matches a YAML 1.1 implicit-boolean/null reserved word
+    """
+    s = str(value).replace("\n", " ")
+    needs_quote = (
+        s == ""
+        or s != s.strip()
+        or s.startswith(_YAML_SPECIAL_LEADS)
+        or ": " in s
+        or " #" in s
+        or s[:1].isdigit()
+        or s in _YAML_RESERVED_WORDS
+    )
+    if needs_quote:
+        # Use double quotes; escape embedded double-quotes and backslashes.
+        escaped = s.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    return s
+
+
 # ── Source-of-truth dataclasses ───────────────────────────────────────────────
 
 

--- a/tools/adapters/base.py
+++ b/tools/adapters/base.py
@@ -257,7 +257,7 @@ _YAML_SPECIAL_LEADS = (
     "-",
 )
 
-# YAML 1.1 implicit booleans/null — must be quoted to avoid being interpreted as bool/None.
+# YAML 1.1 implicit booleans/null, which must be quoted to avoid loading as bool/None.
 # YAML 1.2 narrowed this list, but PyYAML's default is still 1.1 (and many consumers are
 # affected); quote conservatively.
 _YAML_RESERVED_WORDS = frozenset(
@@ -287,6 +287,15 @@ _YAML_RESERVED_WORDS = frozenset(
     }
 )
 
+# Implicit numbers that a leading-digit test misses because they open with `+` or `.`.
+# PyYAML resolves the YAML 1.1 spellings, so `+1` loads as the int 1, `.5` and `.0` as
+# floats, and `.inf`, `.INF`, `+.inf`, `.nan`, `.NaN` as float infinity or not-a-number.
+# YAML 1.2 loaders go further and read a signed bare fraction such as `+.5` as a float
+# too. A string-valued field carrying any of these must be quoted to load back as the
+# string that was written. Values led by `-` are already covered by _YAML_SPECIAL_LEADS.
+# A dot followed by a non-number, `.gitignore` or `.info`, stays bare.
+_YAML_IMPLICIT_NUMBER = re.compile(r"^[-+]?\.?[0-9]|^[-+]?\.(?:inf|Inf|INF|nan|NaN|NAN)$")
+
 
 def yaml_scalar(value: object) -> str:
     """Render a value as a YAML scalar, quoting when needed to avoid ambiguity.
@@ -303,6 +312,7 @@ def yaml_scalar(value: object) -> str:
     - contains ` #` (would be interpreted as a comment)
     - has leading or trailing whitespace
     - starts with a digit (number-like)
+    - is an implicit number led by `+` or `.`, such as `+1`, `.5`, `.inf` or `.nan`
     - matches a YAML 1.1 implicit-boolean/null reserved word
     """
     s = str(value).replace("\n", " ")
@@ -313,6 +323,7 @@ def yaml_scalar(value: object) -> str:
         or ": " in s
         or " #" in s
         or s[:1].isdigit()
+        or _YAML_IMPLICIT_NUMBER.match(s) is not None
         or s in _YAML_RESERVED_WORDS
     )
     if needs_quote:

--- a/tools/adapters/codex.py
+++ b/tools/adapters/codex.py
@@ -27,6 +27,7 @@ from tools.adapters.base import (
     HarnessAdapter,
     PluginSource,
     SkillSource,
+    yaml_scalar,
 )
 from tools.adapters.capabilities import TOOL_NAME_MAPS, resolve_model
 
@@ -81,86 +82,6 @@ def _filter_frontmatter(fm: dict, drop: set[str]) -> dict:
     return {k: v for k, v in fm.items() if k not in drop}
 
 
-_YAML_SPECIAL_LEADS = (
-    "[",
-    "{",
-    "*",
-    "&",
-    "!",
-    "|",
-    ">",
-    "'",
-    '"',
-    "@",
-    "`",
-    "#",
-    "%",
-    ",",
-    "?",
-    ":",
-    "-",
-)
-
-# YAML 1.1 implicit booleans/null — must be quoted to avoid being interpreted as bool/None.
-# YAML 1.2 narrowed this list, but PyYAML's default is still 1.1 (and many consumers are
-# affected); quote conservatively.
-_YAML_RESERVED_WORDS = frozenset(
-    {
-        "true",
-        "false",
-        "yes",
-        "no",
-        "on",
-        "off",
-        "null",
-        "~",
-        "True",
-        "False",
-        "Yes",
-        "No",
-        "On",
-        "Off",
-        "Null",
-        "TRUE",
-        "FALSE",
-        "YES",
-        "NO",
-        "ON",
-        "OFF",
-        "NULL",
-    }
-)
-
-
-def _yaml_scalar(value: str) -> str:
-    """Render a string as a YAML scalar, quoting when needed to avoid ambiguity.
-
-    Quotes when the value:
-    - is empty / pure whitespace
-    - starts with a YAML special character
-    - contains `:` followed by whitespace (would be interpreted as a key)
-    - contains ` #` (would be interpreted as a comment)
-    - has leading or trailing whitespace
-    - starts with a digit or `-`/`+` (number-like)
-    - matches a YAML 1.1 implicit-boolean/null reserved word
-    """
-    s = str(value).replace("\n", " ")
-    needs_quote = (
-        s == ""
-        or s != s.strip()
-        or s.startswith(_YAML_SPECIAL_LEADS)
-        or ": " in s
-        or " #" in s
-        or s[:1].isdigit()
-        or s in _YAML_RESERVED_WORDS
-    )
-    if needs_quote:
-        # Use double quotes; escape embedded double-quotes and backslashes.
-        escaped = s.replace("\\", "\\\\").replace('"', '\\"')
-        return f'"{escaped}"'
-    return s
-
-
 def _frontmatter_block(fm: dict) -> str:
     """Render a minimal YAML-ish frontmatter block (string/scalar fields only)."""
     lines = ["---"]
@@ -168,15 +89,15 @@ def _frontmatter_block(fm: dict) -> str:
         if isinstance(v, list):
             lines.append(f"{k}:")
             for item in v:
-                lines.append(f"  - {_yaml_scalar(item)}")
+                lines.append(f"  - {yaml_scalar(item)}")
         elif isinstance(v, dict):
             lines.append(f"{k}:")
             for subk, subv in v.items():
-                lines.append(f"  {subk}: {_yaml_scalar(subv)}")
+                lines.append(f"  {subk}: {yaml_scalar(subv)}")
         elif v is None:
             continue
         else:
-            lines.append(f"{k}: {_yaml_scalar(v)}")
+            lines.append(f"{k}: {yaml_scalar(v)}")
     lines.append("---")
     return "\n".join(lines)
 

--- a/tools/adapters/copilot.py
+++ b/tools/adapters/copilot.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 from tools.adapters.base import (
@@ -13,22 +12,9 @@ from tools.adapters.base import (
     PluginSource,
     SkillSource,
     h1_from_body,
+    yaml_scalar,
 )
 from tools.adapters.capabilities import TOOL_NAME_MAPS, resolve_model
-
-
-def _needs_yaml_quoting(value: str) -> bool:
-    """Check if a string value needs YAML quoting to prevent type coercion."""
-    return bool(re.match(r"^\d+(\.\d+)?$", value)) or value.lower() in (
-        "true",
-        "false",
-        "yes",
-        "no",
-        "on",
-        "off",
-        "null",
-        "~",
-    )
 
 
 def _copilot_frontmatter(fm: dict) -> str:
@@ -38,14 +24,17 @@ def _copilot_frontmatter(fm: dict) -> str:
         if isinstance(v, list):
             lines.append(f"{k}:")
             for item in v:
-                lines.append(f"  - {item}")
+                lines.append(f"  - {yaml_scalar(item)}")
+        elif isinstance(v, dict):
+            # Preserve mapping-valued fields (e.g. `metadata`) as a nested YAML
+            # mapping instead of stringifying the Python dict repr.
+            lines.append(f"{k}:")
+            for subk, subv in v.items():
+                lines.append(f"  {subk}: {yaml_scalar(subv)}")
         elif isinstance(v, bool):
             lines.append(f"{k}: {'true' if v else 'false'}")
         elif v is not None:
-            value = str(v).replace("\n", " ").strip()
-            if _needs_yaml_quoting(value):
-                value = f'"{value}"'
-            lines.append(f"{k}: {value}")
+            lines.append(f"{k}: {yaml_scalar(v)}")
     lines.append("---")
     return "\n".join(lines)
 

--- a/tools/adapters/opencode.py
+++ b/tools/adapters/opencode.py
@@ -27,6 +27,7 @@ from tools.adapters.base import (
     HarnessAdapter,
     PluginSource,
     SkillSource,
+    yaml_scalar,
 )
 from tools.adapters.capabilities import TOOL_NAME_MAPS, resolve_model
 
@@ -135,18 +136,17 @@ def _opencode_frontmatter(fm: dict) -> str:
         if isinstance(v, dict):
             lines.append(f"{k}:")
             for sk, sv in v.items():
-                lines.append(f"  {sk}: {sv}")
+                lines.append(f"  {sk}: {yaml_scalar(sv)}")
         elif isinstance(v, list):
             lines.append(f"{k}:")
             for item in v:
-                lines.append(f"  - {item}")
+                lines.append(f"  - {yaml_scalar(item)}")
         elif isinstance(v, bool):
             lines.append(f"{k}: {'true' if v else 'false'}")
         elif v is None:
             continue
         else:
-            value = str(v).replace("\n", " ").strip()
-            lines.append(f"{k}: {value}")
+            lines.append(f"{k}: {yaml_scalar(v)}")
     lines.append("---")
     return "\n".join(lines)
 

--- a/tools/tests/test_adapters.py
+++ b/tools/tests/test_adapters.py
@@ -11,15 +11,13 @@ import json
 import re
 from pathlib import Path
 
+import yaml
+
 # tools.adapters.* imports happen via the conftest sys.path injection
 from tools.adapters.antigravity import AntigravityAdapter
-from tools.adapters.base import PluginSource, parse_frontmatter
+from tools.adapters.base import PluginSource, parse_frontmatter, yaml_scalar
 from tools.adapters.codex import CodexAdapter, _split_body_if_oversized
-from tools.adapters.copilot import (
-    CopilotAdapter,
-    _build_tools_list,
-    _needs_yaml_quoting,
-)
+from tools.adapters.copilot import CopilotAdapter, _build_tools_list
 from tools.adapters.cursor import CursorAdapter
 from tools.adapters.opencode import OpenCodeAdapter, _opencode_skill_id
 
@@ -1352,20 +1350,6 @@ class TestCopilotAdapter:
         assert _build_tools_list(["CustomTool"]) == ["CustomTool"]
         assert _build_tools_list([]) == []
 
-    def test_yaml_quoting(self):
-        assert _needs_yaml_quoting("123")
-        assert _needs_yaml_quoting("3.14")
-        assert _needs_yaml_quoting("true")
-        assert _needs_yaml_quoting("false")
-        assert _needs_yaml_quoting("yes")
-        assert _needs_yaml_quoting("no")
-        assert _needs_yaml_quoting("on")
-        assert _needs_yaml_quoting("off")
-        assert _needs_yaml_quoting("null")
-        assert _needs_yaml_quoting("~")
-        assert not _needs_yaml_quoting("hello world")
-        assert not _needs_yaml_quoting("Use when testing.")
-
     def test_explicit_empty_tools(self, tmp_path: Path, output_root: Path):
         from tools.tests.conftest import _make_agent
 
@@ -1415,6 +1399,131 @@ class TestCopilotAdapter:
         assert fm["description"] == "Use when unrestricted."
         assert fm["model"] == "claude-opus-4.8"
         assert "tools" not in fm
+
+
+# ── Cross-cutting: emitted frontmatter must parse as YAML ────────────────────
+
+# Both values are shapes that exist in the repo today: `conductor:manage` has a colon
+# in its description, and `agent-teams:team-delegate` has a bracketed argument hint.
+# Their source files quote them correctly, so an adapter that drops the quotes turns
+# valid source into an artifact the target harness cannot load.
+_COLON_DESCRIPTION = "Manage track lifecycle: archive, restore, delete"
+_BRACKET_HINT = "[--archive | --restore | --list]"
+
+
+def _ambiguous_plugin(tmp_path: Path) -> PluginSource:
+    """A one-command plugin whose frontmatter needs quoting to stay parseable."""
+    from tools.tests.conftest import _make_command
+
+    plugin_json = {"name": "demo", "description": _COLON_DESCRIPTION}
+    plugin_dir = tmp_path / "demo"
+    plugin_dir.mkdir()
+    (plugin_dir / ".claude-plugin").mkdir()
+    (plugin_dir / ".claude-plugin" / "plugin.json").write_text(json.dumps(plugin_json))
+    command = _make_command(
+        plugin_dir,
+        "manage",
+        f'description: "{_COLON_DESCRIPTION}"\nargument-hint: "{_BRACKET_HINT}"',
+        "# Manage\n\nBody.\n",
+    )
+    return PluginSource(name="demo", dir=plugin_dir, plugin_json=plugin_json, commands=[command])
+
+
+def _safe_load_frontmatter(path: Path) -> dict:
+    """Parse a generated file's frontmatter with a real YAML parser."""
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\n"), f"{path} has no frontmatter"
+    end = text.index("\n---", 3)
+    loaded = yaml.safe_load(text[4:end])
+    assert isinstance(loaded, dict), f"{path} frontmatter is not a mapping: {loaded!r}"
+    return loaded
+
+
+class TestFrontmatterYamlSafety:
+    """Every adapter must emit frontmatter a real YAML parser accepts.
+
+    `parse_frontmatter` is a tolerant hand-rolled reader, so the repo's own validators
+    accept output that PyYAML rejects. These tests use PyYAML directly.
+    """
+
+    def test_yaml_scalar_round_trips_ambiguous_values(self):
+        for value in (
+            _COLON_DESCRIPTION,
+            _BRACKET_HINT,
+            "",
+            "  padded  ",
+            "true",
+            "false",
+            "yes",
+            "NO",
+            "on",
+            "off",
+            "null",
+            "~",
+            "123",
+            "3.14",
+            "- leading dash",
+            "trailing # hash",
+            'has "quotes" and \\ backslash',
+        ):
+            assert yaml.safe_load(f"k: {yaml_scalar(value)}") == {"k": value}
+
+    def test_yaml_scalar_leaves_plain_values_unquoted(self):
+        for value in ("hello world", "Use when testing.", "claude-sonnet-5"):
+            assert yaml_scalar(value) == value
+
+    def test_copilot_emits_parseable_frontmatter(self, tmp_path: Path, output_root: Path):
+        plugin = _ambiguous_plugin(tmp_path)
+        result = CopilotAdapter(output_root=output_root).emit_plugin(plugin)
+
+        emitted = [p for p in result.written if p.suffix == ".md"]
+        assert emitted
+        for path in emitted:
+            fm = _safe_load_frontmatter(path)
+            assert fm["description"] == _COLON_DESCRIPTION
+            if "argument-hint" in fm:
+                assert fm["argument-hint"] == _BRACKET_HINT
+
+    def test_opencode_emits_parseable_frontmatter(self, tmp_path: Path, output_root: Path):
+        plugin = _ambiguous_plugin(tmp_path)
+        result = OpenCodeAdapter(output_root=output_root).emit_plugin(plugin)
+
+        emitted = [p for p in result.written if p.suffix == ".md"]
+        assert emitted
+        for path in emitted:
+            fm = _safe_load_frontmatter(path)
+            assert fm["description"] == _COLON_DESCRIPTION
+            assert fm["argument-hint"] == _BRACKET_HINT
+
+    def test_antigravity_emits_parseable_frontmatter(self, tmp_path: Path, output_root: Path):
+        plugin = _ambiguous_plugin(tmp_path)
+        result = AntigravityAdapter(output_root=output_root).emit_plugin(plugin)
+
+        for path in (p for p in result.written if p.suffix == ".md"):
+            _safe_load_frontmatter(path)
+
+    def test_copilot_preserves_mapping_valued_fields(self, tmp_path: Path, output_root: Path):
+        from tools.tests.conftest import _make_skill
+
+        plugin_dir = tmp_path / "demo"
+        plugin_dir.mkdir()
+        (plugin_dir / ".claude-plugin").mkdir()
+        (plugin_dir / ".claude-plugin" / "plugin.json").write_text('{"name": "demo"}')
+        skill = _make_skill(
+            plugin_dir,
+            "hello",
+            "name: hello\ndescription: Use when greeting.\nmetadata:\n  owner: platform\n  tier: 1",
+            "# Hello\n\nBody.\n",
+        )
+        plugin = PluginSource(
+            name="demo", dir=plugin_dir, plugin_json={"name": "demo"}, skills=[skill]
+        )
+        CopilotAdapter(output_root=output_root).emit_plugin(plugin)
+
+        fm = _safe_load_frontmatter(
+            output_root / ".copilot" / "skills" / "demo__hello" / "SKILL.md"
+        )
+        assert fm["metadata"] == {"owner": "platform", "tier": "1"}
 
 
 # ── Cross-cutting: capabilities consistency ──────────────────────────────────

--- a/tools/tests/test_adapters.py
+++ b/tools/tests/test_adapters.py
@@ -1410,6 +1410,42 @@ class TestCopilotAdapter:
 _COLON_DESCRIPTION = "Manage track lifecycle: archive, restore, delete"
 _BRACKET_HINT = "[--archive | --restore | --list]"
 
+# Strings a YAML loader silently retypes when they are emitted bare. `+1` and `+0x1A`
+# come back as ints, `.5` and `.0` as floats, `.inf`/`.INF`/`+.inf` as float infinity,
+# `.nan`/`.NaN` as float not-a-number, `+1:30` as a sexagesimal int, and `+.5` as a float
+# under YAML 1.2. A version, port, offset or flag field holding one of these must survive
+# as the string that was written.
+_IMPLICIT_NUMBERS = (
+    "+1",
+    "+3",
+    "+0x1A",
+    "+1_000",
+    "+1:30",
+    ".0",
+    ".5",
+    "+.5",
+    ".inf",
+    ".Inf",
+    ".INF",
+    "+.inf",
+    "-.inf",
+    ".nan",
+    ".NaN",
+    ".NAN",
+)
+
+# Flow collections treat each of these as structural, so an item carrying one anywhere,
+# not only in the leading position, has to be quoted.
+_FLOW_DELIMITER_ITEMS = (
+    "a {b",
+    "a [b",
+    "a }b",
+    "a ]b",
+    "a ,b",
+    "{a}",
+    "[a]",
+)
+
 
 def _ambiguous_plugin(tmp_path: Path) -> PluginSource:
     """A one-command plugin whose frontmatter needs quoting to stay parseable."""
@@ -1427,6 +1463,30 @@ def _ambiguous_plugin(tmp_path: Path) -> PluginSource:
         "# Manage\n\nBody.\n",
     )
     return PluginSource(name="demo", dir=plugin_dir, plugin_json=plugin_json, commands=[command])
+
+
+def _ambiguous_skill_plugin(tmp_path: Path) -> PluginSource:
+    """A one-skill plugin whose frontmatter needs quoting to stay parseable.
+
+    Antigravity emits commands as TOML, so `_ambiguous_plugin` gives it no Markdown to
+    check. A skill lands at `skills/<skill>/SKILL.md` in every harness that writes
+    Markdown, which makes this the fixture the Antigravity YAML test needs.
+    """
+    from tools.tests.conftest import _make_skill
+
+    plugin_json = {"name": "demo", "description": _COLON_DESCRIPTION}
+    plugin_dir = tmp_path / "demo"
+    plugin_dir.mkdir()
+    (plugin_dir / ".claude-plugin").mkdir()
+    (plugin_dir / ".claude-plugin" / "plugin.json").write_text(json.dumps(plugin_json))
+    skill = _make_skill(
+        plugin_dir,
+        "manage",
+        f'name: manage\ndescription: "{_COLON_DESCRIPTION}"\n'
+        f'argument-hint: "{_BRACKET_HINT}"\nversion: "+1"',
+        "# Manage\n\nBody.\n",
+    )
+    return PluginSource(name="demo", dir=plugin_dir, plugin_json=plugin_json, skills=[skill])
 
 
 def _safe_load_frontmatter(path: Path) -> dict:
@@ -1496,11 +1556,72 @@ class TestFrontmatterYamlSafety:
             assert fm["argument-hint"] == _BRACKET_HINT
 
     def test_antigravity_emits_parseable_frontmatter(self, tmp_path: Path, output_root: Path):
-        plugin = _ambiguous_plugin(tmp_path)
+        # A skill, not a command: Antigravity writes commands as `.toml`, so a
+        # command-only plugin gives this test nothing to parse.
+        plugin = _ambiguous_skill_plugin(tmp_path)
         result = AntigravityAdapter(output_root=output_root).emit_plugin(plugin)
 
-        for path in (p for p in result.written if p.suffix == ".md"):
-            _safe_load_frontmatter(path)
+        emitted = [p for p in result.written if p.suffix == ".md"]
+        assert emitted, "Antigravity emitted no Markdown, so no frontmatter was checked"
+        for path in emitted:
+            fm = _safe_load_frontmatter(path)
+            assert fm["description"] == _COLON_DESCRIPTION
+            assert fm["argument-hint"] == _BRACKET_HINT
+            assert fm["version"] == "+1"
+
+    def test_yaml_scalar_round_trips_implicit_numbers(self):
+        for value in _IMPLICIT_NUMBERS:
+            loaded = yaml.safe_load(f"k: {yaml_scalar(value)}")["k"]
+            assert loaded == value, f"{value!r} came back as {loaded!r}"
+            assert isinstance(loaded, str), f"{value!r} came back as {type(loaded).__name__}"
+
+    def test_yaml_scalar_leaves_non_numeric_dot_and_sign_values_unquoted(self):
+        # The implicit-number rule must not swallow ordinary values that merely open
+        # with `.` or `+`, or every dotfile name in frontmatter would gain quotes.
+        for value in (".gitignore", ".info", ".", "+", "+abc", "..", ".x5"):
+            assert yaml_scalar(value) == value
+
+    def test_antigravity_flow_sequence_round_trips_delimiters(self):
+        from tools.adapters.antigravity import _antigravity_frontmatter
+
+        block = _antigravity_frontmatter({"tools": list(_FLOW_DELIMITER_ITEMS)})
+        loaded = yaml.safe_load(block[len("---\n") : -len("\n---")])
+        assert loaded["tools"] == list(_FLOW_DELIMITER_ITEMS)
+
+    def test_every_frontmatter_emitter_round_trips_hostile_values(self):
+        """The four adapters that share `yaml_scalar` must agree on every hostile shape.
+
+        `yaml_scalar` is the single quoting rule, so a value it mishandles is wrong in
+        all four outputs at once. Antigravity additionally renders lists as flow
+        sequences, which is the one place an adapter adds a rule of its own.
+        """
+        from tools.adapters.antigravity import _antigravity_frontmatter
+        from tools.adapters.codex import _frontmatter_block
+        from tools.adapters.copilot import _copilot_frontmatter
+        from tools.adapters.opencode import _opencode_frontmatter
+
+        values = (
+            _COLON_DESCRIPTION,
+            _BRACKET_HINT,
+            *_IMPLICIT_NUMBERS,
+            *_FLOW_DELIMITER_ITEMS,
+            "trailing # hash",
+            'has "quotes" and \\ backslash',
+        )
+        fm: dict = {f"field{i}": value for i, value in enumerate(values)}
+        fm["listed"] = list(values)
+        fm["mapped"] = {f"sub{i}": value for i, value in enumerate(values)}
+
+        for name, emitter in (
+            ("antigravity", _antigravity_frontmatter),
+            ("codex", _frontmatter_block),
+            ("copilot", _copilot_frontmatter),
+            ("opencode", _opencode_frontmatter),
+        ):
+            block = emitter(fm)
+            body = block[len("---\n") : -len("\n---")]
+            loaded = yaml.safe_load(body)
+            assert loaded == fm, f"{name} frontmatter did not round-trip"
 
     def test_copilot_preserves_mapping_valued_fields(self, tmp_path: Path, output_root: Path):
         from tools.tests.conftest import _make_skill


### PR DESCRIPTION
## Summary

- `_opencode_frontmatter` (`tools/adapters/opencode.py:132`) writes every scalar bare, and `_copilot_frontmatter` (`tools/adapters/copilot.py:32`) quotes only pure numbers and lowercase reserved words through `_needs_yaml_quoting`. Source frontmatter that is already correctly quoted loses its quotes on the way out, so both harnesses get files a YAML parser rejects.
- Codex and Antigravity never had this problem: both already route scalars through a private `_yaml_scalar` helper, duplicated verbatim between `codex.py` and `antigravity.py`. This moves that helper into `tools/adapters/base.py` as `yaml_scalar` and has all four adapters use it.
- Copilot also had no `dict` branch, so a mapping-valued field like `metadata:` came out as a Python dict repr. It now emits a nested mapping, matching `_antigravity_frontmatter`.

## The bug

`plugins/conductor/commands/manage.md` starts with valid, correctly quoted YAML:

```yaml
description: "Manage track lifecycle: archive, restore, delete, rename, and cleanup"
argument-hint: "[--archive | --restore | --delete | --rename | --list | --cleanup]"
```

`make generate HARNESS=opencode` turns it into this, which `yaml.safe_load` refuses with `ScannerError: mapping values are not allowed here`:

```yaml
description: Manage track lifecycle: archive, restore, delete, rename, and cleanup
argument-hint: [--archive | --restore | --delete | --rename | --list | --cleanup]
```

The second failure mode is silent. When a bracketed hint has no colon inside it, YAML accepts it as a flow sequence, so `argument-hint: "[--resume]"` round-trips to the list `['--resume']` instead of the string `[--resume]`.

I generated every plugin for all four harnesses from `a30778f` and ran `yaml.safe_load` over each emitted frontmatter block:

| harness | blocks | unparseable | mistyped |
|---|---|---|---|
| opencode | 490 | 8 | 12 |
| copilot | 687 | 30 | 24 |
| codex | 288 | 0 | 0 |
| antigravity | 385 | 0 | 0 |

The repo's own gates do not catch it because `validate_generated.py` and `doc_gardener.py` read frontmatter with `parse_frontmatter`, the tolerant hand-rolled reader in `base.py`, not with a YAML parser.

## The fix

`yaml_scalar` quotes a value when it is empty or pure whitespace, starts with a YAML special character, contains `: ` or ` #`, has leading or trailing whitespace, starts with a digit, is an implicit number led by `+` or `.` such as `+1`, `.5`, `.inf` or `.nan`, or is a YAML 1.1 implicit boolean or null. Every clause except the implicit-number one is the existing Codex and Antigravity behavior, moved rather than rewritten; no value in the repo today hits the implicit-number clause, so those two adapters are unaffected and verified byte identical below.

## Test plan

- [x] `make validate STRICT=1` gives `OK: no issues across 5 harness(es).`
- [x] `make garden` gives `0 error(s), 18 warning(s)`, identical to `a30778f` with the change stashed (9 `SKILL_OVER_CODEX_CAP`, 9 `AGENT_BODY_DIVERGENT`, all pre-existing).
- [x] `make test` gives `619 passed`.
- [x] `make lint` gives ruff check `All checks passed!`, ruff format `41 files already formatted`, ty `All checks passed!` (with `uv sync --all-extras`, as the code-quality workflow does).
- [x] `make generate-all` leaves the committed registries unchanged, so there is no drift.
- [ ] `make smoke-test`: 6 passed, 5 skipped (opencode, agy and codex are not on this machine), 1 failed in `test_gh_skill_discovers_every_source_skill` because my `gh` does not accept `gh skill install . --from-local`. That failure reproduces identically on `a30778f` with the change stashed, so it is my GitHub CLI version, not this PR.

Byte-identical output check for the two adapters I only refactored, generating every plugin before and after into separate trees:

```
diff -r base-codex fix-codex            # no differences, 908 files
diff -r base-antigravity fix-antigravity  # no differences, 824 files
```

After the change all four harnesses report 0 unparseable and 0 mistyped. The only output differences are 37 opencode files (38 lines) and 77 copilot files (81 removed, 87 added), and every one is a frontmatter value gaining quotes, a `version:` like `1.0.0` becoming `"1.0.0"`, or Copilot's `metadata:` dict repr expanding into a nested mapping.

`tools/tests/test_adapters.py` gains a `TestFrontmatterYamlSafety` class that parses emitted frontmatter with PyYAML instead of `parse_frontmatter`, using the two real shapes above. Running that same emission through the unmodified `a30778f` adapters, all four generated files raise `ScannerError`: copilot's SKILL.md, index.md and manage.md, and opencode's `demo__manage.md`. I replaced `TestCopilotAdapter.test_yaml_quoting`, which asserted on the now-deleted `_needs_yaml_quoting`, with a `yaml_scalar` case covering everything it did plus the shapes it missed.

## Scope

- [ ] Plugin authoring (new or modified `plugins/<name>/...`)
- [x] Adapter framework (`tools/adapters/`)
- [ ] Quality tooling (validators, gardener, plugin-eval)
- [ ] Per-harness setup or docs (docs/harnesses.md)
- [ ] AGENTS.md / ARCHITECTURE.md / docs/
- [ ] CI / build / release
- [ ] Other

## Affected harnesses

- [ ] Claude Code
- [ ] OpenAI Codex CLI
- [ ] Cursor
- [x] OpenCode
- [ ] Antigravity CLI
- [x] GitHub Copilot

Codex and Antigravity are touched but their output is unchanged.

## Cross-harness portability notes

N/A, no plugin content changed.

## Related issue(s)

None. This is a self-contained adapter fix with a regression test.

